### PR TITLE
Add changelog entries for 2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ We maintain separate change logs for the individual packages:
 
 ## Closed Issues and PRs
 
-* [v2.0.0](https://github.com/langium/langium/milestone/7?closed=1)
+* [v2.0.0](https://github.com/langium/langium/milestone/10?closed=1)
+* [v1.3.0](https://github.com/langium/langium/milestone/7?closed=1)
 * [v1.2.0](https://github.com/langium/langium/milestone/8?closed=1)
 * [v1.1.0](https://github.com/langium/langium/milestone/6?closed=1)
 * [v1.0.0](https://github.com/langium/langium/milestone/5?closed=1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ We maintain separate change logs for the individual packages:
 
 ## Closed Issues and PRs
 
+* [v2.0.0](https://github.com/langium/langium/milestone/7?closed=1)
+* [v1.2.0](https://github.com/langium/langium/milestone/8?closed=1)
+* [v1.1.0](https://github.com/langium/langium/milestone/6?closed=1)
 * [v1.0.0](https://github.com/langium/langium/milestone/5?closed=1)
 * [v0.5.0](https://github.com/langium/langium/milestone/4?closed=1)
 * [v0.4.0](https://github.com/langium/langium/milestone/3?closed=1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ We maintain separate change logs for the individual packages:
 
 ## Closed Issues and PRs
 
-* [v2.0.0](https://github.com/langium/langium/milestone/10?closed=1)
+* [v2.0.0](https://github.com/langium/langium/milestone/9?closed=1)
 * [v1.3.0](https://github.com/langium/langium/milestone/7?closed=1)
 * [v1.2.0](https://github.com/langium/langium/milestone/8?closed=1)
 * [v1.1.0](https://github.com/langium/langium/milestone/6?closed=1)

--- a/packages/generator-langium/CHANGELOG.md
+++ b/packages/generator-langium/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log of `generator-langium`
 
+## v2.0.0 (Jul. 2023)
+
+* Added a bundle configuration using `esbuild` ([#1125](https://github.com/langium/langium/pull/1125)).
+* Configured the project as an ESM project to adapt to the changes in Langium ([#1125](https://github.com/langium/langium/pull/1125)).
+* Fixed a few syntax highlighting related issues ([#1064](https://github.com/langium/langium/pull/1064), [#1079](https://github.com/langium/langium/pull/1079)).
+
 ## v1.2.0 (May. 2023)
 
 * Refactored the generator to enable multiple "environments". Devs will be asked whether they want a given environment in their project setup:

--- a/packages/generator-langium/CHANGELOG.md
+++ b/packages/generator-langium/CHANGELOG.md
@@ -1,9 +1,12 @@
 # Change Log of `generator-langium`
 
-## v2.0.0 (Jul. 2023)
+## v2.0.0 (Aug. 2023)
 
 * Added a bundle configuration using `esbuild` ([#1125](https://github.com/langium/langium/pull/1125)).
 * Configured the project as an ESM project to adapt to the changes in Langium ([#1125](https://github.com/langium/langium/pull/1125)).
+
+## v1.3.0 (Aug. 2023)
+
 * Fixed a few syntax highlighting related issues ([#1064](https://github.com/langium/langium/pull/1064), [#1079](https://github.com/langium/langium/pull/1079)).
 
 ## v1.2.0 (May. 2023)

--- a/packages/langium-cli/CHANGELOG.md
+++ b/packages/langium-cli/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Change Log of `langium-cli`
 
-## v2.0.0 (Jul. 2023)
+## v2.0.0 (Aug. 2023)
+
+### EcmaScript Modules (ESM)
+
+This package is now compiling to ESM only, refer to [this changelog entry](https://github.com/langium/langium/blob/main/packages/langium/CHANGELOG.md#ecmascript-modules-esm)
+
+## v1.3.0 (Aug. 2023)
 
 ### Railroad Syntax Diagrams
 

--- a/packages/langium-cli/CHANGELOG.md
+++ b/packages/langium-cli/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 This package is now compiling to ESM only, refer to [this changelog entry](https://github.com/langium/langium/blob/main/packages/langium/CHANGELOG.md#ecmascript-modules-esm)
 
+### Breaking Changes
+
+* The CLI now always uses the original `projectName` of the `langium-config.json` property for the generated type/object names. It no longer performs kebab-case transformation ([#1122](https://github.com/langium/langium/pull/1122)).
+* We've decided to remove generated `$container` type declarations for types where it isn't clear what the container types can be ([#1055](https://github.com/langium/langium/pull/1055)).
+
 ## v1.3.0 (Aug. 2023)
 
 ### Railroad Syntax Diagrams
@@ -39,11 +44,6 @@ This allows to more easily reuse those regular expressions in your code.
 * The CLI can now resolve grammar imports transitively ([#1113](https://github.com/langium/langium/pull/1113)).
 * A new `mode` configuration/argument can be used to improve bundle size of Langium projects ([#1077](https://github.com/langium/langium/pull/1077)).
 * Fixed an error in the way the CLI creates directories ([#1105](https://github.com/langium/langium/pull/1105)).
-
-### Breaking Changes
-
-* The CLI now always uses the original `projectName` of the `langium-config.json` property for the generated type/object names. It no longer performs kebab-case transformation ([#1122](https://github.com/langium/langium/pull/1122)).
-* We've decided to remove generated `$container` type declarations for types where it isn't clear what the container types can be ([#1055](https://github.com/langium/langium/pull/1055)).
 
 ## v1.2.1 (Jun. 2023)
 

--- a/packages/langium-cli/CHANGELOG.md
+++ b/packages/langium-cli/CHANGELOG.md
@@ -1,6 +1,37 @@
 # Change Log of `langium-cli`
 
-## v1.2.1 (June. 2023)
+## v2.0.0 (Jul. 2023)
+
+### Railroad Syntax Diagrams
+
+With the introduction of [`langium-railroad`](https://github.com/langium/langium/tree/main/packages/langium-railroad), the CLI is now capable of generating railroad syntax diagrams for your language ([#1075](https://github.com/langium/langium/pull/1075)).
+To generate them to a file, use the following example config:
+
+```json
+{
+    ...
+    "languages": [{
+        ...
+        "railroad": {
+            "out": "docs/syntax-diagram.html"
+        }
+    }],
+    ...
+}
+```
+
+### Generated Terminal Definitions
+
+The generated `ast.ts` file will now also contain an object containing all regular expressions used by your grammar's terminal rules ([#1097](https://github.com/langium/langium/pull/1097)).
+This allows to more easily reuse those regular expressions in your code.
+
+### General Improvements
+
+* The CLI can now resolve grammar imports transitively ([#1113](https://github.com/langium/langium/pull/1113)).
+* A new `mode` configuration/argument can be used to improve bundle size of Langium projects ([#1077](https://github.com/langium/langium/pull/1077)).
+* Fixed an error in the way the CLI creates directories ([#1105](https://github.com/langium/langium/pull/1105)).
+
+## v1.2.1 (Jun. 2023)
 
 * The generated code now performs split imports for runtime and compile time dependencies ([#1018](https://github.com/langium/langium/pull/1018)).
 * The new configuration field `importExtension` can be used to specify the file extension for generated imports ([#1072](https://github.com/langium/langium/pull/1072)).

--- a/packages/langium-cli/CHANGELOG.md
+++ b/packages/langium-cli/CHANGELOG.md
@@ -20,6 +20,9 @@ To generate them to a file, use the following example config:
 }
 ```
 
+> **Note**
+> The vscode extension for Langium contributes the `Show Railroad Syntax Diagram` command to show this HTML in a webview.
+
 ### Generated Terminal Definitions
 
 The generated `ast.ts` file will now also contain an object containing all regular expressions used by your grammar's terminal rules ([#1097](https://github.com/langium/langium/pull/1097)).
@@ -30,6 +33,11 @@ This allows to more easily reuse those regular expressions in your code.
 * The CLI can now resolve grammar imports transitively ([#1113](https://github.com/langium/langium/pull/1113)).
 * A new `mode` configuration/argument can be used to improve bundle size of Langium projects ([#1077](https://github.com/langium/langium/pull/1077)).
 * Fixed an error in the way the CLI creates directories ([#1105](https://github.com/langium/langium/pull/1105)).
+
+### Breaking Changes
+
+* The CLI now always uses the original `projectName` of the `langium-config.json` property for the generated type/object names. It no longer performs kebab-case transformation ([#1122](https://github.com/langium/langium/pull/1122)).
+* We've decided to remove generated `$container` type declarations for types where it isn't clear what the container types can be ([#1055](https://github.com/langium/langium/pull/1055)).
 
 ## v1.2.1 (Jun. 2023)
 

--- a/packages/langium-railroad/CHANGELOG.md
+++ b/packages/langium-railroad/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Change Log of `langium-railroad`
+
+## v2.0.0 (Aug. 2023)
+
+### EcmaScript Modules (ESM)
+
+This package is now compiling to ESM only, refer to [this changelog entry](https://github.com/langium/langium/blob/main/packages/langium/CHANGELOG.md#ecmascript-modules-esm)
+
+## v1.3.0 (Aug. 2023)
+
+Initial release of the `langium-railroad` package. This package is in charge of generating SVG syntax diagrams for grammars.

--- a/packages/langium-vscode/CHANGELOG.md
+++ b/packages/langium-vscode/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log of `langium-vscode`
 
-## v2.0.0 (Jul. 2023)
+## v2.0.0 (Aug. 2023)
 
 * Includes a command to open a railroad syntax diagram for the currently selected langium grammar. Use the `Show Railroad Syntax Diagram` command or the corresponding button in the editor title bar to open the diagram ([#1075](https://github.com/langium/langium/pull/1075)).
 * Improvements to validation regarding cyclic type usage ([#1130](https://github.com/langium/langium/pull/1130)).

--- a/packages/langium-vscode/CHANGELOG.md
+++ b/packages/langium-vscode/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## v2.0.0 (Jul. 2023)
 
-* Improvements to validation regarding cyclic type usage ([#1130](https://github.com/langium/langium/pull/1130)).
 * Includes a command to open a railroad syntax diagram for the currently selected langium grammar. Use the `Show Railroad Syntax Diagram` command or the corresponding button in the editor title bar to open the diagram ([#1075](https://github.com/langium/langium/pull/1075)).
+* Improvements to validation regarding cyclic type usage ([#1130](https://github.com/langium/langium/pull/1130)).
+* The grammar language can now resolve grammar imports transitively ([#1113](https://github.com/langium/langium/pull/1113)).
 
 ## v1.2.0 (May. 2023)
 

--- a/packages/langium-vscode/CHANGELOG.md
+++ b/packages/langium-vscode/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Change Log of `langium-vscode`
 
+## v2.0.0 (Jul. 2023)
+
+* Improvements to validation regarding cyclic type usage ([#1130](https://github.com/langium/langium/pull/1130)).
+* Includes a command to open a railroad syntax diagram for the currently selected langium grammar. Use the `Show Railroad Syntax Diagram` command or the corresponding button in the editor title bar to open the diagram ([#1075](https://github.com/langium/langium/pull/1075)).
+
 ## v1.2.0 (May. 2023)
 
-* Various improvements to the type generator/validator. ([#942](https://github.com/langium/langium/pull/942), [#946](https://github.com/langium/langium/pull/946), [#947](https://github.com/langium/langium/pull/947), [#950](https://github.com/langium/langium/pull/950), [#973](https://github.com/langium/langium/pull/973), [#1003](https://github.com/langium/langium/pull/1003))
+* Various improvements to the type generator/validator ([#942](https://github.com/langium/langium/pull/942), [#946](https://github.com/langium/langium/pull/946), [#947](https://github.com/langium/langium/pull/947), [#950](https://github.com/langium/langium/pull/950), [#973](https://github.com/langium/langium/pull/973), [#1003](https://github.com/langium/langium/pull/1003)).
 
 ## v1.1.0 (Feb. 2023)
 

--- a/packages/langium/CHANGELOG.md
+++ b/packages/langium/CHANGELOG.md
@@ -14,9 +14,10 @@ This leaves us with a problem, as all vscode extensions need to run as CJS code.
 Luckily, JavaScript bundlers such as `esbuild` are capable of transforming ESM code into CJS code.
 Using a bundler for vscode extensions and language servers is heavily recommended anyway,
 so we hope that adopters don't have much trouble upgrading to Langium 2.0.
+You can find a small instruction manual on how to migrate TypeScript projects to ESM [here](https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c#how-can-i-make-my-typescript-project-output-esm).
 
 Note that the newest version of the yeoman generator contains a ready-to-use bundler configuration.
-We also have [a guide available on our website](https://langium.org/guides/code-bundling/) that goes into more detail on this topic.
+We also have [a guide available on our website](https://langium.org/guides/code-bundling/) that goes into more detail on this topic. If you have any questions on this topic, feel free to ask us on the [GitHub Discussions Board](https://github.com/langium/langium/discussions).
 
 ### Regular Expression Flags
 
@@ -45,6 +46,12 @@ Langium provides 2 new classes:
 ### Breaking Changes
 
 * Langium is now compiling to ESM. See [here](#ecmascript-modules-esm) for more information ([#1125](https://github.com/langium/langium/pull/1125)).
+* The `CodeLensProvider`, `DocumentLinkProvider` and `InlayHintProvider` services were moved from the shared LSP services container to the language specific services container. Additionally, their `resolve` methods have been removed ([#1107](https://github.com/langium/langium/pull/1107)). 
+* Deprecated a few properties available on CST nodes. They have been renamed and their old property names will be deleted in a future version ([#1131](https://github.com/langium/langium/pull/1131)):
+    * `CstNode#parent` -> `container`
+    * `CstNode#feature` -> `grammarSource`
+    * `CstNode#element` -> `astNode`
+    * `CompositeCstNode#children` -> `content`
 * The `IndexManager#getAffectedDocuments` has been changed to `isAffected`. Instead of returning a stream of all affected documents of a change, it now only returns whether a specified document is affected by the change of a set of documents ([#1094](https://github.com/langium/langium/pull/1094)).
 * The `BuildOptions#validationChecks` property has been replaced with `validation?: boolean | ValidationOptions` ([#1094](https://github.com/langium/langium/pull/1094)).
 

--- a/packages/langium/CHANGELOG.md
+++ b/packages/langium/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log of `langium`
 
-## v2.0.0 (Jul. 2023)
+## v2.0.0 (Aug. 2023)
 
 ### EcmaScript Modules (ESM)
 
@@ -18,6 +18,8 @@ You can find a small instruction manual on how to migrate TypeScript projects to
 
 Note that the newest version of the yeoman generator contains a ready-to-use bundler configuration.
 We also have [a guide available on our website](https://langium.org/guides/code-bundling/) that goes into more detail on this topic. If you have any questions on this topic, feel free to ask us on the [GitHub Discussions Board](https://github.com/langium/langium/discussions).
+
+## v1.3.0 (Aug. 2023)
 
 ### Regular Expression Flags
 
@@ -37,15 +39,14 @@ Langium provides 2 new classes:
 
 ### General Improvements
 
-* The `DefaultCompletionProvider` has received a few improvements and should be even more accurate now ([#1106](https://github.com/langium/langium/pull/1106)).
-* Various performance improvements related to scoping and linking ([#1091](https://github.com/langium/langium/pull/1091) and [#1121](https://github.com/langium/langium/pull/1121)).
+* The `DefaultCompletionProvider` has received some improvements and should be even more accurate now ([#1106](https://github.com/langium/langium/pull/1106), [#1138](https://github.com/langium/langium/pull/1138)).
+* Various performance improvements related to scoping and linking ([#1091](https://github.com/langium/langium/pull/1091), [#1121](https://github.com/langium/langium/pull/1121)).
 * The new `CommentProvider` serves as a way to override how the comment of an AST node is computed ([#1095](https://github.com/langium/langium/pull/1095)).
 * The LSP `workspace/symbol` request is now resolved by the `WorkspaceSymbolProvider` ([#1100](https://github.com/langium/langium/pull/1100)).
 * The `DefaultDocumentBuilder` has been refactored to allow for more flexible and fine-grained validation behavior. ([#1094](https://github.com/langium/langium/pull/1094)).
 
 ### Breaking Changes
 
-* Langium is now compiling to ESM. See [here](#ecmascript-modules-esm) for more information ([#1125](https://github.com/langium/langium/pull/1125)).
 * The `CodeLensProvider`, `DocumentLinkProvider` and `InlayHintProvider` services were moved from the shared LSP services container to the language specific services container. Additionally, their `resolve` methods have been removed ([#1107](https://github.com/langium/langium/pull/1107)). 
 * Deprecated a few properties available on CST nodes. They have been renamed and their old property names will be deleted in a future version ([#1131](https://github.com/langium/langium/pull/1131)):
     * `CstNode#parent` -> `container`

--- a/packages/langium/CHANGELOG.md
+++ b/packages/langium/CHANGELOG.md
@@ -23,8 +23,8 @@ We also have [a guide available on our website](https://langium.org/guides/code-
 
 The Langium grammar language now supports regular expression flags as part of terminal definitions:
 
-1. `u` Enables unicode support for the specified terminal
-2. `i` Makes the terminal case-insensitive
+1. `u` Enables unicode support for the specified terminal.
+2. `i` Makes the terminal case-insensitive.
 3. `s` Makes the wild character "`.`" match newlines as well.
 
 ### Cache Support

--- a/packages/langium/CHANGELOG.md
+++ b/packages/langium/CHANGELOG.md
@@ -17,32 +17,11 @@ so we hope that adopters don't have much trouble upgrading to Langium 2.0.
 You can find a small instruction manual on how to migrate TypeScript projects to ESM [here](https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c#how-can-i-make-my-typescript-project-output-esm).
 
 Note that the newest version of the yeoman generator contains a ready-to-use bundler configuration.
+Adopters can use the generated project as a basis for upgrading to 2.0.
 We also have [a guide available on our website](https://langium.org/guides/code-bundling/) that goes into more detail on this topic. If you have any questions on this topic, feel free to ask us on the [GitHub Discussions Board](https://github.com/langium/langium/discussions).
-
-## v1.3.0 (Aug. 2023)
-
-### Regular Expression Flags
-
-The Langium grammar language now supports regular expression flags as part of terminal definitions:
-
-1. `u` Enables unicode support for the specified terminal.
-2. `i` Makes the terminal case-insensitive.
-3. `s` Makes the wild character "`.`" match newlines as well.
-
-### Cache Support
-
-In order to build caches that are instantly invalidated on workspace or document changes,
-Langium provides 2 new classes:
-
-1. The `WorkspaceCache` is a cache that gets cleared whenever a file in the workspace is changed, removed or created.
-2. The `DocumentCache` is a cache that stores information for specific documents. Whenever that document is modified in any way, the cache for that document is invalidated.
 
 ### General Improvements
 
-* The `DefaultCompletionProvider` has received some improvements and should be even more accurate now ([#1106](https://github.com/langium/langium/pull/1106), [#1138](https://github.com/langium/langium/pull/1138)).
-* Various performance improvements related to scoping and linking ([#1091](https://github.com/langium/langium/pull/1091), [#1121](https://github.com/langium/langium/pull/1121)).
-* The new `CommentProvider` serves as a way to override how the comment of an AST node is computed ([#1095](https://github.com/langium/langium/pull/1095)).
-* The LSP `workspace/symbol` request is now resolved by the `WorkspaceSymbolProvider` ([#1100](https://github.com/langium/langium/pull/1100)).
 * The `DefaultDocumentBuilder` has been refactored to allow for more flexible and fine-grained validation behavior. ([#1094](https://github.com/langium/langium/pull/1094)).
 
 ### Breaking Changes
@@ -55,6 +34,39 @@ Langium provides 2 new classes:
     * `CompositeCstNode#children` -> `content`
 * The `IndexManager#getAffectedDocuments` has been changed to `isAffected`. Instead of returning a stream of all affected documents of a change, it now only returns whether a specified document is affected by the change of a set of documents ([#1094](https://github.com/langium/langium/pull/1094)).
 * The `BuildOptions#validationChecks` property has been replaced with `validation?: boolean | ValidationOptions` ([#1094](https://github.com/langium/langium/pull/1094)).
+
+---
+
+## v1.3.0 (Aug. 2023)
+
+### Regular Expression Flags
+
+With [#1070](https://github.com/eclipse-langium/langium/pull/1070), the Langium grammar language now supports regular expression flags as part of terminal definitions:
+
+1. `u` Enables unicode support for the specified terminal.
+2. `i` Makes the terminal case-insensitive.
+3. `s` Makes the wild character "`.`" match newlines as well.
+
+### Cache Support
+
+In order to build caches that are instantly invalidated on workspace or document changes,
+Langium provides 2 new classes with [#1123](https://github.com/eclipse-langium/langium/pull/1123):
+
+1. The `WorkspaceCache` is a cache that gets cleared whenever a file in the workspace is changed, removed or created.
+2. The `DocumentCache` is a cache that stores information for specific documents. Whenever that document is modified in any way, the cache for that document is invalidated.
+
+### General Improvements
+
+* The `DefaultCompletionProvider` has received some improvements and should be even more accurate now ([#1106](https://github.com/langium/langium/pull/1106), [#1138](https://github.com/langium/langium/pull/1138)).
+* Various performance improvements related to scoping and linking ([#1091](https://github.com/langium/langium/pull/1091), [#1121](https://github.com/langium/langium/pull/1121)).
+* The new `CommentProvider` serves as a way to override how the comment of an AST node is computed ([#1095](https://github.com/langium/langium/pull/1095)).
+* The LSP `workspace/symbol` request is now resolved by the `WorkspaceSymbolProvider` ([#1100](https://github.com/langium/langium/pull/1100)).
+* Properties in guarded groups are now properly typed as optional ([#1116](https://github.com/eclipse-langium/langium/pull/1116)).
+* Some generated regular expressions are now more accurate ([#1109](https://github.com/eclipse-langium/langium/pull/1109)).
+* Generated language metadata is now being typed as `const` ([#1111](https://github.com/eclipse-langium/langium/pull/1111)).
+* Fixed typing of the `root` property on CST nodes ([#1090](https://github.com/eclipse-langium/langium/pull/1090)).
+* Parser error messages are now overridable in a service ([#1108](https://github.com/eclipse-langium/langium/pull/1108)).
+* Prevent file name collisions during testing ([#1153](https://github.com/eclipse-langium/langium/pull/1153)).
 
 ---
 

--- a/packages/langium/CHANGELOG.md
+++ b/packages/langium/CHANGELOG.md
@@ -1,5 +1,59 @@
 # Change Log of `langium`
 
+## v2.0.0 (Jul. 2023)
+
+### EcmaScript Modules (ESM)
+
+Langium is now compiling to ESM instead of CommonJS (CJS).
+CommonJS is the JavaScript convention introduced by Node.js and has historically been used in all Node.js based application.
+With the introduction of ESM to modern versions of the Node.js runtime, more and more projects and libraries are making the move to ESM. Since a lot of our dependencies have moved on, we decided to do so as well.
+
+While ESM based projects in Node.js can continue to import CJS code, CJS projects cannot (easily) import ESM code.
+This is a **very important change** for adopters, as it prevents using Langium as-is in CJS projects.
+This leaves us with a problem, as all vscode extensions need to run as CJS code.
+Luckily, JavaScript bundlers such as `esbuild` are capable of transforming ESM code into CJS code.
+Using a bundler for vscode extensions and language servers is heavily recommended anyway,
+so we hope that adopters don't have much trouble upgrading to Langium 2.0.
+
+Note that the newest version of the yeoman generator contains a ready-to-use bundler configuration.
+We also have [a guide available on our website](https://langium.org/guides/code-bundling/) that goes into more detail on this topic.
+
+### Regular Expression Flags
+
+The Langium grammar language now supports regular expression flags as part of terminal definitions:
+
+1. `u` Enables unicode support for the specified terminal
+2. `i` Makes the terminal case-insensitive
+3. `s` Makes the wild character "`.`" match newlines as well.
+
+### Cache Support
+
+In order to build caches that are instantly invalidated on workspace or document changes,
+Langium provides 2 new classes:
+
+1. The `WorkspaceCache` is a cache that gets cleared whenever a file in the workspace is changed, removed or created.
+2. The `DocumentCache` is a cache that stores information for specific documents. Whenever that document is modified in any way, the cache for that document is invalidated.
+
+### General Improvements
+
+* The `DefaultCompletionProvider` has received a few improvements and should be even more accurate now ([#1106](https://github.com/langium/langium/pull/1106)).
+* Various performance improvements related to scoping and linking ([#1091](https://github.com/langium/langium/pull/1091) and [#1121](https://github.com/langium/langium/pull/1121)).
+* The new `CommentProvider` serves as a way to override how the comment of an AST node is computed ([#1095](https://github.com/langium/langium/pull/1095)).
+* The LSP `workspace/symbol` request is now resolved by the `WorkspaceSymbolProvider` ([#1100](https://github.com/langium/langium/pull/1100)).
+* The `DefaultDocumentBuilder` has been refactored to allow for more flexible and fine-grained validation behavior. ([#1094](https://github.com/langium/langium/pull/1094)).
+
+### Breaking Changes
+
+* Langium is now compiling to ESM. See [here](#ecmascript-modules-esm) for more information ([#1125](https://github.com/langium/langium/pull/1125)).
+* The `IndexManager#getAffectedDocuments` has been changed to `isAffected`. Instead of returning a stream of all affected documents of a change, it now only returns whether a specified document is affected by the change of a set of documents ([#1094](https://github.com/langium/langium/pull/1094)).
+* The `BuildOptions#validationChecks` property has been replaced with `validation?: boolean | ValidationOptions` ([#1094](https://github.com/langium/langium/pull/1094)).
+
+---
+
+## v1.2.1 (Jun. 2023)
+
+Fixed a minor generator issue ([#1043](https://github.com/langium/langium/pull/1043)).
+
 ## v1.2.0 (Apr. 2023)
 
 ### General Improvements


### PR DESCRIPTION
In preparation for our 2.0 release, I've already added the changelog entries that contain the most important changes for adopters.