### PR TITLE
Prevent file names collisions during tests

### DIFF
--- a/packages/langium/src/test/langium-test.ts
+++ b/packages/langium/src/test/langium-test.ts
@@ -21,6 +21,9 @@ import type { AsyncDisposable } from '../utils/disposable.js';
 import { Disposable } from '../utils/disposable.js';
 
 export interface ParseHelperOptions extends BuildOptions {
+    /**
+     * Specifies the URI of the generated document. Will use a counter variable if not specified.
+     */
     documentUri?: string;
 }
 
@@ -54,10 +57,26 @@ export function expectFunction(functions: ExpectFunction): void {
 }
 
 export interface ExpectedBase {
+    /**
+     * Document content.
+     * Use `<|>` and `<|...|>` to mark special items that are relevant to the test case.
+     */
     text: string
+    /**
+     * Parse options used to parse the {@link text} property.
+     */
     parseOptions?: ParseHelperOptions
+    /**
+     * String to mark indices for test cases. `<|>` by default.
+     */
     indexMarker?: string
+    /**
+     * String to mark start indices for test cases. `<|` by default.
+     */
     rangeStartMarker?: string
+    /**
+     * String to mark end indices for test cases. `|>` by default.
+     */
     rangeEndMarker?: string
     /**
      * Whether to dispose the created documents right after performing the check.
@@ -408,10 +427,32 @@ export function expectHover(services: LangiumServices): (expectedHover: Expected
 }
 
 export interface ExpectFormatting {
+    /**
+     * Document content before formatting.
+     */
     before: string
+    /**
+     * Expected document content after formatting.
+     * The test case will compare this to the actual formatted document.
+     */
     after: string
+    /**
+     * Parse options used to parse the {@link text} property.
+     */
     parseOptions?: ParseHelperOptions
+    /**
+     * If given, only the specified range will be affected by the formatter
+     */
     range?: Range
+    /**
+     * Options used by the formatter. Default:
+     * ```ts
+     * {
+     *     insertSpaces: true,
+     *     tabSize: 4
+     * }
+     * ```
+     */
     options?: FormattingOptions
     /**
      * Whether to dispose the created documents right after performing the check.

--- a/packages/langium/src/test/langium-test.ts
+++ b/packages/langium/src/test/langium-test.ts
@@ -16,17 +16,21 @@ import { findNodeForProperty } from '../utils/grammar-util.js';
 import { SemanticTokensDecoder } from '../lsp/semantic-token-provider.js';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import * as assert from 'node:assert';
+import { stream } from '../utils/stream.js';
+import type { AsyncDisposable } from '../utils/disposable.js';
+import { Disposable } from '../utils/disposable.js';
 
 export interface ParseHelperOptions extends BuildOptions {
     documentUri?: string;
 }
 
+let nextDocumentId = 1;
+
 export function parseHelper<T extends AstNode = AstNode>(services: LangiumServices): (input: string, options?: ParseHelperOptions) => Promise<LangiumDocument<T>> {
     const metaData = services.LanguageMetaData;
     const documentBuilder = services.shared.workspace.DocumentBuilder;
     return async (input, options) => {
-        const randomNumber = Math.floor(Math.random() * 10000000) + 1000000;
-        const uri = URI.parse(options?.documentUri ?? `file:///${randomNumber}${metaData.fileExtensions[0]}`);
+        const uri = URI.parse(options?.documentUri ?? `file:///${nextDocumentId++}${metaData.fileExtensions[0] ?? ''}`);
         const document = services.shared.workspace.LangiumDocumentFactory.fromString<T>(input, uri);
         services.shared.workspace.LangiumDocuments.addDocument(document);
         await documentBuilder.build([document], options);
@@ -51,9 +55,11 @@ export function expectFunction(functions: ExpectFunction): void {
 
 export interface ExpectedBase {
     text: string
+    parseOptions?: ParseHelperOptions
     indexMarker?: string
     rangeStartMarker?: string
     rangeEndMarker?: string
+    dispose?: boolean;
 }
 
 export interface ExpectedHighlight extends ExpectedBase {
@@ -66,7 +72,7 @@ export interface ExpectedHighlight extends ExpectedBase {
  *
  * @returns A function that performs the assertion
  */
-export function expectHighlight(services: LangiumServices): (input: ExpectedHighlight) => Promise<void> {
+export function expectHighlight(services: LangiumServices): (input: ExpectedHighlight) => Promise<AsyncDisposable> {
     return async input => {
         const { output, indices, ranges } = replaceIndices(input);
         const document = await parseDocument(services, output);
@@ -104,6 +110,11 @@ export function expectHighlight(services: LangiumServices): (input: ExpectedHigh
                 expectedFunction(targetRange, expectedRange, `Expected range ${rangeToString(expectedRange)} does not match actual range ${rangeToString(targetRange)}`);
             }
         }
+        const disposable = Disposable.create(() => clearDocuments(services, [document]));
+        if (input.dispose) {
+            await disposable.dispose();
+        }
+        return disposable;
     };
 }
 
@@ -116,9 +127,9 @@ export interface ExpectedSymbolsCallback extends ExpectedBase {
 }
 export type ExpectedSymbols = ExpectedSymbolsList | ExpectedSymbolsCallback;
 
-export function expectSymbols(services: LangiumServices): (input: ExpectedSymbols) => Promise<void> {
+export function expectSymbols(services: LangiumServices): (input: ExpectedSymbols) => Promise<AsyncDisposable> {
     return async input => {
-        const document = await parseDocument(services, input.text);
+        const document = await parseDocument(services, input.text, input.parseOptions);
         const symbolProvider = services.lsp.DocumentSymbolProvider;
         const symbols = await symbolProvider?.getSymbols(document, textDocumentParams(document)) ?? [];
 
@@ -143,6 +154,11 @@ export function expectSymbols(services: LangiumServices): (input: ExpectedSymbol
                 expectedFunction(symbolsMapped, expectedSymbols, `Expected ${expectedSymbols.length} but found ${symbols.length} symbols in document`);
             }
         }
+        const disposable = Disposable.create(() => clearDocuments(services, [document]));
+        if (input.dispose) {
+            await disposable.dispose();
+        }
+        return disposable;
     };
 }
 
@@ -197,10 +213,10 @@ export interface ExpectedFoldings extends ExpectedBase {
     assert?: (foldings: FoldingRange[], expected: Array<[number, number]>) => void;
 }
 
-export function expectFoldings(services: LangiumServices): (input: ExpectedFoldings) => Promise<void> {
+export function expectFoldings(services: LangiumServices): (input: ExpectedFoldings) => Promise<AsyncDisposable> {
     return async input => {
         const { output, ranges } = replaceIndices(input);
-        const document = await parseDocument(services, output);
+        const document = await parseDocument(services, output, input.parseOptions);
         const foldingRangeProvider = services.lsp.FoldingRangeProvider;
         const foldings = await foldingRangeProvider?.getFoldingRanges(document, textDocumentParams(document)) ?? [];
         foldings.sort((a, b) => a.startLine - b.startLine);
@@ -218,6 +234,11 @@ export function expectFoldings(services: LangiumServices): (input: ExpectedFoldi
                 expectedFunction(item.endLine, expectedEnd.line, `Expected folding end at line ${expectedEnd.line} but received folding end at line ${item.endLine} instead.`);
             }
         }
+        const disposable = Disposable.create(() => clearDocuments(services, [document]));
+        if (input.dispose) {
+            await disposable.dispose();
+        }
+        return disposable;
     };
 }
 
@@ -236,10 +257,10 @@ export interface ExpectedCompletionCallback extends ExpectedBase {
 }
 export type ExpectedCompletion = ExpectedCompletionItems | ExpectedCompletionCallback;
 
-export function expectCompletion(services: LangiumServices): (expectedCompletion: ExpectedCompletion) => Promise<void> {
+export function expectCompletion(services: LangiumServices): (expectedCompletion: ExpectedCompletion) => Promise<AsyncDisposable> {
     return async expectedCompletion => {
         const { output, indices } = replaceIndices(expectedCompletion);
-        const document = await parseDocument(services, output);
+        const document = await parseDocument(services, output, expectedCompletion.parseOptions);
         const completionProvider = services.lsp.CompletionProvider;
         const offset = indices[expectedCompletion.index];
         const completions = await completionProvider?.getCompletion(document, textDocumentPositionParams(document, offset)) ?? { isIncomplete: false, items: [] };
@@ -262,12 +283,16 @@ export function expectCompletion(services: LangiumServices): (expectedCompletion
                         expectedFunction(completion, expected);
                     }
                 }
-
             } else {
                 const itemsMapped = items.map((s, i) => expectedItems[i] === undefined || typeof expectedItems[i] === 'string' ? itemToString(s) : s);
                 expectedFunction(itemsMapped, expectedItems, `Expected ${expectedItems.length} but received ${items.length} completion items`);
             }
         }
+        const disposable = Disposable.create(() => clearDocuments(services, [document]));
+        if (expectedCompletion.dispose) {
+            await disposable.dispose();
+        }
+        return disposable;
     };
 }
 
@@ -276,10 +301,10 @@ export interface ExpectedGoToDefinition extends ExpectedBase {
     rangeIndex: number | number[]
 }
 
-export function expectGoToDefinition(services: LangiumServices): (expectedGoToDefinition: ExpectedGoToDefinition) => Promise<void> {
+export function expectGoToDefinition(services: LangiumServices): (expectedGoToDefinition: ExpectedGoToDefinition) => Promise<AsyncDisposable> {
     return async expectedGoToDefinition => {
         const { output, indices, ranges } = replaceIndices(expectedGoToDefinition);
-        const document = await parseDocument(services, output);
+        const document = await parseDocument(services, output, expectedGoToDefinition.parseOptions);
         const definitionProvider = services.lsp.DefinitionProvider;
         const locationLinks = await definitionProvider?.getDefinition(document, textDocumentPositionParams(document, indices[expectedGoToDefinition.index])) ?? [];
         const rangeIndex = expectedGoToDefinition.rangeIndex;
@@ -302,6 +327,11 @@ export function expectGoToDefinition(services: LangiumServices): (expectedGoToDe
             const range = locationLinks[0].targetSelectionRange;
             expectedFunction(range, expectedRange, `Expected range ${rangeToString(expectedRange)} does not match actual range ${rangeToString(range)}`);
         }
+        const disposable = Disposable.create(() => clearDocuments(services, [document]));
+        if (expectedGoToDefinition.dispose) {
+            await disposable.dispose();
+        }
+        return disposable;
     };
 }
 
@@ -309,10 +339,10 @@ export interface ExpectedFindReferences extends ExpectedBase {
     includeDeclaration: boolean
 }
 
-export function expectFindReferences(services: LangiumServices): (expectedFindReferences: ExpectedFindReferences) => Promise<void> {
+export function expectFindReferences(services: LangiumServices): (expectedFindReferences: ExpectedFindReferences) => Promise<AsyncDisposable> {
     return async expectedFindReferences => {
         const { output, indices, ranges } = replaceIndices(expectedFindReferences);
-        const document = await parseDocument(services, output);
+        const document = await parseDocument(services, output, expectedFindReferences.parseOptions);
         const expectedRanges: Range[] = ranges.map(range => ({
             start: document.textDocument.positionAt(range[0]),
             end: document.textDocument.positionAt(range[1])
@@ -327,7 +357,11 @@ export function expectFindReferences(services: LangiumServices): (expectedFindRe
                 expectedFunction(expectedRanges.some(range => isRangeEqual(range, reference.range)), true, `Found unexpected reference at range ${rangeToString(reference.range)}`);
             }
         }
-        clearDocuments(services);
+        const disposable = Disposable.create(() => clearDocuments(services, [document]));
+        if (expectedFindReferences.dispose) {
+            await disposable.dispose();
+        }
+        return disposable;
     };
 }
 
@@ -343,10 +377,10 @@ export interface ExpectedHover extends ExpectedBase {
     hover?: string | RegExp
 }
 
-export function expectHover(services: LangiumServices): (expectedHover: ExpectedHover) => Promise<void> {
+export function expectHover(services: LangiumServices): (expectedHover: ExpectedHover) => Promise<AsyncDisposable> {
     return async expectedHover => {
         const { output, indices } = replaceIndices(expectedHover);
-        const document = await parseDocument(services, output);
+        const document = await parseDocument(services, output, expectedHover.parseOptions);
         const hoverProvider = services.lsp.HoverProvider;
         const hover = await hoverProvider?.getHoverContent(document, textDocumentPositionParams(document, indices[expectedHover.index]));
         const hoverContent = hover && MarkupContent.is(hover.contents) ? hover.contents.value : undefined;
@@ -360,23 +394,30 @@ export function expectHover(services: LangiumServices): (expectedHover: Expected
                 `Hover '${value}' does not match regex /${expectedHover.hover.source}/${expectedHover.hover.flags}.`
             );
         }
+        const disposable = Disposable.create(() => clearDocuments(services, [document]));
+        if (expectedHover.dispose) {
+            await disposable.dispose();
+        }
+        return disposable;
     };
 }
 
 export interface ExpectFormatting {
     before: string
     after: string
+    parseOptions?: ParseHelperOptions
     range?: Range
     options?: FormattingOptions
+    dispose?: boolean;
 }
 
-export function expectFormatting(services: LangiumServices): (expectedFormatting: ExpectFormatting) => Promise<void> {
+export function expectFormatting(services: LangiumServices): (expectedFormatting: ExpectFormatting) => Promise<AsyncDisposable> {
     const formatter = services.lsp.Formatter;
     if (!formatter) {
         throw new Error(`No formatter registered for language ${services.LanguageMetaData.languageId}`);
     }
     return async expectedFormatting => {
-        const document = await parseDocument(services, expectedFormatting.before);
+        const document = await parseDocument(services, expectedFormatting.before, expectedFormatting.parseOptions);
         const identifier = { uri: document.uri.toString() };
         const options = expectedFormatting.options ?? {
             insertSpaces: true,
@@ -388,6 +429,12 @@ export function expectFormatting(services: LangiumServices): (expectedFormatting
 
         const editedDocument = TextDocument.applyEdits(document.textDocument, edits);
         expectedFunction(editedDocument, expectedFormatting.after);
+
+        const disposable = Disposable.create(() => clearDocuments(services, [document]));
+        if (expectedFormatting.dispose) {
+            await disposable.dispose();
+        }
+        return disposable;
     };
 }
 
@@ -395,8 +442,8 @@ export function textDocumentPositionParams(document: LangiumDocument, offset: nu
     return { textDocument: { uri: document.textDocument.uri }, position: document.textDocument.positionAt(offset) };
 }
 
-export async function parseDocument<T extends AstNode = AstNode>(services: LangiumServices, input: string): Promise<LangiumDocument<T>> {
-    const document = await parseHelper<T>(services)(input);
+export async function parseDocument<T extends AstNode = AstNode>(services: LangiumServices, input: string, options?: ParseHelperOptions): Promise<LangiumDocument<T>> {
+    const document = await parseHelper<T>(services)(input, options);
     if (!document.parseResult) {
         throw new Error('Could not parse document');
     }
@@ -441,16 +488,23 @@ export function replaceIndices(base: ExpectedBase): { output: string, indices: n
     return { output: input, indices, ranges: ranges.sort((a, b) => a[0] - b[0]) };
 }
 
-export interface ValidationResult<T extends AstNode = AstNode> {
+export interface ValidationResult<T extends AstNode = AstNode> extends AsyncDisposable {
     diagnostics: Diagnostic[];
     document: LangiumDocument<T>;
 }
 
-export function validationHelper<T extends AstNode = AstNode>(services: LangiumServices): (input: string) => Promise<ValidationResult<T>> {
+export function validationHelper<T extends AstNode = AstNode>(services: LangiumServices): (input: string, options?: ParseHelperOptions) => Promise<ValidationResult<T>> {
     const parse = parseHelper<T>(services);
-    return async (input) => {
-        const document = await parse(input, { validation: true });
-        return { document, diagnostics: document.diagnostics ?? [] };
+    return async (input, options) => {
+        const document = await parse(input, {
+            ...(options ?? {}),
+            validation: true
+        });
+        return {
+            document,
+            diagnostics: document.diagnostics ?? [],
+            dispose: () => clearDocuments(services, [document])
+        };
     };
 }
 
@@ -588,9 +642,10 @@ export function expectWarning<T extends AstNode = AstNode, N extends AstNode = A
     });
 }
 
-export function clearDocuments(services: LangiumServices): Promise<void> {
-    const allDocs = services.shared.workspace.LangiumDocuments.all.map(x => x.uri).toArray();
-    return services.shared.workspace.DocumentBuilder.update([], allDocs);
+export function clearDocuments(services: LangiumServices | LangiumSharedServices, documents?: LangiumDocument[]): Promise<void> {
+    const shared = 'shared' in services ? services.shared : services;
+    const allDocs = (documents ? stream(documents) : shared.workspace.LangiumDocuments.all).map(x => x.uri).toArray();
+    return shared.workspace.DocumentBuilder.update([], allDocs);
 }
 
 export interface DecodedSemanticTokensWithRanges {
@@ -598,14 +653,14 @@ export interface DecodedSemanticTokensWithRanges {
     ranges: Array<[number, number]>;
 }
 
-export function highlightHelper<T extends AstNode = AstNode>(services: LangiumServices): (input: string) => Promise<DecodedSemanticTokensWithRanges> {
+export function highlightHelper<T extends AstNode = AstNode>(services: LangiumServices): (input: string, options?: ParseHelperOptions) => Promise<DecodedSemanticTokensWithRanges> {
     const parse = parseHelper<T>(services);
     const tokenProvider = services.lsp.SemanticTokenProvider!;
-    return async text => {
+    return async (text, options) => {
         const { output: input, ranges } = replaceIndices({
             text
         });
-        const document = await parse(input);
+        const document = await parse(input, options);
         const params: SemanticTokensParams = { textDocument: { uri: document.textDocument.uri } };
         const tokens = await tokenProvider.semanticHighlight(document, params, new CancellationTokenSource().token);
         return { tokens: SemanticTokensDecoder.decode(tokens, document), ranges };

--- a/packages/langium/src/test/langium-test.ts
+++ b/packages/langium/src/test/langium-test.ts
@@ -59,7 +59,12 @@ export interface ExpectedBase {
     indexMarker?: string
     rangeStartMarker?: string
     rangeEndMarker?: string
-    dispose?: boolean;
+    /**
+     * Whether to dispose the created documents right after performing the check.
+     *
+     * Defaults to `false`.
+     */
+    disposeAfterCheck?: boolean;
 }
 
 export interface ExpectedHighlight extends ExpectedBase {
@@ -111,7 +116,7 @@ export function expectHighlight(services: LangiumServices): (input: ExpectedHigh
             }
         }
         const disposable = Disposable.create(() => clearDocuments(services, [document]));
-        if (input.dispose) {
+        if (input.disposeAfterCheck) {
             await disposable.dispose();
         }
         return disposable;
@@ -155,7 +160,7 @@ export function expectSymbols(services: LangiumServices): (input: ExpectedSymbol
             }
         }
         const disposable = Disposable.create(() => clearDocuments(services, [document]));
-        if (input.dispose) {
+        if (input.disposeAfterCheck) {
             await disposable.dispose();
         }
         return disposable;
@@ -235,7 +240,7 @@ export function expectFoldings(services: LangiumServices): (input: ExpectedFoldi
             }
         }
         const disposable = Disposable.create(() => clearDocuments(services, [document]));
-        if (input.dispose) {
+        if (input.disposeAfterCheck) {
             await disposable.dispose();
         }
         return disposable;
@@ -289,7 +294,7 @@ export function expectCompletion(services: LangiumServices): (expectedCompletion
             }
         }
         const disposable = Disposable.create(() => clearDocuments(services, [document]));
-        if (expectedCompletion.dispose) {
+        if (expectedCompletion.disposeAfterCheck) {
             await disposable.dispose();
         }
         return disposable;
@@ -328,7 +333,7 @@ export function expectGoToDefinition(services: LangiumServices): (expectedGoToDe
             expectedFunction(range, expectedRange, `Expected range ${rangeToString(expectedRange)} does not match actual range ${rangeToString(range)}`);
         }
         const disposable = Disposable.create(() => clearDocuments(services, [document]));
-        if (expectedGoToDefinition.dispose) {
+        if (expectedGoToDefinition.disposeAfterCheck) {
             await disposable.dispose();
         }
         return disposable;
@@ -358,7 +363,7 @@ export function expectFindReferences(services: LangiumServices): (expectedFindRe
             }
         }
         const disposable = Disposable.create(() => clearDocuments(services, [document]));
-        if (expectedFindReferences.dispose) {
+        if (expectedFindReferences.disposeAfterCheck) {
             await disposable.dispose();
         }
         return disposable;
@@ -395,7 +400,7 @@ export function expectHover(services: LangiumServices): (expectedHover: Expected
             );
         }
         const disposable = Disposable.create(() => clearDocuments(services, [document]));
-        if (expectedHover.dispose) {
+        if (expectedHover.disposeAfterCheck) {
             await disposable.dispose();
         }
         return disposable;
@@ -408,7 +413,12 @@ export interface ExpectFormatting {
     parseOptions?: ParseHelperOptions
     range?: Range
     options?: FormattingOptions
-    dispose?: boolean;
+    /**
+     * Whether to dispose the created documents right after performing the check.
+     *
+     * Defaults to `false`.
+     */
+    disposeAfterCheck?: boolean;
 }
 
 export function expectFormatting(services: LangiumServices): (expectedFormatting: ExpectFormatting) => Promise<AsyncDisposable> {
@@ -431,7 +441,7 @@ export function expectFormatting(services: LangiumServices): (expectedFormatting
         expectedFunction(editedDocument, expectedFormatting.after);
 
         const disposable = Disposable.create(() => clearDocuments(services, [document]));
-        if (expectedFormatting.dispose) {
+        if (expectedFormatting.disposeAfterCheck) {
             await disposable.dispose();
         }
         return disposable;

--- a/packages/langium/src/utils/caching.ts
+++ b/packages/langium/src/utils/caching.ts
@@ -4,7 +4,7 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import type { Disposable } from 'vscode-languageserver';
+import type { Disposable } from './disposable.js';
 import type { URI } from './uri-util.js';
 import type { LangiumSharedServices } from '../services.js';
 

--- a/packages/langium/src/utils/disposable.ts
+++ b/packages/langium/src/utils/disposable.ts
@@ -1,0 +1,29 @@
+/******************************************************************************
+ * Copyright 2021 TypeFox GmbH
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License, which is available in the project root.
+ ******************************************************************************/
+
+export interface Disposable {
+    /**
+     * Dispose this object.
+     */
+    dispose(): void;
+}
+
+export interface AsyncDisposable {
+    /**
+     * Dispose this object.
+     */
+    dispose(): Promise<void>;
+}
+
+export namespace Disposable {
+    export function create(callback: () => Promise<void>): AsyncDisposable;
+    export function create(callback: () => void): Disposable;
+    export function create(callback: () => void | Promise<void>): Disposable | AsyncDisposable {
+        return {
+            dispose: async () => await callback()
+        };
+    }
+}

--- a/packages/langium/src/utils/index.ts
+++ b/packages/langium/src/utils/index.ts
@@ -8,6 +8,7 @@ export * from './ast-util.js';
 export * from './caching.js';
 export * from './collections.js';
 export * from './cst-util.js';
+export * from './disposable.js';
 export * from './errors.js';
 export * from './grammar-util.js';
 export * from './promise-util.js';

--- a/packages/langium/test/grammar/references/grammar-scope.test.ts
+++ b/packages/langium/test/grammar/references/grammar-scope.test.ts
@@ -7,7 +7,7 @@
 import type { Grammar } from 'langium';
 import type { GrammarAST as GrammarTypes } from 'langium';
 import { beforeEach, describe, expect, test } from 'vitest';
-import { createLangiumGrammarServices, EmptyFileSystem, UriUtils } from 'langium';
+import { createLangiumGrammarServices, EmptyFileSystem } from 'langium';
 import { clearDocuments, parseHelper } from 'langium/test';
 
 describe('Type Linking', () => {
@@ -42,10 +42,12 @@ describe('Type Linking', () => {
         A infers A:
             'A' a=ID;
         terminal ID: /[_a-zA-Z][\\w_]*/;
-        `);
+        `, {
+            documentUri: 'file:///inferred.langium'
+        });
         const grammar2 = await parse(`
         grammar Debug
-        import './${UriUtils.basename(grammar1.uri)}'
+        import './inferred'
         entry Model:
             (b+=B | a+=A)*;
         B infers B:
@@ -88,10 +90,12 @@ describe('Type Linking', () => {
         A returns A:
             'A' a=ID;
         terminal ID: /[_a-zA-Z][\\w_]*/;
-        `);
+        `, {
+            documentUri: 'file:///declared.langium'
+        });
         const grammar2 = await parse(`
         grammar Debug
-        import './${UriUtils.basename(grammar1.uri)}'
+        import './declared'
         interface B {
             b: @A
         }
@@ -111,16 +115,20 @@ describe('Type Linking', () => {
         interface A {
             a: string
         }
-        `);
+        `, {
+            documentUri: 'file:///declaredTransitive.langium'
+        });
         const grammar2 = await parse(`
-        import './${UriUtils.basename(grammar1.uri)}'
+        import './declaredTransitive'
         A returns A:
             'A' a=ID;
         terminal ID: /[_a-zA-Z][\\w_]*/;
-        `);
+        `, {
+            documentUri: 'file:///declaredProxy.langium'
+        });
         const grammar3 = await parse(`
         grammar Debug
-        import './${UriUtils.basename(grammar2.uri)}'
+        import './declaredProxy'
         interface B {
             b: @A
         }

--- a/packages/langium/test/utils/disposable.test.ts
+++ b/packages/langium/test/utils/disposable.test.ts
@@ -1,0 +1,33 @@
+/******************************************************************************
+ * Copyright 2023 TypeFox GmbH
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License, which is available in the project root.
+ ******************************************************************************/
+
+import { describe, test, expect } from 'vitest';
+import { Disposable } from 'langium';
+
+describe('Disposable', () => {
+
+    test('Sync disposable disposes instantly', () => {
+        let disposed = false;
+        const disposable = Disposable.create(() => disposed = true);
+        disposable.dispose();
+        expect(disposed).toBe(true);
+    });
+
+    test('Async disposable disposes during await', async () => {
+        let disposed = false;
+        const disposable = Disposable.create(() => new Promise<void>(resolve => {
+            setTimeout(() => {
+                disposed = true;
+                resolve();
+            }, 50);
+        }));
+        const promise = disposable.dispose();
+        expect(disposed).toBe(false);
+        await promise;
+        expect(disposed).toBe(true);
+    });
+
+});


### PR DESCRIPTION
Closes https://github.com/eclipse-langium/langium/issues/1146

Uses a running ID to prevent name collisions during tests. Also adds the parse options to all test methods.