### PR TITLE
Fix CLI API import

### DIFF
--- a/packages/langium-cli/src/index.ts
+++ b/packages/langium-cli/src/index.ts
@@ -5,4 +5,4 @@
  ******************************************************************************/
 
 export type { GenerateOptions } from './generate.js';
-export { generate } from './langium.js';
+export { generate } from './generate.js';


### PR DESCRIPTION
Closes https://github.com/eclipse-langium/langium/issues/1150

Moves the functions out of the `commander` file. Importing the file led to immediate execution of the CLI with incorrect arguments.