### PR TITLE
Support default values on interface properties

### DIFF
--- a/examples/arithmetics/src/language-server/generated/ast.ts
+++ b/examples/arithmetics/src/language-server/generated/ast.ts
@@ -183,34 +183,72 @@ export class ArithmeticsAstReflection extends AbstractAstReflection {
 
     getTypeMetaData(type: string): TypeMetaData {
         switch (type) {
+            case 'BinaryExpression': {
+                return {
+                    name: 'BinaryExpression',
+                    properties: [
+                        { name: 'left' },
+                        { name: 'operator' },
+                        { name: 'right' }
+                    ]
+                };
+            }
+            case 'DeclaredParameter': {
+                return {
+                    name: 'DeclaredParameter',
+                    properties: [
+                        { name: 'name' }
+                    ]
+                };
+            }
             case 'Definition': {
                 return {
                     name: 'Definition',
-                    mandatory: [
-                        { name: 'args', type: 'array' }
+                    properties: [
+                        { name: 'args', defaultValue: [] },
+                        { name: 'expr' },
+                        { name: 'name' }
+                    ]
+                };
+            }
+            case 'Evaluation': {
+                return {
+                    name: 'Evaluation',
+                    properties: [
+                        { name: 'expression' }
                     ]
                 };
             }
             case 'FunctionCall': {
                 return {
                     name: 'FunctionCall',
-                    mandatory: [
-                        { name: 'args', type: 'array' }
+                    properties: [
+                        { name: 'args', defaultValue: [] },
+                        { name: 'func' }
                     ]
                 };
             }
             case 'Module': {
                 return {
                     name: 'Module',
-                    mandatory: [
-                        { name: 'statements', type: 'array' }
+                    properties: [
+                        { name: 'name' },
+                        { name: 'statements', defaultValue: [] }
+                    ]
+                };
+            }
+            case 'NumberLiteral': {
+                return {
+                    name: 'NumberLiteral',
+                    properties: [
+                        { name: 'value' }
                     ]
                 };
             }
             default: {
                 return {
                     name: type,
-                    mandatory: []
+                    properties: []
                 };
             }
         }

--- a/examples/domainmodel/src/language-server/generated/ast.ts
+++ b/examples/domainmodel/src/language-server/generated/ast.ts
@@ -149,42 +149,55 @@ export class DomainModelAstReflection extends AbstractAstReflection {
 
     getTypeMetaData(type: string): TypeMetaData {
         switch (type) {
+            case 'DataType': {
+                return {
+                    name: 'DataType',
+                    properties: [
+                        { name: 'name' }
+                    ]
+                };
+            }
             case 'Domainmodel': {
                 return {
                     name: 'Domainmodel',
-                    mandatory: [
-                        { name: 'elements', type: 'array' }
+                    properties: [
+                        { name: 'elements', defaultValue: [] }
                     ]
                 };
             }
             case 'Entity': {
                 return {
                     name: 'Entity',
-                    mandatory: [
-                        { name: 'features', type: 'array' }
+                    properties: [
+                        { name: 'features', defaultValue: [] },
+                        { name: 'name' },
+                        { name: 'superType' }
                     ]
                 };
             }
             case 'Feature': {
                 return {
                     name: 'Feature',
-                    mandatory: [
-                        { name: 'many', type: 'boolean' }
+                    properties: [
+                        { name: 'many', defaultValue: false },
+                        { name: 'name' },
+                        { name: 'type' }
                     ]
                 };
             }
             case 'PackageDeclaration': {
                 return {
                     name: 'PackageDeclaration',
-                    mandatory: [
-                        { name: 'elements', type: 'array' }
+                    properties: [
+                        { name: 'elements', defaultValue: [] },
+                        { name: 'name' }
                     ]
                 };
             }
             default: {
                 return {
                     name: type,
-                    mandatory: []
+                    properties: []
                 };
             }
         }

--- a/examples/requirements/src/language-server/generated/ast.ts
+++ b/examples/requirements/src/language-server/generated/ast.ts
@@ -135,44 +135,67 @@ export class RequirementsAndTestsAstReflection extends AbstractAstReflection {
 
     getTypeMetaData(type: string): TypeMetaData {
         switch (type) {
+            case 'Contact': {
+                return {
+                    name: 'Contact',
+                    properties: [
+                        { name: 'user_name' }
+                    ]
+                };
+            }
+            case 'Environment': {
+                return {
+                    name: 'Environment',
+                    properties: [
+                        { name: 'description' },
+                        { name: 'name' }
+                    ]
+                };
+            }
             case 'Requirement': {
                 return {
                     name: 'Requirement',
-                    mandatory: [
-                        { name: 'environments', type: 'array' }
+                    properties: [
+                        { name: 'environments', defaultValue: [] },
+                        { name: 'name' },
+                        { name: 'text' }
                     ]
                 };
             }
             case 'RequirementModel': {
                 return {
                     name: 'RequirementModel',
-                    mandatory: [
-                        { name: 'environments', type: 'array' },
-                        { name: 'requirements', type: 'array' }
+                    properties: [
+                        { name: 'contact' },
+                        { name: 'environments', defaultValue: [] },
+                        { name: 'requirements', defaultValue: [] }
                     ]
                 };
             }
             case 'Test': {
                 return {
                     name: 'Test',
-                    mandatory: [
-                        { name: 'environments', type: 'array' },
-                        { name: 'requirements', type: 'array' }
+                    properties: [
+                        { name: 'environments', defaultValue: [] },
+                        { name: 'name' },
+                        { name: 'requirements', defaultValue: [] },
+                        { name: 'testFile' }
                     ]
                 };
             }
             case 'TestModel': {
                 return {
                     name: 'TestModel',
-                    mandatory: [
-                        { name: 'tests', type: 'array' }
+                    properties: [
+                        { name: 'contact' },
+                        { name: 'tests', defaultValue: [] }
                     ]
                 };
             }
             default: {
                 return {
                     name: type,
-                    mandatory: []
+                    properties: []
                 };
             }
         }

--- a/examples/statemachine/src/language-server/generated/ast.ts
+++ b/examples/statemachine/src/language-server/generated/ast.ts
@@ -123,29 +123,57 @@ export class StatemachineAstReflection extends AbstractAstReflection {
 
     getTypeMetaData(type: string): TypeMetaData {
         switch (type) {
+            case 'Command': {
+                return {
+                    name: 'Command',
+                    properties: [
+                        { name: 'name' }
+                    ]
+                };
+            }
+            case 'Event': {
+                return {
+                    name: 'Event',
+                    properties: [
+                        { name: 'name' }
+                    ]
+                };
+            }
             case 'State': {
                 return {
                     name: 'State',
-                    mandatory: [
-                        { name: 'actions', type: 'array' },
-                        { name: 'transitions', type: 'array' }
+                    properties: [
+                        { name: 'actions', defaultValue: [] },
+                        { name: 'name' },
+                        { name: 'transitions', defaultValue: [] }
                     ]
                 };
             }
             case 'Statemachine': {
                 return {
                     name: 'Statemachine',
-                    mandatory: [
-                        { name: 'commands', type: 'array' },
-                        { name: 'events', type: 'array' },
-                        { name: 'states', type: 'array' }
+                    properties: [
+                        { name: 'commands', defaultValue: [] },
+                        { name: 'events', defaultValue: [] },
+                        { name: 'init' },
+                        { name: 'name' },
+                        { name: 'states', defaultValue: [] }
+                    ]
+                };
+            }
+            case 'Transition': {
+                return {
+                    name: 'Transition',
+                    properties: [
+                        { name: 'event' },
+                        { name: 'state' }
                     ]
                 };
             }
             default: {
                 return {
                     name: type,
-                    mandatory: []
+                    properties: []
                 };
             }
         }

--- a/packages/generator-langium/test/yeoman-generator.test.ts
+++ b/packages/generator-langium/test/yeoman-generator.test.ts
@@ -58,6 +58,7 @@ describe('Check yeoman generator works', () => {
             }).finally(() => {
                 context.cleanTestDirectory(true);
             });
+        context.cleanTestDirectory(true); // clean-up examples/hello-world
     }, 120_000);
 
 });

--- a/packages/langium/src/grammar/generated/grammar.ts
+++ b/packages/langium/src/grammar/generated/grammar.ts
@@ -38,7 +38,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@60"
+                    "$ref": "#/rules@63"
                   },
                   "arguments": []
                 }
@@ -62,7 +62,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                       "terminal": {
                         "$type": "RuleCall",
                         "rule": {
-                          "$ref": "#/rules@60"
+                          "$ref": "#/rules@63"
                         },
                         "arguments": []
                       },
@@ -88,7 +88,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                           "terminal": {
                             "$type": "RuleCall",
                             "rule": {
-                              "$ref": "#/rules@60"
+                              "$ref": "#/rules@63"
                             },
                             "arguments": []
                           },
@@ -127,12 +127,12 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                         "terminal": {
                           "$type": "CrossReference",
                           "type": {
-                            "$ref": "#/rules@11"
+                            "$ref": "#/rules@15"
                           },
                           "terminal": {
                             "$type": "RuleCall",
                             "rule": {
-                              "$ref": "#/rules@60"
+                              "$ref": "#/rules@63"
                             },
                             "arguments": []
                           },
@@ -153,12 +153,12 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                             "terminal": {
                               "$type": "CrossReference",
                               "type": {
-                                "$ref": "#/rules@11"
+                                "$ref": "#/rules@15"
                               },
                               "terminal": {
                                 "$type": "RuleCall",
                                 "rule": {
-                                  "$ref": "#/rules@60"
+                                  "$ref": "#/rules@63"
                                 },
                                 "arguments": []
                               },
@@ -188,7 +188,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@12"
+                "$ref": "#/rules@16"
               },
               "arguments": []
             },
@@ -204,7 +204,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@11"
+                    "$ref": "#/rules@15"
                   },
                   "arguments": []
                 }
@@ -228,7 +228,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@10"
+                    "$ref": "#/rules@14"
                   },
                   "arguments": []
                 }
@@ -261,7 +261,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@60"
+                "$ref": "#/rules@63"
               },
               "arguments": []
             }
@@ -285,7 +285,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                   "terminal": {
                     "$type": "RuleCall",
                     "rule": {
-                      "$ref": "#/rules@60"
+                      "$ref": "#/rules@63"
                     },
                     "arguments": []
                   },
@@ -311,7 +311,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                       "terminal": {
                         "$type": "RuleCall",
                         "rule": {
-                          "$ref": "#/rules@60"
+                          "$ref": "#/rules@63"
                         },
                         "arguments": []
                       },
@@ -325,29 +325,6 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "cardinality": "?"
           },
           {
-            "$type": "RuleCall",
-            "rule": {
-              "$ref": "#/rules@2"
-            },
-            "arguments": []
-          }
-        ]
-      },
-      "definesHiddenTokens": false,
-      "entry": false,
-      "fragment": false,
-      "hiddenTokens": [],
-      "parameters": [],
-      "wildcard": false
-    },
-    {
-      "$type": "ParserRule",
-      "name": "SchemaType",
-      "fragment": true,
-      "definition": {
-        "$type": "Group",
-        "elements": [
-          {
             "$type": "Keyword",
             "value": "{"
           },
@@ -358,7 +335,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@3"
+                "$ref": "#/rules@2"
               },
               "arguments": []
             },
@@ -377,6 +354,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       },
       "definesHiddenTokens": false,
       "entry": false,
+      "fragment": false,
       "hiddenTokens": [],
       "parameters": [],
       "wildcard": false
@@ -394,7 +372,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@59"
+                "$ref": "#/rules@62"
               },
               "arguments": []
             }
@@ -420,10 +398,32 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@4"
+                "$ref": "#/rules@8"
               },
               "arguments": []
             }
+          },
+          {
+            "$type": "Group",
+            "elements": [
+              {
+                "$type": "Keyword",
+                "value": "="
+              },
+              {
+                "$type": "Assignment",
+                "feature": "defaultValue",
+                "operator": "=",
+                "terminal": {
+                  "$type": "RuleCall",
+                  "rule": {
+                    "$ref": "#/rules@3"
+                  },
+                  "arguments": []
+                }
+              }
+            ],
+            "cardinality": "?"
           },
           {
             "$type": "Keyword",
@@ -441,11 +441,189 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
     },
     {
       "$type": "ParserRule",
+      "name": "ValueLiteral",
+      "definition": {
+        "$type": "Alternatives",
+        "elements": [
+          {
+            "$type": "RuleCall",
+            "rule": {
+              "$ref": "#/rules@4"
+            },
+            "arguments": []
+          },
+          {
+            "$type": "RuleCall",
+            "rule": {
+              "$ref": "#/rules@5"
+            },
+            "arguments": []
+          },
+          {
+            "$type": "RuleCall",
+            "rule": {
+              "$ref": "#/rules@6"
+            },
+            "arguments": []
+          },
+          {
+            "$type": "RuleCall",
+            "rule": {
+              "$ref": "#/rules@7"
+            },
+            "arguments": []
+          }
+        ]
+      },
+      "definesHiddenTokens": false,
+      "entry": false,
+      "fragment": false,
+      "hiddenTokens": [],
+      "parameters": [],
+      "wildcard": false
+    },
+    {
+      "$type": "ParserRule",
+      "name": "StringLiteral",
+      "definition": {
+        "$type": "Assignment",
+        "feature": "value",
+        "operator": "=",
+        "terminal": {
+          "$type": "RuleCall",
+          "rule": {
+            "$ref": "#/rules@64"
+          },
+          "arguments": []
+        }
+      },
+      "definesHiddenTokens": false,
+      "entry": false,
+      "fragment": false,
+      "hiddenTokens": [],
+      "parameters": [],
+      "wildcard": false
+    },
+    {
+      "$type": "ParserRule",
+      "name": "NumberLiteral",
+      "definition": {
+        "$type": "Assignment",
+        "feature": "value",
+        "operator": "=",
+        "terminal": {
+          "$type": "RuleCall",
+          "rule": {
+            "$ref": "#/rules@65"
+          },
+          "arguments": []
+        }
+      },
+      "definesHiddenTokens": false,
+      "entry": false,
+      "fragment": false,
+      "hiddenTokens": [],
+      "parameters": [],
+      "wildcard": false
+    },
+    {
+      "$type": "ParserRule",
+      "name": "BooleanLiteral",
+      "definition": {
+        "$type": "Alternatives",
+        "elements": [
+          {
+            "$type": "Assignment",
+            "feature": "true",
+            "operator": "?=",
+            "terminal": {
+              "$type": "Keyword",
+              "value": "true"
+            }
+          },
+          {
+            "$type": "Keyword",
+            "value": "false"
+          }
+        ]
+      },
+      "definesHiddenTokens": false,
+      "entry": false,
+      "fragment": false,
+      "hiddenTokens": [],
+      "parameters": [],
+      "wildcard": false
+    },
+    {
+      "$type": "ParserRule",
+      "name": "ArrayLiteral",
+      "definition": {
+        "$type": "Group",
+        "elements": [
+          {
+            "$type": "Keyword",
+            "value": "["
+          },
+          {
+            "$type": "Group",
+            "elements": [
+              {
+                "$type": "Assignment",
+                "feature": "elements",
+                "operator": "+=",
+                "terminal": {
+                  "$type": "RuleCall",
+                  "rule": {
+                    "$ref": "#/rules@3"
+                  },
+                  "arguments": []
+                }
+              },
+              {
+                "$type": "Group",
+                "elements": [
+                  {
+                    "$type": "Keyword",
+                    "value": ","
+                  },
+                  {
+                    "$type": "Assignment",
+                    "feature": "elements",
+                    "operator": "+=",
+                    "terminal": {
+                      "$type": "RuleCall",
+                      "rule": {
+                        "$ref": "#/rules@3"
+                      },
+                      "arguments": []
+                    }
+                  }
+                ],
+                "cardinality": "*"
+              }
+            ],
+            "cardinality": "?"
+          },
+          {
+            "$type": "Keyword",
+            "value": "]"
+          }
+        ]
+      },
+      "definesHiddenTokens": false,
+      "entry": false,
+      "fragment": false,
+      "hiddenTokens": [],
+      "parameters": [],
+      "wildcard": false
+    },
+    {
+      "$type": "ParserRule",
       "name": "TypeDefinition",
       "definition": {
         "$type": "RuleCall",
         "rule": {
-          "$ref": "#/rules@5"
+          "$ref": "#/rules@9"
         },
         "arguments": []
       },
@@ -469,7 +647,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@6"
+              "$ref": "#/rules@10"
             },
             "arguments": []
           },
@@ -499,7 +677,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$ref": "#/rules@6"
+                        "$ref": "#/rules@10"
                       },
                       "arguments": []
                     }
@@ -532,7 +710,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@7"
+              "$ref": "#/rules@11"
             },
             "arguments": []
           },
@@ -581,7 +759,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@8"
+              "$ref": "#/rules@12"
             },
             "arguments": []
           },
@@ -606,7 +784,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@8"
+                    "$ref": "#/rules@12"
                   },
                   "arguments": []
                 }
@@ -642,7 +820,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
               {
                 "$type": "RuleCall",
                 "rule": {
-                  "$ref": "#/rules@4"
+                  "$ref": "#/rules@8"
                 },
                 "arguments": []
               },
@@ -677,7 +855,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                       "terminal": {
                         "$type": "RuleCall",
                         "rule": {
-                          "$ref": "#/rules@60"
+                          "$ref": "#/rules@63"
                         },
                         "arguments": []
                       },
@@ -691,7 +869,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$ref": "#/rules@9"
+                        "$ref": "#/rules@13"
                       },
                       "arguments": []
                     }
@@ -703,7 +881,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$ref": "#/rules@61"
+                        "$ref": "#/rules@64"
                       },
                       "arguments": []
                     }
@@ -774,7 +952,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@60"
+                "$ref": "#/rules@63"
               },
               "arguments": []
             }
@@ -790,7 +968,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@4"
+                "$ref": "#/rules@8"
               },
               "arguments": []
             }
@@ -818,14 +996,14 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@13"
+              "$ref": "#/rules@17"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@47"
+              "$ref": "#/rules@50"
             },
             "arguments": []
           }
@@ -855,7 +1033,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@61"
+                "$ref": "#/rules@64"
               },
               "arguments": []
             }
@@ -907,7 +1085,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@15"
+              "$ref": "#/rules@19"
             },
             "arguments": []
           },
@@ -945,7 +1123,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                           "terminal": {
                             "$type": "RuleCall",
                             "rule": {
-                              "$ref": "#/rules@60"
+                              "$ref": "#/rules@63"
                             },
                             "arguments": []
                           },
@@ -959,7 +1137,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                         "terminal": {
                           "$type": "RuleCall",
                           "rule": {
-                            "$ref": "#/rules@9"
+                            "$ref": "#/rules@13"
                           },
                           "arguments": []
                         }
@@ -975,13 +1153,13 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@14"
+                    "$ref": "#/rules@18"
                   },
                   "arguments": [
                     {
                       "$type": "NamedArgument",
                       "value": {
-                        "$type": "LiteralCondition",
+                        "$type": "BooleanLiteral",
                         "true": false
                       },
                       "calledByName": false
@@ -1018,12 +1196,12 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                     "terminal": {
                       "$type": "CrossReference",
                       "type": {
-                        "$ref": "#/rules@11"
+                        "$ref": "#/rules@15"
                       },
                       "terminal": {
                         "$type": "RuleCall",
                         "rule": {
-                          "$ref": "#/rules@60"
+                          "$ref": "#/rules@63"
                         },
                         "arguments": []
                       },
@@ -1044,12 +1222,12 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                         "terminal": {
                           "$type": "CrossReference",
                           "type": {
-                            "$ref": "#/rules@11"
+                            "$ref": "#/rules@15"
                           },
                           "terminal": {
                             "$type": "RuleCall",
                             "rule": {
-                              "$ref": "#/rules@60"
+                              "$ref": "#/rules@63"
                             },
                             "arguments": []
                           },
@@ -1080,7 +1258,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@17"
+                "$ref": "#/rules@21"
               },
               "arguments": []
             }
@@ -1118,7 +1296,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "guardCondition": {
                   "$type": "ParameterReference",
                   "parameter": {
-                    "$ref": "#/rules@14/parameters@0"
+                    "$ref": "#/rules@18/parameters@0"
                   }
                 },
                 "elements": [
@@ -1135,7 +1313,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                   "value": {
                     "$type": "ParameterReference",
                     "parameter": {
-                      "$ref": "#/rules@14/parameters@0"
+                      "$ref": "#/rules@18/parameters@0"
                     }
                   }
                 },
@@ -1155,7 +1333,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@60"
+                "$ref": "#/rules@63"
               },
               "arguments": []
             }
@@ -1182,7 +1360,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@60"
+                "$ref": "#/rules@63"
               },
               "arguments": []
             }
@@ -1204,7 +1382,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$ref": "#/rules@16"
+                        "$ref": "#/rules@20"
                       },
                       "arguments": []
                     }
@@ -1223,7 +1401,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                         "terminal": {
                           "$type": "RuleCall",
                           "rule": {
-                            "$ref": "#/rules@16"
+                            "$ref": "#/rules@20"
                           },
                           "arguments": []
                         }
@@ -1259,7 +1437,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
         "terminal": {
           "$type": "RuleCall",
           "rule": {
-            "$ref": "#/rules@60"
+            "$ref": "#/rules@63"
           },
           "arguments": []
         }
@@ -1284,7 +1462,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@18"
+              "$ref": "#/rules@22"
             },
             "arguments": []
           },
@@ -1314,7 +1492,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$ref": "#/rules@18"
+                        "$ref": "#/rules@22"
                       },
                       "arguments": []
                     }
@@ -1347,7 +1525,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@19"
+              "$ref": "#/rules@23"
             },
             "arguments": []
           },
@@ -1372,7 +1550,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@30"
+                    "$ref": "#/rules@33"
                   },
                   "arguments": []
                 }
@@ -1388,7 +1566,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@21"
+                    "$ref": "#/rules@25"
                   },
                   "arguments": []
                 },
@@ -1418,7 +1596,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@20"
+              "$ref": "#/rules@24"
             },
             "arguments": []
           },
@@ -1448,7 +1626,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$ref": "#/rules@20"
+                        "$ref": "#/rules@24"
                       },
                       "arguments": []
                     }
@@ -1481,7 +1659,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@21"
+              "$ref": "#/rules@25"
             },
             "arguments": []
           },
@@ -1504,7 +1682,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@21"
+                    "$ref": "#/rules@25"
                   },
                   "arguments": []
                 },
@@ -1535,14 +1713,14 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@22"
+              "$ref": "#/rules@26"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@23"
+              "$ref": "#/rules@27"
             },
             "arguments": []
           }
@@ -1571,14 +1749,14 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
               {
                 "$type": "RuleCall",
                 "rule": {
-                  "$ref": "#/rules@38"
+                  "$ref": "#/rules@41"
                 },
                 "arguments": []
               },
               {
                 "$type": "RuleCall",
                 "rule": {
-                  "$ref": "#/rules@24"
+                  "$ref": "#/rules@28"
                 },
                 "arguments": []
               }
@@ -1652,7 +1830,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                   "terminal": {
                     "$type": "RuleCall",
                     "rule": {
-                      "$ref": "#/rules@60"
+                      "$ref": "#/rules@63"
                     },
                     "arguments": []
                   },
@@ -1666,13 +1844,13 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@14"
+                    "$ref": "#/rules@18"
                   },
                   "arguments": [
                     {
                       "$type": "NamedArgument",
                       "value": {
-                        "$type": "LiteralCondition",
+                        "$type": "BooleanLiteral",
                         "true": true
                       },
                       "calledByName": false
@@ -1696,7 +1874,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@59"
+                    "$ref": "#/rules@62"
                   },
                   "arguments": []
                 }
@@ -1752,49 +1930,49 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@26"
+              "$ref": "#/rules@30"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@27"
+              "$ref": "#/rules@31"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@44"
+              "$ref": "#/rules@47"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@36"
+              "$ref": "#/rules@39"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@37"
+              "$ref": "#/rules@40"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@45"
+              "$ref": "#/rules@48"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@25"
+              "$ref": "#/rules@29"
             },
             "arguments": []
           }
@@ -1843,7 +2021,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
         "terminal": {
           "$type": "RuleCall",
           "rule": {
-            "$ref": "#/rules@61"
+            "$ref": "#/rules@64"
           },
           "arguments": []
         }
@@ -1868,12 +2046,12 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "CrossReference",
               "type": {
-                "$ref": "#/rules@11"
+                "$ref": "#/rules@15"
               },
               "terminal": {
                 "$type": "RuleCall",
                 "rule": {
-                  "$ref": "#/rules@60"
+                  "$ref": "#/rules@63"
                 },
                 "arguments": []
               },
@@ -1894,7 +2072,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@28"
+                    "$ref": "#/rules@32"
                   },
                   "arguments": []
                 }
@@ -1913,7 +2091,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$ref": "#/rules@28"
+                        "$ref": "#/rules@32"
                       },
                       "arguments": []
                     }
@@ -1953,12 +2131,12 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "CrossReference",
                   "type": {
-                    "$ref": "#/rules@16"
+                    "$ref": "#/rules@20"
                   },
                   "terminal": {
                     "$type": "RuleCall",
                     "rule": {
-                      "$ref": "#/rules@60"
+                      "$ref": "#/rules@63"
                     },
                     "arguments": []
                   },
@@ -1984,38 +2162,10 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@30"
+                "$ref": "#/rules@33"
               },
               "arguments": []
             }
-          }
-        ]
-      },
-      "definesHiddenTokens": false,
-      "entry": false,
-      "fragment": false,
-      "hiddenTokens": [],
-      "parameters": [],
-      "wildcard": false
-    },
-    {
-      "$type": "ParserRule",
-      "name": "LiteralCondition",
-      "definition": {
-        "$type": "Alternatives",
-        "elements": [
-          {
-            "$type": "Assignment",
-            "feature": "true",
-            "operator": "?=",
-            "terminal": {
-              "$type": "Keyword",
-              "value": "true"
-            }
-          },
-          {
-            "$type": "Keyword",
-            "value": "false"
           }
         ]
       },
@@ -2039,7 +2189,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@31"
+              "$ref": "#/rules@34"
             },
             "arguments": []
           },
@@ -2066,7 +2216,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@31"
+                    "$ref": "#/rules@34"
                   },
                   "arguments": []
                 }
@@ -2096,7 +2246,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@32"
+              "$ref": "#/rules@35"
             },
             "arguments": []
           },
@@ -2123,7 +2273,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@32"
+                    "$ref": "#/rules@35"
                   },
                   "arguments": []
                 }
@@ -2153,7 +2303,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@33"
+              "$ref": "#/rules@36"
             },
             "arguments": []
           },
@@ -2178,7 +2328,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@32"
+                    "$ref": "#/rules@35"
                   },
                   "arguments": []
                 }
@@ -2207,21 +2357,21 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@35"
+              "$ref": "#/rules@38"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@34"
+              "$ref": "#/rules@37"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@29"
+              "$ref": "#/rules@6"
             },
             "arguments": []
           }
@@ -2251,7 +2401,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@30"
+              "$ref": "#/rules@33"
             },
             "arguments": []
           },
@@ -2278,12 +2428,12 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
         "terminal": {
           "$type": "CrossReference",
           "type": {
-            "$ref": "#/rules@16"
+            "$ref": "#/rules@20"
           },
           "terminal": {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@60"
+              "$ref": "#/rules@63"
             },
             "arguments": []
           },
@@ -2327,7 +2477,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@61"
+                "$ref": "#/rules@64"
               },
               "arguments": []
             }
@@ -2371,12 +2521,12 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "CrossReference",
               "type": {
-                "$ref": "#/rules@11"
+                "$ref": "#/rules@15"
               },
               "terminal": {
                 "$type": "RuleCall",
                 "rule": {
-                  "$ref": "#/rules@60"
+                  "$ref": "#/rules@63"
                 },
                 "arguments": []
               },
@@ -2397,7 +2547,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@28"
+                    "$ref": "#/rules@32"
                   },
                   "arguments": []
                 }
@@ -2416,7 +2566,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$ref": "#/rules@28"
+                        "$ref": "#/rules@32"
                       },
                       "arguments": []
                     }
@@ -2478,7 +2628,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@59"
+                "$ref": "#/rules@62"
               },
               "arguments": []
             }
@@ -2512,7 +2662,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@39"
+                "$ref": "#/rules@42"
               },
               "arguments": []
             }
@@ -2539,28 +2689,28 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@26"
+              "$ref": "#/rules@30"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@27"
+              "$ref": "#/rules@31"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@40"
+              "$ref": "#/rules@43"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@42"
+              "$ref": "#/rules@45"
             },
             "arguments": []
           }
@@ -2590,7 +2740,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@41"
+              "$ref": "#/rules@44"
             },
             "arguments": []
           },
@@ -2620,7 +2770,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@39"
+              "$ref": "#/rules@42"
             },
             "arguments": []
           },
@@ -2650,7 +2800,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$ref": "#/rules@39"
+                        "$ref": "#/rules@42"
                       },
                       "arguments": []
                     }
@@ -2731,7 +2881,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@43"
+                    "$ref": "#/rules@46"
                   },
                   "arguments": []
                 }
@@ -2765,14 +2915,14 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@26"
+              "$ref": "#/rules@30"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@27"
+              "$ref": "#/rules@31"
             },
             "arguments": []
           }
@@ -2802,7 +2952,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@17"
+              "$ref": "#/rules@21"
             },
             "arguments": []
           },
@@ -2853,7 +3003,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@17"
+                "$ref": "#/rules@21"
               },
               "arguments": []
             }
@@ -2884,14 +3034,14 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@9"
+                "$ref": "#/rules@13"
               },
               "arguments": []
             },
             {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@60"
+                "$ref": "#/rules@63"
               },
               "arguments": []
             }
@@ -2947,7 +3097,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$ref": "#/rules@60"
+                        "$ref": "#/rules@63"
                       },
                       "arguments": []
                     }
@@ -2964,7 +3114,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$ref": "#/rules@60"
+                        "$ref": "#/rules@63"
                       },
                       "arguments": []
                     }
@@ -2983,7 +3133,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                         "terminal": {
                           "$type": "RuleCall",
                           "rule": {
-                            "$ref": "#/rules@46"
+                            "$ref": "#/rules@49"
                           },
                           "arguments": []
                         }
@@ -3006,7 +3156,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@48"
+                "$ref": "#/rules@51"
               },
               "arguments": []
             }
@@ -3037,7 +3187,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@49"
+              "$ref": "#/rules@52"
             },
             "arguments": []
           },
@@ -3064,7 +3214,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@49"
+                    "$ref": "#/rules@52"
                   },
                   "arguments": []
                 }
@@ -3094,7 +3244,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@50"
+              "$ref": "#/rules@53"
             },
             "arguments": []
           },
@@ -3117,7 +3267,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@50"
+                    "$ref": "#/rules@53"
                   },
                   "arguments": []
                 },
@@ -3148,7 +3298,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@51"
+              "$ref": "#/rules@54"
             },
             "arguments": []
           },
@@ -3197,35 +3347,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@58"
-            },
-            "arguments": []
-          },
-          {
-            "$type": "RuleCall",
-            "rule": {
-              "$ref": "#/rules@53"
-            },
-            "arguments": []
-          },
-          {
-            "$type": "RuleCall",
-            "rule": {
-              "$ref": "#/rules@52"
-            },
-            "arguments": []
-          },
-          {
-            "$type": "RuleCall",
-            "rule": {
-              "$ref": "#/rules@54"
-            },
-            "arguments": []
-          },
-          {
-            "$type": "RuleCall",
-            "rule": {
-              "$ref": "#/rules@55"
+              "$ref": "#/rules@61"
             },
             "arguments": []
           },
@@ -3239,7 +3361,35 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
+              "$ref": "#/rules@55"
+            },
+            "arguments": []
+          },
+          {
+            "$type": "RuleCall",
+            "rule": {
               "$ref": "#/rules@57"
+            },
+            "arguments": []
+          },
+          {
+            "$type": "RuleCall",
+            "rule": {
+              "$ref": "#/rules@58"
+            },
+            "arguments": []
+          },
+          {
+            "$type": "RuleCall",
+            "rule": {
+              "$ref": "#/rules@59"
+            },
+            "arguments": []
+          },
+          {
+            "$type": "RuleCall",
+            "rule": {
+              "$ref": "#/rules@60"
             },
             "arguments": []
           }
@@ -3288,7 +3438,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@48"
+              "$ref": "#/rules@51"
             },
             "arguments": []
           },
@@ -3329,12 +3479,12 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "CrossReference",
               "type": {
-                "$ref": "#/rules@47"
+                "$ref": "#/rules@50"
               },
               "terminal": {
                 "$type": "RuleCall",
                 "rule": {
-                  "$ref": "#/rules@60"
+                  "$ref": "#/rules@63"
                 },
                 "arguments": []
               },
@@ -3378,7 +3528,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@51"
+                "$ref": "#/rules@54"
               },
               "arguments": []
             }
@@ -3420,7 +3570,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@51"
+                "$ref": "#/rules@54"
               },
               "arguments": []
             }
@@ -3458,7 +3608,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@62"
+                "$ref": "#/rules@66"
               },
               "arguments": []
             }
@@ -3526,7 +3676,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@26"
+                "$ref": "#/rules@30"
               },
               "arguments": []
             }
@@ -3545,7 +3695,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@26"
+                    "$ref": "#/rules@30"
                   },
                   "arguments": []
                 }
@@ -3636,14 +3786,14 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@9"
+              "$ref": "#/rules@13"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@60"
+              "$ref": "#/rules@63"
             },
             "arguments": []
           }
@@ -3672,6 +3822,20 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       "definition": {
         "$type": "RegexToken",
         "regex": "/\\"(\\\\\\\\.|[^\\"\\\\\\\\])*\\"|'(\\\\\\\\.|[^'\\\\\\\\])*'/"
+      },
+      "fragment": false,
+      "hidden": false
+    },
+    {
+      "$type": "TerminalRule",
+      "name": "NUMBER",
+      "type": {
+        "$type": "ReturnType",
+        "name": "number"
+      },
+      "definition": {
+        "$type": "RegexToken",
+        "regex": "/NaN|-?((\\\\d*\\\\.\\\\d+|\\\\d+)([Ee][+-]?\\\\d+)?|Infinity)/"
       },
       "fragment": false,
       "hidden": false
@@ -3737,19 +3901,19 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "SimpleType",
             "typeRef": {
-              "$ref": "#/rules@10"
+              "$ref": "#/rules@14"
             }
           },
           {
             "$type": "SimpleType",
             "typeRef": {
-              "$ref": "#/rules@23/definition/elements@0"
+              "$ref": "#/rules@27/definition/elements@0"
             }
           },
           {
             "$type": "SimpleType",
             "typeRef": {
-              "$ref": "#/rules@13"
+              "$ref": "#/rules@17"
             }
           }
         ]

--- a/packages/langium/src/grammar/langium-grammar.langium
+++ b/packages/langium/src/grammar/langium-grammar.langium
@@ -16,13 +16,25 @@ entry Grammar:
 Interface:
     'interface' name=ID
     ('extends' superTypes+=[AbstractType:ID] (',' superTypes+=[AbstractType:ID])*)?
-    SchemaType;
-
-fragment SchemaType:
-    '{' attributes+=TypeAttribute* '}' ';'?;
+    '{' 
+        attributes+=TypeAttribute* 
+    '}'
+';'?;
 
 TypeAttribute:
-    name=FeatureName (isOptional?='?')? ':' type=TypeDefinition ';'?;
+    name=FeatureName (isOptional?='?')? ':' type=TypeDefinition ('=' defaultValue=ValueLiteral)? ';'?;
+
+ValueLiteral:
+    StringLiteral | NumberLiteral | BooleanLiteral | ArrayLiteral;
+
+StringLiteral:
+    value=STRING;
+NumberLiteral:
+    value=NUMBER;
+BooleanLiteral:
+    true?='true' | 'false';
+ArrayLiteral:
+    '[' (elements+=ValueLiteral (',' elements+=ValueLiteral)*)? ']';
 
 TypeDefinition: UnionType;
 
@@ -116,9 +128,6 @@ NamedArgument:
     ( parameter=[Parameter:ID] calledByName?='=')?
     ( value=Disjunction );
 
-LiteralCondition:
-    true?='true' | 'false';
-
 Disjunction infers Condition:
     Conjunction ({infer Disjunction.left=current} '|' right=Conjunction)*;
 
@@ -129,7 +138,7 @@ Negation infers Condition:
     Atom | {infer Negation} '!' value=Negation;
 
 Atom infers Condition:
-    ParameterReference | ParenthesizedCondition | LiteralCondition;
+    ParameterReference | ParenthesizedCondition | BooleanLiteral;
 
 ParenthesizedCondition infers Condition:
     '(' Disjunction ')';
@@ -213,6 +222,7 @@ FeatureName returns string:
 
 terminal ID: /\^?[_a-zA-Z][\w_]*/;
 terminal STRING: /"(\\.|[^"\\])*"|'(\\.|[^'\\])*'/;
+terminal NUMBER returns number: /NaN|-?((\d*\.\d+|\d+)([Ee][+-]?\d+)?|Infinity)/;
 terminal RegexLiteral returns string: /\/(?![*+?])(?:[^\r\n\[/\\]|\\.|\[(?:[^\r\n\]\\]|\\.)*\])+\/[a-z]*/;
 
 hidden terminal WS: /\s+/;

--- a/packages/langium/src/grammar/type-system/type-collector/types.ts
+++ b/packages/langium/src/grammar/type-system/type-collector/types.ts
@@ -10,11 +10,14 @@ import type { Action, Assignment, TypeAttribute } from '../../../languages/gener
 import { distinctAndSorted } from '../types-util.js';
 
 export interface Property {
-    name: string,
-    optional: boolean,
-    type: PropertyType,
-    astNodes: Set<Assignment | Action | TypeAttribute>,
+    name: string;
+    optional: boolean;
+    type: PropertyType;
+    defaultValue?: PropertyDefaultValue;
+    astNodes: Set<Assignment | Action | TypeAttribute>;
 }
+
+export type PropertyDefaultValue = string | number | boolean | PropertyDefaultValue[];
 
 export type PropertyType =
     | ReferenceType
@@ -33,7 +36,7 @@ export function isReferenceType(propertyType: PropertyType): propertyType is Ref
 }
 
 export interface ArrayType {
-    elementType: PropertyType
+    elementType: PropertyType | undefined
 }
 
 export function isArrayType(propertyType: PropertyType): propertyType is ArrayType {
@@ -272,7 +275,12 @@ export function isTypeAssignable(from: PropertyType, to: PropertyType): boolean 
     return isTypeAssignableInternal(from, to, new Map());
 }
 
-function isTypeAssignableInternal(from: PropertyType, to: PropertyType, visited: Map<string, boolean>): boolean {
+function isTypeAssignableInternal(from: PropertyType | undefined, to: PropertyType | undefined, visited: Map<string, boolean>): boolean {
+    if (!from) {
+        return true;
+    } else if (!to) {
+        return false;
+    }
     const key = `${propertyTypeToKeyString(from)}»${propertyTypeToKeyString(to)}`;
     let result = visited.get(key);
     if (result !== undefined) {
@@ -337,7 +345,7 @@ function propertyTypeToKeyString(type: PropertyType): string {
     if (isReferenceType(type)) {
         return `@(${propertyTypeToKeyString(type.referenceType)})}`;
     } else if (isArrayType(type)) {
-        return `(${propertyTypeToKeyString(type.elementType)})[]`;
+        return type.elementType ? `(${propertyTypeToKeyString(type.elementType)})[]` : 'unknown[]';
     } else if (isPropertyUnion(type)) {
         const union = type.types.map(e => propertyTypeToKeyString(e)).join(' | ');
         if (type.types.length <= 1) {
@@ -354,13 +362,16 @@ function propertyTypeToKeyString(type: PropertyType): string {
     throw new Error('Invalid type');
 }
 
-export function propertyTypeToString(type: PropertyType, mode: 'AstType' | 'DeclaredType' = 'AstType'): string {
+export function propertyTypeToString(type?: PropertyType, mode: 'AstType' | 'DeclaredType' = 'AstType'): string {
+    if (!type) {
+        return 'unknown';
+    }
     if (isReferenceType(type)) {
         const refType = propertyTypeToString(type.referenceType, mode);
         return mode === 'AstType' ? `Reference<${refType}>` : `@${typeParenthesis(type.referenceType, refType)}`;
     } else if (isArrayType(type)) {
         const arrayType = propertyTypeToString(type.elementType, mode);
-        return mode === 'AstType' ? `Array<${arrayType}>` : `${typeParenthesis(type.elementType, arrayType)}[]`;
+        return mode === 'AstType' ? `Array<${arrayType}>` : `${type.elementType ? typeParenthesis(type.elementType, arrayType) : 'unknown'}[]`;
     } else if (isPropertyUnion(type)) {
         const types = type.types.map(e => typeParenthesis(e, propertyTypeToString(e, mode)));
         return distinctAndSorted(types).join(' | ');

--- a/packages/langium/src/grammar/type-system/types-util.ts
+++ b/packages/langium/src/grammar/type-system/types-util.ts
@@ -197,7 +197,7 @@ export function findReferenceTypes(type: PropertyType): string[] {
             return [refType.value.name];
         }
     } else if (isArrayType(type)) {
-        return findReferenceTypes(type.elementType);
+        return type.elementType ? findReferenceTypes(type.elementType) : [];
     }
     return [];
 }
@@ -222,7 +222,7 @@ export function findAstTypesInternal(type: PropertyType, visited: Set<PropertyTy
             return [value.name];
         }
     } else if (isArrayType(type)) {
-        return findAstTypesInternal(type.elementType, visited);
+        return type.elementType ? findAstTypesInternal(type.elementType, visited) : [];
     }
     return [];
 }

--- a/packages/langium/src/languages/generated/ast.ts
+++ b/packages/langium/src/languages/generated/ast.ts
@@ -10,6 +10,7 @@ import { AbstractAstReflection } from '../../syntax-tree.js';
 export const LangiumGrammarTerminals = {
     ID: /\^?[_a-zA-Z][\w_]*/,
     STRING: /"(\\.|[^"\\])*"|'(\\.|[^'\\])*'/,
+    NUMBER: /NaN|-?((\d*\.\d+|\d+)([Ee][+-]?\d+)?|Infinity)/,
     RegexLiteral: /\/(?![*+?])(?:[^\r\n\[/\\]|\\.|\[(?:[^\r\n\]\\]|\\.)*\])+\/[a-z]*/,
     WS: /\s+/,
     ML_COMMENT: /\/\*[\s\S]*?\*\//,
@@ -32,7 +33,7 @@ export function isAbstractType(item: unknown): item is AbstractType {
     return reflection.isInstance(item, AbstractType);
 }
 
-export type Condition = Conjunction | Disjunction | LiteralCondition | Negation | ParameterReference;
+export type Condition = BooleanLiteral | Conjunction | Disjunction | Negation | ParameterReference;
 
 export const Condition = 'Condition';
 
@@ -60,6 +61,14 @@ export function isTypeDefinition(item: unknown): item is TypeDefinition {
     return reflection.isInstance(item, TypeDefinition);
 }
 
+export type ValueLiteral = ArrayLiteral | BooleanLiteral | NumberLiteral | StringLiteral;
+
+export const ValueLiteral = 'ValueLiteral';
+
+export function isValueLiteral(item: unknown): item is ValueLiteral {
+    return reflection.isInstance(item, ValueLiteral);
+}
+
 export interface AbstractElement extends AstNode {
     readonly $type: 'AbstractElement' | 'Action' | 'Alternatives' | 'Assignment' | 'CharacterRange' | 'CrossReference' | 'EndOfFile' | 'Group' | 'Keyword' | 'NegatedToken' | 'RegexToken' | 'RuleCall' | 'TerminalAlternatives' | 'TerminalGroup' | 'TerminalRuleCall' | 'UnorderedGroup' | 'UntilToken' | 'Wildcard';
     cardinality?: '*' | '+' | '?'
@@ -72,6 +81,18 @@ export function isAbstractElement(item: unknown): item is AbstractElement {
     return reflection.isInstance(item, AbstractElement);
 }
 
+export interface ArrayLiteral extends AstNode {
+    readonly $container: ArrayLiteral | TypeAttribute;
+    readonly $type: 'ArrayLiteral';
+    elements: Array<ValueLiteral>
+}
+
+export const ArrayLiteral = 'ArrayLiteral';
+
+export function isArrayLiteral(item: unknown): item is ArrayLiteral {
+    return reflection.isInstance(item, ArrayLiteral);
+}
+
 export interface ArrayType extends AstNode {
     readonly $container: ArrayType | ReferenceType | Type | TypeAttribute | UnionType;
     readonly $type: 'ArrayType';
@@ -82,6 +103,18 @@ export const ArrayType = 'ArrayType';
 
 export function isArrayType(item: unknown): item is ArrayType {
     return reflection.isInstance(item, ArrayType);
+}
+
+export interface BooleanLiteral extends AstNode {
+    readonly $container: ArrayLiteral | Conjunction | Disjunction | Group | NamedArgument | Negation | TypeAttribute;
+    readonly $type: 'BooleanLiteral';
+    true: boolean
+}
+
+export const BooleanLiteral = 'BooleanLiteral';
+
+export function isBooleanLiteral(item: unknown): item is BooleanLiteral {
+    return reflection.isInstance(item, BooleanLiteral);
 }
 
 export interface Conjunction extends AstNode {
@@ -167,18 +200,6 @@ export function isInterface(item: unknown): item is Interface {
     return reflection.isInstance(item, Interface);
 }
 
-export interface LiteralCondition extends AstNode {
-    readonly $container: Conjunction | Disjunction | Group | NamedArgument | Negation;
-    readonly $type: 'LiteralCondition';
-    true: boolean
-}
-
-export const LiteralCondition = 'LiteralCondition';
-
-export function isLiteralCondition(item: unknown): item is LiteralCondition {
-    return reflection.isInstance(item, LiteralCondition);
-}
-
 export interface NamedArgument extends AstNode {
     readonly $container: RuleCall;
     readonly $type: 'NamedArgument';
@@ -203,6 +224,18 @@ export const Negation = 'Negation';
 
 export function isNegation(item: unknown): item is Negation {
     return reflection.isInstance(item, Negation);
+}
+
+export interface NumberLiteral extends AstNode {
+    readonly $container: ArrayLiteral | TypeAttribute;
+    readonly $type: 'NumberLiteral';
+    value: number
+}
+
+export const NumberLiteral = 'NumberLiteral';
+
+export function isNumberLiteral(item: unknown): item is NumberLiteral {
+    return reflection.isInstance(item, NumberLiteral);
 }
 
 export interface Parameter extends AstNode {
@@ -289,6 +322,18 @@ export function isSimpleType(item: unknown): item is SimpleType {
     return reflection.isInstance(item, SimpleType);
 }
 
+export interface StringLiteral extends AstNode {
+    readonly $container: ArrayLiteral | TypeAttribute;
+    readonly $type: 'StringLiteral';
+    value: string
+}
+
+export const StringLiteral = 'StringLiteral';
+
+export function isStringLiteral(item: unknown): item is StringLiteral {
+    return reflection.isInstance(item, StringLiteral);
+}
+
 export interface TerminalRule extends AstNode {
     readonly $container: Grammar;
     readonly $type: 'TerminalRule';
@@ -321,6 +366,7 @@ export function isType(item: unknown): item is Type {
 export interface TypeAttribute extends AstNode {
     readonly $container: Interface;
     readonly $type: 'TypeAttribute';
+    defaultValue?: ValueLiteral
     isOptional: boolean
     name: FeatureName
     type: TypeDefinition
@@ -546,8 +592,10 @@ export type LangiumGrammarAstType = {
     AbstractType: AbstractType
     Action: Action
     Alternatives: Alternatives
+    ArrayLiteral: ArrayLiteral
     ArrayType: ArrayType
     Assignment: Assignment
+    BooleanLiteral: BooleanLiteral
     CharacterRange: CharacterRange
     Condition: Condition
     Conjunction: Conjunction
@@ -560,10 +608,10 @@ export type LangiumGrammarAstType = {
     InferredType: InferredType
     Interface: Interface
     Keyword: Keyword
-    LiteralCondition: LiteralCondition
     NamedArgument: NamedArgument
     NegatedToken: NegatedToken
     Negation: Negation
+    NumberLiteral: NumberLiteral
     Parameter: Parameter
     ParameterReference: ParameterReference
     ParserRule: ParserRule
@@ -572,6 +620,7 @@ export type LangiumGrammarAstType = {
     ReturnType: ReturnType
     RuleCall: RuleCall
     SimpleType: SimpleType
+    StringLiteral: StringLiteral
     TerminalAlternatives: TerminalAlternatives
     TerminalGroup: TerminalGroup
     TerminalRule: TerminalRule
@@ -582,13 +631,14 @@ export type LangiumGrammarAstType = {
     UnionType: UnionType
     UnorderedGroup: UnorderedGroup
     UntilToken: UntilToken
+    ValueLiteral: ValueLiteral
     Wildcard: Wildcard
 }
 
 export class LangiumGrammarAstReflection extends AbstractAstReflection {
 
     getAllTypes(): string[] {
-        return ['AbstractElement', 'AbstractRule', 'AbstractType', 'Action', 'Alternatives', 'ArrayType', 'Assignment', 'CharacterRange', 'Condition', 'Conjunction', 'CrossReference', 'Disjunction', 'EndOfFile', 'Grammar', 'GrammarImport', 'Group', 'InferredType', 'Interface', 'Keyword', 'LiteralCondition', 'NamedArgument', 'NegatedToken', 'Negation', 'Parameter', 'ParameterReference', 'ParserRule', 'ReferenceType', 'RegexToken', 'ReturnType', 'RuleCall', 'SimpleType', 'TerminalAlternatives', 'TerminalGroup', 'TerminalRule', 'TerminalRuleCall', 'Type', 'TypeAttribute', 'TypeDefinition', 'UnionType', 'UnorderedGroup', 'UntilToken', 'Wildcard'];
+        return ['AbstractElement', 'AbstractRule', 'AbstractType', 'Action', 'Alternatives', 'ArrayLiteral', 'ArrayType', 'Assignment', 'BooleanLiteral', 'CharacterRange', 'Condition', 'Conjunction', 'CrossReference', 'Disjunction', 'EndOfFile', 'Grammar', 'GrammarImport', 'Group', 'InferredType', 'Interface', 'Keyword', 'NamedArgument', 'NegatedToken', 'Negation', 'NumberLiteral', 'Parameter', 'ParameterReference', 'ParserRule', 'ReferenceType', 'RegexToken', 'ReturnType', 'RuleCall', 'SimpleType', 'StringLiteral', 'TerminalAlternatives', 'TerminalGroup', 'TerminalRule', 'TerminalRuleCall', 'Type', 'TypeAttribute', 'TypeDefinition', 'UnionType', 'UnorderedGroup', 'UntilToken', 'ValueLiteral', 'Wildcard'];
     }
 
     protected override computeIsSubtype(subtype: string, supertype: string): boolean {
@@ -614,15 +664,22 @@ export class LangiumGrammarAstReflection extends AbstractAstReflection {
             case Wildcard: {
                 return this.isSubtype(AbstractElement, supertype);
             }
+            case ArrayLiteral:
+            case NumberLiteral:
+            case StringLiteral: {
+                return this.isSubtype(ValueLiteral, supertype);
+            }
             case ArrayType:
             case ReferenceType:
             case SimpleType:
             case UnionType: {
                 return this.isSubtype(TypeDefinition, supertype);
             }
+            case BooleanLiteral: {
+                return this.isSubtype(Condition, supertype) || this.isSubtype(ValueLiteral, supertype);
+            }
             case Conjunction:
             case Disjunction:
-            case LiteralCondition:
             case Negation:
             case ParameterReference: {
                 return this.isSubtype(Condition, supertype);
@@ -676,144 +733,367 @@ export class LangiumGrammarAstReflection extends AbstractAstReflection {
 
     getTypeMetaData(type: string): TypeMetaData {
         switch (type) {
+            case 'AbstractElement': {
+                return {
+                    name: 'AbstractElement',
+                    properties: [
+                        { name: 'cardinality' },
+                        { name: 'lookahead' }
+                    ]
+                };
+            }
+            case 'ArrayLiteral': {
+                return {
+                    name: 'ArrayLiteral',
+                    properties: [
+                        { name: 'elements', defaultValue: [] }
+                    ]
+                };
+            }
+            case 'ArrayType': {
+                return {
+                    name: 'ArrayType',
+                    properties: [
+                        { name: 'elementType' }
+                    ]
+                };
+            }
+            case 'BooleanLiteral': {
+                return {
+                    name: 'BooleanLiteral',
+                    properties: [
+                        { name: 'true', defaultValue: false }
+                    ]
+                };
+            }
+            case 'Conjunction': {
+                return {
+                    name: 'Conjunction',
+                    properties: [
+                        { name: 'left' },
+                        { name: 'right' }
+                    ]
+                };
+            }
+            case 'Disjunction': {
+                return {
+                    name: 'Disjunction',
+                    properties: [
+                        { name: 'left' },
+                        { name: 'right' }
+                    ]
+                };
+            }
             case 'Grammar': {
                 return {
                     name: 'Grammar',
-                    mandatory: [
-                        { name: 'definesHiddenTokens', type: 'boolean' },
-                        { name: 'hiddenTokens', type: 'array' },
-                        { name: 'imports', type: 'array' },
-                        { name: 'interfaces', type: 'array' },
-                        { name: 'isDeclared', type: 'boolean' },
-                        { name: 'rules', type: 'array' },
-                        { name: 'types', type: 'array' },
-                        { name: 'usedGrammars', type: 'array' }
+                    properties: [
+                        { name: 'definesHiddenTokens', defaultValue: false },
+                        { name: 'hiddenTokens', defaultValue: [] },
+                        { name: 'imports', defaultValue: [] },
+                        { name: 'interfaces', defaultValue: [] },
+                        { name: 'isDeclared', defaultValue: false },
+                        { name: 'name' },
+                        { name: 'rules', defaultValue: [] },
+                        { name: 'types', defaultValue: [] },
+                        { name: 'usedGrammars', defaultValue: [] }
+                    ]
+                };
+            }
+            case 'GrammarImport': {
+                return {
+                    name: 'GrammarImport',
+                    properties: [
+                        { name: 'path' }
+                    ]
+                };
+            }
+            case 'InferredType': {
+                return {
+                    name: 'InferredType',
+                    properties: [
+                        { name: 'name' }
                     ]
                 };
             }
             case 'Interface': {
                 return {
                     name: 'Interface',
-                    mandatory: [
-                        { name: 'attributes', type: 'array' },
-                        { name: 'superTypes', type: 'array' }
-                    ]
-                };
-            }
-            case 'LiteralCondition': {
-                return {
-                    name: 'LiteralCondition',
-                    mandatory: [
-                        { name: 'true', type: 'boolean' }
+                    properties: [
+                        { name: 'attributes', defaultValue: [] },
+                        { name: 'name' },
+                        { name: 'superTypes', defaultValue: [] }
                     ]
                 };
             }
             case 'NamedArgument': {
                 return {
                     name: 'NamedArgument',
-                    mandatory: [
-                        { name: 'calledByName', type: 'boolean' }
+                    properties: [
+                        { name: 'calledByName', defaultValue: false },
+                        { name: 'parameter' },
+                        { name: 'value' }
+                    ]
+                };
+            }
+            case 'Negation': {
+                return {
+                    name: 'Negation',
+                    properties: [
+                        { name: 'value' }
+                    ]
+                };
+            }
+            case 'NumberLiteral': {
+                return {
+                    name: 'NumberLiteral',
+                    properties: [
+                        { name: 'value' }
+                    ]
+                };
+            }
+            case 'Parameter': {
+                return {
+                    name: 'Parameter',
+                    properties: [
+                        { name: 'name' }
+                    ]
+                };
+            }
+            case 'ParameterReference': {
+                return {
+                    name: 'ParameterReference',
+                    properties: [
+                        { name: 'parameter' }
                     ]
                 };
             }
             case 'ParserRule': {
                 return {
                     name: 'ParserRule',
-                    mandatory: [
-                        { name: 'definesHiddenTokens', type: 'boolean' },
-                        { name: 'entry', type: 'boolean' },
-                        { name: 'fragment', type: 'boolean' },
-                        { name: 'hiddenTokens', type: 'array' },
-                        { name: 'parameters', type: 'array' },
-                        { name: 'wildcard', type: 'boolean' }
+                    properties: [
+                        { name: 'dataType' },
+                        { name: 'definesHiddenTokens', defaultValue: false },
+                        { name: 'definition' },
+                        { name: 'entry', defaultValue: false },
+                        { name: 'fragment', defaultValue: false },
+                        { name: 'hiddenTokens', defaultValue: [] },
+                        { name: 'inferredType' },
+                        { name: 'name' },
+                        { name: 'parameters', defaultValue: [] },
+                        { name: 'returnType' },
+                        { name: 'wildcard', defaultValue: false }
+                    ]
+                };
+            }
+            case 'ReferenceType': {
+                return {
+                    name: 'ReferenceType',
+                    properties: [
+                        { name: 'referenceType' }
+                    ]
+                };
+            }
+            case 'ReturnType': {
+                return {
+                    name: 'ReturnType',
+                    properties: [
+                        { name: 'name' }
+                    ]
+                };
+            }
+            case 'SimpleType': {
+                return {
+                    name: 'SimpleType',
+                    properties: [
+                        { name: 'primitiveType' },
+                        { name: 'stringType' },
+                        { name: 'typeRef' }
+                    ]
+                };
+            }
+            case 'StringLiteral': {
+                return {
+                    name: 'StringLiteral',
+                    properties: [
+                        { name: 'value' }
                     ]
                 };
             }
             case 'TerminalRule': {
                 return {
                     name: 'TerminalRule',
-                    mandatory: [
-                        { name: 'fragment', type: 'boolean' },
-                        { name: 'hidden', type: 'boolean' }
+                    properties: [
+                        { name: 'definition' },
+                        { name: 'fragment', defaultValue: false },
+                        { name: 'hidden', defaultValue: false },
+                        { name: 'name' },
+                        { name: 'type' }
+                    ]
+                };
+            }
+            case 'Type': {
+                return {
+                    name: 'Type',
+                    properties: [
+                        { name: 'name' },
+                        { name: 'type' }
                     ]
                 };
             }
             case 'TypeAttribute': {
                 return {
                     name: 'TypeAttribute',
-                    mandatory: [
-                        { name: 'isOptional', type: 'boolean' }
+                    properties: [
+                        { name: 'defaultValue' },
+                        { name: 'isOptional', defaultValue: false },
+                        { name: 'name' },
+                        { name: 'type' }
                     ]
                 };
             }
             case 'UnionType': {
                 return {
                     name: 'UnionType',
-                    mandatory: [
-                        { name: 'types', type: 'array' }
+                    properties: [
+                        { name: 'types', defaultValue: [] }
+                    ]
+                };
+            }
+            case 'Action': {
+                return {
+                    name: 'Action',
+                    properties: [
+                        { name: 'feature' },
+                        { name: 'inferredType' },
+                        { name: 'operator' },
+                        { name: 'type' }
                     ]
                 };
             }
             case 'Alternatives': {
                 return {
                     name: 'Alternatives',
-                    mandatory: [
-                        { name: 'elements', type: 'array' }
+                    properties: [
+                        { name: 'elements', defaultValue: [] }
+                    ]
+                };
+            }
+            case 'Assignment': {
+                return {
+                    name: 'Assignment',
+                    properties: [
+                        { name: 'feature' },
+                        { name: 'operator' },
+                        { name: 'terminal' }
+                    ]
+                };
+            }
+            case 'CharacterRange': {
+                return {
+                    name: 'CharacterRange',
+                    properties: [
+                        { name: 'left' },
+                        { name: 'right' }
                     ]
                 };
             }
             case 'CrossReference': {
                 return {
                     name: 'CrossReference',
-                    mandatory: [
-                        { name: 'deprecatedSyntax', type: 'boolean' }
+                    properties: [
+                        { name: 'deprecatedSyntax', defaultValue: false },
+                        { name: 'terminal' },
+                        { name: 'type' }
                     ]
                 };
             }
             case 'Group': {
                 return {
                     name: 'Group',
-                    mandatory: [
-                        { name: 'elements', type: 'array' }
+                    properties: [
+                        { name: 'elements', defaultValue: [] },
+                        { name: 'guardCondition' }
+                    ]
+                };
+            }
+            case 'Keyword': {
+                return {
+                    name: 'Keyword',
+                    properties: [
+                        { name: 'value' }
+                    ]
+                };
+            }
+            case 'NegatedToken': {
+                return {
+                    name: 'NegatedToken',
+                    properties: [
+                        { name: 'terminal' }
+                    ]
+                };
+            }
+            case 'RegexToken': {
+                return {
+                    name: 'RegexToken',
+                    properties: [
+                        { name: 'regex' }
                     ]
                 };
             }
             case 'RuleCall': {
                 return {
                     name: 'RuleCall',
-                    mandatory: [
-                        { name: 'arguments', type: 'array' }
+                    properties: [
+                        { name: 'arguments', defaultValue: [] },
+                        { name: 'rule' }
                     ]
                 };
             }
             case 'TerminalAlternatives': {
                 return {
                     name: 'TerminalAlternatives',
-                    mandatory: [
-                        { name: 'elements', type: 'array' }
+                    properties: [
+                        { name: 'elements', defaultValue: [] }
                     ]
                 };
             }
             case 'TerminalGroup': {
                 return {
                     name: 'TerminalGroup',
-                    mandatory: [
-                        { name: 'elements', type: 'array' }
+                    properties: [
+                        { name: 'elements', defaultValue: [] }
+                    ]
+                };
+            }
+            case 'TerminalRuleCall': {
+                return {
+                    name: 'TerminalRuleCall',
+                    properties: [
+                        { name: 'rule' }
                     ]
                 };
             }
             case 'UnorderedGroup': {
                 return {
                     name: 'UnorderedGroup',
-                    mandatory: [
-                        { name: 'elements', type: 'array' }
+                    properties: [
+                        { name: 'elements', defaultValue: [] }
+                    ]
+                };
+            }
+            case 'UntilToken': {
+                return {
+                    name: 'UntilToken',
+                    properties: [
+                        { name: 'terminal' }
                     ]
                 };
             }
             default: {
                 return {
                     name: type,
-                    mandatory: []
+                    properties: []
                 };
             }
         }

--- a/packages/langium/src/parser/parser-builder-base.ts
+++ b/packages/langium/src/parser/parser-builder-base.ts
@@ -10,7 +10,7 @@ import type { BaseParser } from './langium-parser.js';
 import type { AstNode } from '../syntax-tree.js';
 import type { Cardinality } from '../utils/grammar-util.js';
 import { EMPTY_ALT, EOF } from 'chevrotain';
-import { isAction, isAlternatives, isEndOfFile, isAssignment, isConjunction, isCrossReference, isDisjunction, isGroup, isKeyword, isLiteralCondition, isNegation, isParameterReference, isParserRule, isRuleCall, isTerminalRule, isUnorderedGroup } from '../languages/generated/ast.js';
+import { isAction, isAlternatives, isEndOfFile, isAssignment, isConjunction, isCrossReference, isDisjunction, isGroup, isKeyword, isNegation, isParameterReference, isParserRule, isRuleCall, isTerminalRule, isUnorderedGroup, isBooleanLiteral } from '../languages/generated/ast.js';
 import { assertUnreachable, ErrorWithLocation } from '../utils/errors.js';
 import { stream } from '../utils/stream.js';
 import { findNameAssignment, getAllReachableRules, getTypeName } from '../utils/grammar-util.js';
@@ -151,7 +151,7 @@ function buildPredicate(condition: Condition): Predicate {
     } else if (isParameterReference(condition)) {
         const name = condition.parameter.ref!.name;
         return (args) => args !== undefined && args[name] === true;
-    } else if (isLiteralCondition(condition)) {
+    } else if (isBooleanLiteral(condition)) {
         const value = Boolean(condition.true);
         return () => value;
     }

--- a/packages/langium/src/syntax-tree.ts
+++ b/packages/langium/src/syntax-tree.ts
@@ -201,18 +201,25 @@ export abstract class AbstractAstReflection implements AstReflection {
 export interface TypeMetaData {
     /** The name of this meta model type. Corresponds to the `AstNode.$type` value. */
     name: string
-    /** A list of mandatory properties. These are defaults for array and boolean based properties (`[]` and `false` respectively). */
-    mandatory: TypeMandatoryProperty[]
+    /** A list of properties. They can contain default values for their respective property in the AST. */
+    properties: TypeProperty[]
 }
 
 /**
- * Mandatory properties are implicitly expected to be set in an AST node.
+ * Describes the meta data of a property of an AST node.
+ *
+ * The optional `defaultValue` indicates that the property is mandatory in the AST node.
  * For example, if an AST node contains an array, but no elements of this array have been parsed, we still expect an empty array instead of `undefined`.
  */
-export interface TypeMandatoryProperty {
+export interface TypeProperty {
     name: string
-    type: 'array' | 'boolean'
+    defaultValue?: PropertyType
 }
+
+/**
+ * Represents a default value for an AST property.
+ */
+export type PropertyType = number | string | boolean | PropertyType[];
 
 /**
  * A node in the Concrete Syntax Tree (CST).

--- a/packages/langium/test/grammar/ast-reflection-interpreter.test.ts
+++ b/packages/langium/test/grammar/ast-reflection-interpreter.test.ts
@@ -21,7 +21,8 @@ describe('AST reflection interpreter', () => {
                 elementType: {
                     primitive: 'string'
                 }
-            }
+            },
+            defaultValue: 'a'
         }, {
             name: 'Ref',
             astNodes: new Set(),
@@ -42,7 +43,8 @@ describe('AST reflection interpreter', () => {
                 elementType: {
                     primitive: 'string'
                 }
-            }
+            },
+            defaultValue: 'b'
         });
         subType.superTypes.add(superType);
 
@@ -81,12 +83,19 @@ describe('AST reflection interpreter', () => {
 
         test('Creates metadata with super types', () => {
             const superMetadata = reflectionForInheritance.getTypeMetaData('Super');
-            expect(superMetadata.mandatory).toHaveLength(1);
-            expect(superMetadata.mandatory[0].name).toBe('A');
+            expect(superMetadata.properties).toHaveLength(2);
+            expect(superMetadata.properties[0].name).toBe('A');
+            expect(superMetadata.properties[0].defaultValue).toBe('a');
+            expect(superMetadata.properties[1].name).toBe('Ref');
+            expect(superMetadata.properties[1].defaultValue).toBeUndefined();
             const subMetadata = reflectionForInheritance.getTypeMetaData('Sub');
-            expect(subMetadata.mandatory).toHaveLength(2);
-            expect(subMetadata.mandatory[0].name).toBe('A');
-            expect(subMetadata.mandatory[1].name).toBe('B');
+            expect(subMetadata.properties).toHaveLength(3);
+            expect(subMetadata.properties[0].name).toBe('A');
+            expect(subMetadata.properties[0].defaultValue).toBe('a');
+            expect(subMetadata.properties[1].name).toBe('B');
+            expect(subMetadata.properties[1].defaultValue).toBe('b');
+            expect(subMetadata.properties[2].name).toBe('Ref');
+            expect(subMetadata.properties[2].defaultValue).toBeUndefined();
         });
 
     });

--- a/packages/langium/test/parser/langium-parser-builder.test.ts
+++ b/packages/langium/test/parser/langium-parser-builder.test.ts
@@ -648,6 +648,63 @@ describe('Unicode terminal rules', () => {
 
 });
 
+describe('Parsing default values', () => {
+
+    const grammar = `
+        grammar test
+        entry Model returns Model: a=ID b=ID? (c+=ID)*;
+
+        interface Model {
+            a: string
+            b: string = "hello"
+            c: string[] = ["a", "b", "c"]
+        }
+
+        terminal ID: /\\w+/;
+        hidden terminal WS: /\\s+/;
+    `;
+
+    let parser: LangiumParser;
+
+    beforeEach(async () => {
+        parser = await parserFromGrammar(grammar);
+    });
+
+    test('Assigns default values for properties', async () => {
+        const result = parser.parse('hi');
+        const model = result.value as unknown as {
+            a: string
+            b: string
+            c: string[]
+        };
+        expect(model.a).toBe('hi');
+        expect(model.b).toBe('hello');
+        expect(model.c).toEqual(['a', 'b', 'c']);
+    });
+
+    test('Does not overwrite parsed value for "b"', async () => {
+        const result = parser.parse('hi world');
+        const model = result.value as unknown as {
+            a: string
+            b: string
+            c: string[]
+        };
+        expect(model.a).toBe('hi');
+        expect(model.b).toBe('world');
+    });
+
+    test('Does not overwrite parsed value for "c"', async () => {
+        const result = parser.parse('hi you d e');
+        const model = result.value as unknown as {
+            a: string
+            b: string
+            c: string[]
+        };
+        expect(model.c).toEqual(['d', 'e']);
+    });
+
+});
+
 describe('ALL(*) parser', () => {
 
     const grammar = `


### PR DESCRIPTION
Closes https://github.com/eclipse-langium/langium/issues/1154
Closes https://github.com/eclipse-langium/langium/issues/1206

Touches multiple parts of the framework to make this work:
* Support default values on the `TypeAttribute` grammar element
* Support setting default values in the parser (based on the existing mandatory-properties architecture)
* Adds validation so that default values always match the types defined on the property