### PR TITLE
Emit `onUpdate` event on `DocumentBuilder#build`

### DIFF
--- a/packages/langium/test/grammar/type-system/inferred-types.test.ts
+++ b/packages/langium/test/grammar/type-system/inferred-types.test.ts
@@ -292,7 +292,7 @@ describe('Inferred types', () => {
     });
 
     test('Should infer data type rules as unions', async () => {
-        expectTypes(`
+        await expectTypes(`
             Strings returns string: 'a' | 'b' | 'c';
             MoreStrings returns string: Strings | 'd' | 'e';
             Complex returns string: ID ('.' ID)*;
@@ -323,7 +323,7 @@ describe('Inferred types', () => {
     });
 
     test('Infers X as a super interface of Y and Z with property `id`', async () => {
-        expectTypes(`
+        await expectTypes(`
             entry X: id=ID ({infer Y} 'a' | {infer Z} 'b');
             terminal ID: /[a-zA-Z_][a-zA-Z0-9_]*/;
         `, expandToString`
@@ -343,7 +343,7 @@ describe('Inferred types', () => {
 
 describe('inferred types that are used by the grammar', () => {
     test('B is defined and A is not', async () => {
-        expectTypes(`
+        await expectTypes(`
             A infers B: 'a' name=ID (otherA=[B])?;
             hidden terminal WS: /\\s+/;
             terminal ID: /[a-zA-Z_][a-zA-Z0-9_]*/;
@@ -359,7 +359,7 @@ describe('inferred types that are used by the grammar', () => {
 
 describe('inferred and declared types', () => {
     test('Declared interfaces should be preserved as interfaces', async () => {
-        expectTypes(`
+        await expectTypes(`
             X returns X: Y | Z;
             Y: y='y';
             Z: z='z';
@@ -881,10 +881,10 @@ describe('generated types from declared types include all of them', () => {
 // });
 
 const services = createLangiumGrammarServices(EmptyFileSystem).grammar;
+const helper = parseHelper<Grammar>(services);
 
 async function getTypes(grammar: string): Promise<AstTypes> {
     await clearDocuments(services);
-    const helper = parseHelper<Grammar>(services);
     const result = await helper(grammar);
     const gram = result.parseResult.value;
     return collectAst(gram);

--- a/packages/langium/test/workspace/document-builder.test.ts
+++ b/packages/langium/test/workspace/document-builder.test.ts
@@ -45,6 +45,42 @@ describe('DefaultDocumentBuilder', () => {
         return services;
     }
 
+    test('emits `onUpdate` on `update` call', async () => {
+        const services = await createServices();
+        const documentFactory = services.shared.workspace.LangiumDocumentFactory;
+        const documents = services.shared.workspace.LangiumDocuments;
+        const document = documentFactory.fromString('', URI.parse('file:///test1.txt'));
+        documents.addDocument(document);
+
+        const builder = services.shared.workspace.DocumentBuilder;
+        await builder.build([document], {});
+        addTextDocument(document, services);
+        let called = false;
+        builder.onUpdate(() => {
+            called = true;
+        });
+        await builder.update([document.uri], []);
+        expect(called).toBe(true);
+    });
+
+    test('emits `onUpdate` on `build` call', async () => {
+        const services = await createServices();
+        const documentFactory = services.shared.workspace.LangiumDocumentFactory;
+        const documents = services.shared.workspace.LangiumDocuments;
+        const document = documentFactory.fromString('', URI.parse('file:///test1.txt'));
+        documents.addDocument(document);
+
+        const builder = services.shared.workspace.DocumentBuilder;
+        await builder.build([document], {});
+        addTextDocument(document, services);
+        let called = false;
+        builder.onUpdate(() => {
+            called = true;
+        });
+        await builder.build([document]);
+        expect(called).toBe(true);
+    });
+
     test('resumes document build after cancellation', async () => {
         const services = await createServices();
         const documentFactory = services.shared.workspace.LangiumDocumentFactory;


### PR DESCRIPTION
Related to https://github.com/eclipse-langium/langium/discussions/1188.

The global scope cache only gets cleared on `DocumentBuilder#update`, which works well in the language server case. However, in the CLI case, it is recommended to use `build` instead, which doesn't call the listeners registered via `DocumentBuilder#onUpdate`.

This results in incorrectly linked references, as the global scope hasn't been updated. This change also calls the update listeners on `build`, while also allowing the update listener to be potentially promises.