### PR TITLE
Adapt links and readme for Eclipse Foundation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,12 @@ We maintain separate change logs for the individual packages:
 
 ## Closed Issues and PRs
 
-* [v2.0.0](https://github.com/langium/langium/milestone/9?closed=1)
-* [v1.3.0](https://github.com/langium/langium/milestone/7?closed=1)
-* [v1.2.0](https://github.com/langium/langium/milestone/8?closed=1)
-* [v1.1.0](https://github.com/langium/langium/milestone/6?closed=1)
-* [v1.0.0](https://github.com/langium/langium/milestone/5?closed=1)
-* [v0.5.0](https://github.com/langium/langium/milestone/4?closed=1)
-* [v0.4.0](https://github.com/langium/langium/milestone/3?closed=1)
-* [v0.3.0](https://github.com/langium/langium/milestone/2?closed=1)
-* [v0.2.0](https://github.com/langium/langium/milestone/1?closed=1)
+* [v2.0.0](https://github.com/eclipse-langium/langium/milestone/9?closed=1)
+* [v1.3.0](https://github.com/eclipse-langium/langium/milestone/7?closed=1)
+* [v1.2.0](https://github.com/eclipse-langium/langium/milestone/8?closed=1)
+* [v1.1.0](https://github.com/eclipse-langium/langium/milestone/6?closed=1)
+* [v1.0.0](https://github.com/eclipse-langium/langium/milestone/5?closed=1)
+* [v0.5.0](https://github.com/eclipse-langium/langium/milestone/4?closed=1)
+* [v0.4.0](https://github.com/eclipse-langium/langium/milestone/3?closed=1)
+* [v0.3.0](https://github.com/eclipse-langium/langium/milestone/2?closed=1)
+* [v0.2.0](https://github.com/eclipse-langium/langium/milestone/1?closed=1)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,12 @@
 
 Thank you for your interest in the Langium project! The following is a set of guidelines for contributing to Langium.
 
+## Eclipse Contributor Agreement
+
+If you're planning to contribute to this or any other repository in the [`eclipse-langium` GitHub organization](https://github.com/eclipse-langium), please sign the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php).
+
+By signing the ECA you promise that your contributions adhere to the license used in the repository of the corresponding Eclipse project. This ensures that Langium can be used by any adopter without any legal issues.
+
 ## Prerequisites
 
 For developing Langium you require at least the Maintenance LTS version of Node.js (currently 16) and at least npm version 7.7.0 (`npm@^7.7.0`) to be able to use npm workspaces. With Node.js versions below 16 you have to install the correct version of npm with `npm install -g npm@7`.
@@ -53,7 +59,7 @@ When you add a dependency to a `package.json` npm resolves this from the configu
 
 There is an npm build target available (`npm run dev-build`) linking all Langium packages to your global scope. It unlinks and uninstalls the Langium packages from the global scope, deletes any `node_modules` folders below the packages directory (see warning above), afterwards performs `npm install` and then links all packages to the global scope again. Then your are able to use `yo langium` or `langium generate` containing your local Langium adjustments from everywhere with your local user.
 
-A project you created with `yo langium` contains a dependency to `langium` (e.g. `0.1.0`) and a dev-dependency to `langium-cli`) inside `package.json` by default. Now, you have to link your own global Langium build to your own language project.
+A project you created with `yo langium` contains a dependency to `langium` (e.g. `2.0.0`) and a dev-dependency to `langium-cli`) inside `package.json` by default. Now, you have to link your own global Langium build to your own language project.
 Issue the following commands in a shell from the root of your language project:
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div id="langium-logo" align="center">
-  <a href="https://github.com/langium/langium">
+  <a href="https://github.com/eclipse-langium/langium">
     <img alt="Langium Logo" width="60%" src="https://user-images.githubusercontent.com/4377073/135283991-90ef7724-649d-440a-8720-df13c23bda82.png">
   </a>
   <h3>
@@ -10,16 +10,16 @@
 <div id="badges" align="center">
 
   [![npm](https://img.shields.io/npm/v/langium)](https://www.npmjs.com/package/langium)
-  [![Build](https://github.com/langium/langium/actions/workflows/build.yml/badge.svg)](https://github.com/langium/langium/actions/workflows/build.yml)
+  [![Build](https://github.com/eclipse-langium/langium/actions/workflows/actions.yml/badge.svg)](https://github.com/eclipse-langium/langium/actions/workflows/actions.yml)
   [![Gitter Chat](https://img.shields.io/badge/chat-on%20gitter-0DBD8B?logo=gitter)](https://app.gitter.im/#/room/#langium:gitter.im)
-  [![Github Discussions](https://img.shields.io/badge/github-discussions-blue?logo=github)](https://github.com/langium/langium/discussions)
-  [![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-ready--to--code-FFAE33?logo=gitpod)](https://gitpod.io/#https://github.com/langium/langium)
+  [![Github Discussions](https://img.shields.io/badge/github-discussions-blue?logo=github)](https://github.com/eclipse-langium/langium/discussions)
+  [![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-ready--to--code-FFAE33?logo=gitpod)](https://gitpod.io/#https://github.com/eclipse-langium/langium)
 
 </div>
 
 ---
 
-Langium (IPA: /ˈlæŋɡiəm/, like **lang**uage and equilibr**ium**) is a language engineering tool for [TypeScript](https://www.typescriptlang.org/) with built-in support for the [Language Server Protocol](https://microsoft.github.io/language-server-protocol/). The framework is an all-in-one solution for building programming languages, domain specific languages, code generators, interpreters and compilers. It serves as a spiritual successor to the [Eclipse Xtext framework](https://www.eclipse.org/Xtext/).
+Eclipse Langium (IPA: /ˈlæŋɡiəm/, like **lang**uage and equilibr**ium**) is a language engineering tool for [TypeScript](https://www.typescriptlang.org/) with built-in support for the [Language Server Protocol](https://microsoft.github.io/language-server-protocol/). The framework is an all-in-one solution for building programming languages, domain specific languages, code generators, interpreters and compilers. It serves as a spiritual successor to the [Eclipse Xtext framework](https://www.eclipse.org/Xtext/).
 
 * **Semantics First:** Building on top of a [grammar declaration language](https://langium.org/docs/grammar-language/), Langium enables you to build the abstract model of your language in parallel to its syntax. Langium parsers are powered by [Chevrotain](https://chevrotain.io).
 * **Lean by Default, Customizable by Design:** Langium offers the infrastructure you need to build languages purely by defining their grammar. If that is not enough, you can fine tune every detail of your language using our [dependency injection system](https://langium.org/docs/configuration-services/).
@@ -53,12 +53,12 @@ The documentation website is hosted in [this repository](https://github.com/lang
 
 ## Examples
 
-We host a number of simple examples in our [main repo](https://github.com/langium/langium/tree/main/examples):
+We host a number of simple examples in our [main repo](https://github.com/eclipse-langium/langium/tree/main/examples):
 
-* **[arithmetics](https://github.com/langium/langium/tree/main/examples/arithmetics)**: How to create an expression language + interpreter.
-* **[domainmodel](https://github.com/langium/langium/tree/main/examples/domainmodel)**: How to create a language with fully qualified name identifiers.
-* **[requirements](https://github.com/langium/langium/tree/main/examples/requirements)**: How to create a Langium project with multiple languages.
-* **[statemachine](https://github.com/langium/langium/tree/main/examples/statemachine)**: How to create a code generator.
+* **[arithmetics](https://github.com/eclipse-langium/langium/tree/main/examples/arithmetics)**: How to create an expression language + interpreter.
+* **[domainmodel](https://github.com/eclipse-langium/langium/tree/main/examples/domainmodel)**: How to create a language with fully qualified name identifiers.
+* **[requirements](https://github.com/eclipse-langium/langium/tree/main/examples/requirements)**: How to create a Langium project with multiple languages.
+* **[statemachine](https://github.com/eclipse-langium/langium/tree/main/examples/statemachine)**: How to create a code generator.
 
 More complex examples are available as separate repositories in [our GitHub organization](https://github.com/langium):
 
@@ -67,6 +67,6 @@ More complex examples are available as separate repositories in [our GitHub orga
 
 ## Contributing
 
-If you want to contribute to Langium, please take a look at [our contributing guide](https://github.com/langium/langium/blob/main/CONTRIBUTING.md).
+If you want to contribute to Langium, please take a look at [our contributing guide](https://github.com/eclipse-langium/langium/blob/main/CONTRIBUTING.md).
 
-Langium is fully [MIT licensed](https://github.com/langium/langium/blob/main/LICENSE).
+Langium is fully [MIT licensed](https://github.com/eclipse-langium/langium/blob/main/LICENSE).

--- a/package-lock.json
+++ b/package-lock.json
@@ -4003,9 +4003,9 @@
       }
     },
     "node_modules/get-func-name": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-      "integrity": "sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
       "dev": true,
       "engines": {
         "node": "*"

--- a/packages/generator-langium/CHANGELOG.md
+++ b/packages/generator-langium/CHANGELOG.md
@@ -2,12 +2,12 @@
 
 ## v2.0.0 (Aug. 2023)
 
-* Added a bundle configuration using `esbuild` ([#1125](https://github.com/langium/langium/pull/1125)).
-* Configured the project as an ESM project to adapt to the changes in Langium ([#1125](https://github.com/langium/langium/pull/1125)).
+* Added a bundle configuration using `esbuild` ([#1125](https://github.com/eclipse-langium/langium/pull/1125)).
+* Configured the project as an ESM project to adapt to the changes in Langium ([#1125](https://github.com/eclipse-langium/langium/pull/1125)).
 
 ## v1.3.0 (Aug. 2023)
 
-* Fixed a few syntax highlighting related issues ([#1064](https://github.com/langium/langium/pull/1064), [#1079](https://github.com/langium/langium/pull/1079)).
+* Fixed a few syntax highlighting related issues ([#1064](https://github.com/eclipse-langium/langium/pull/1064), [#1079](https://github.com/eclipse-langium/langium/pull/1079)).
 
 ## v1.2.0 (May. 2023)
 
@@ -18,11 +18,11 @@
 
 ## v1.1.0 (Feb. 2023)
 
-* Users that have vscode installed in the environment will be asked whether they want to open the generated project in vscode ([#911](https://github.com/langium/langium/pull/911)).
+* Users that have vscode installed in the environment will be asked whether they want to open the generated project in vscode ([#911](https://github.com/eclipse-langium/langium/pull/911)).
 
 ## v1.0.0 (Dec. 2022) 🎉
 
- * Validation checks are registered in a plain function instead of a registry subclass ([#821](https://github.com/langium/langium/pull/821)).
+ * Validation checks are registered in a plain function instead of a registry subclass ([#821](https://github.com/eclipse-langium/langium/pull/821)).
 
 ---
 
@@ -38,9 +38,9 @@ This release updates the generated dependencies to Langium version `0.4.0`.
 
 ## v0.3.0 (Mar. 2022)
 
- * The generated project is adapted to the new structure supporting multiple languages ([#311](https://github.com/langium/langium/pull/311)). This mainly affects the configuration format of the `langium` CLI and the separation of _shared services_ and _language-specific services_.
- * The generator now prints descriptions of the requested values ([#373](https://github.com/langium/langium/pull/373)).
- * Added an `attach` launch config for debugging the language server ([#380](https://github.com/langium/langium/pull/380)).
+ * The generated project is adapted to the new structure supporting multiple languages ([#311](https://github.com/eclipse-langium/langium/pull/311)). This mainly affects the configuration format of the `langium` CLI and the separation of _shared services_ and _language-specific services_.
+ * The generator now prints descriptions of the requested values ([#373](https://github.com/eclipse-langium/langium/pull/373)).
+ * Added an `attach` launch config for debugging the language server ([#380](https://github.com/eclipse-langium/langium/pull/380)).
 
 ---
 
@@ -54,10 +54,10 @@ This release updates the generated dependencies to Langium version `0.4.0`.
 
 ### Added CLI Example
 
-The generated package now includes a Node.js CLI that can be adapted to generate code from your language ([#175](https://github.com/langium/langium/pull/175)). The executable entry point is in the `bin` subfolder.
+The generated package now includes a Node.js CLI that can be adapted to generate code from your language ([#175](https://github.com/eclipse-langium/langium/pull/175)). The executable entry point is in the `bin` subfolder.
 
 The initial generator example is based on the "Hello World" grammar; it generates JavaScript code that prints greetings to the console.
 
 ### Improved Debugging
 
- By setting the environment variable `DEBUG_BREAK` to a non-empty value, the language server is started with the `--inspect-brk` option of Node.js during debugging ([#227](https://github.com/langium/langium/pull/227)). When active, the language server execution is halted at the start of the entry point (`main.ts`), enabling to debug the initialization phase.
+ By setting the environment variable `DEBUG_BREAK` to a non-empty value, the language server is started with the `--inspect-brk` option of Node.js during debugging ([#227](https://github.com/eclipse-langium/langium/pull/227)). When active, the language server execution is halted at the start of the entry point (`main.ts`), enabling to debug the initialization phase.

--- a/packages/langium-cli/CHANGELOG.md
+++ b/packages/langium-cli/CHANGELOG.md
@@ -8,18 +8,18 @@ Fix a bug that prevented usage of the JS API of the CLI package ([#1160](https:/
 
 ### EcmaScript Modules (ESM)
 
-This package is now compiling to ESM only, refer to [this changelog entry](https://github.com/langium/langium/blob/main/packages/langium/CHANGELOG.md#ecmascript-modules-esm)
+This package is now compiling to ESM only, refer to [this changelog entry](https://github.com/eclipse-langium/langium/blob/main/packages/langium/CHANGELOG.md#ecmascript-modules-esm)
 
 ### Breaking Changes
 
-* The CLI now always uses the original `projectName` of the `langium-config.json` property for the generated type/object names. It no longer performs kebab-case transformation ([#1122](https://github.com/langium/langium/pull/1122)).
-* We've decided to remove generated `$container` type declarations for types where it isn't clear what the container types can be ([#1055](https://github.com/langium/langium/pull/1055)).
+* The CLI now always uses the original `projectName` of the `langium-config.json` property for the generated type/object names. It no longer performs kebab-case transformation ([#1122](https://github.com/eclipse-langium/langium/pull/1122)).
+* We've decided to remove generated `$container` type declarations for types where it isn't clear what the container types can be ([#1055](https://github.com/eclipse-langium/langium/pull/1055)).
 
 ## v1.3.0 (Aug. 2023)
 
 ### Railroad Syntax Diagrams
 
-With the introduction of [`langium-railroad`](https://github.com/langium/langium/tree/main/packages/langium-railroad), the CLI is now capable of generating railroad syntax diagrams for your language ([#1075](https://github.com/langium/langium/pull/1075)).
+With the introduction of [`langium-railroad`](https://github.com/eclipse-langium/langium/tree/main/packages/langium-railroad), the CLI is now capable of generating railroad syntax diagrams for your language ([#1075](https://github.com/eclipse-langium/langium/pull/1075)).
 To generate them to a file, use the following example config:
 
 ```json
@@ -40,19 +40,19 @@ To generate them to a file, use the following example config:
 
 ### Generated Terminal Definitions
 
-The generated `ast.ts` file will now also contain an object containing all regular expressions used by your grammar's terminal rules ([#1097](https://github.com/langium/langium/pull/1097)).
+The generated `ast.ts` file will now also contain an object containing all regular expressions used by your grammar's terminal rules ([#1097](https://github.com/eclipse-langium/langium/pull/1097)).
 This allows to more easily reuse those regular expressions in your code.
 
 ### General Improvements
 
-* The CLI can now resolve grammar imports transitively ([#1113](https://github.com/langium/langium/pull/1113)).
-* A new `mode` configuration/argument can be used to improve bundle size of Langium projects ([#1077](https://github.com/langium/langium/pull/1077)).
-* Fixed an error in the way the CLI creates directories ([#1105](https://github.com/langium/langium/pull/1105)).
+* The CLI can now resolve grammar imports transitively ([#1113](https://github.com/eclipse-langium/langium/pull/1113)).
+* A new `mode` configuration/argument can be used to improve bundle size of Langium projects ([#1077](https://github.com/eclipse-langium/langium/pull/1077)).
+* Fixed an error in the way the CLI creates directories ([#1105](https://github.com/eclipse-langium/langium/pull/1105)).
 
 ## v1.2.1 (Jun. 2023)
 
-* The generated code now performs split imports for runtime and compile time dependencies ([#1018](https://github.com/langium/langium/pull/1018)).
-* The new configuration field `importExtension` can be used to specify the file extension for generated imports ([#1072](https://github.com/langium/langium/pull/1072)).
+* The generated code now performs split imports for runtime and compile time dependencies ([#1018](https://github.com/eclipse-langium/langium/pull/1018)).
+* The new configuration field `importExtension` can be used to specify the file extension for generated imports ([#1072](https://github.com/eclipse-langium/langium/pull/1072)).
 
 ## v1.2.0 (May. 2023)
 
@@ -78,28 +78,28 @@ Enable the generator by adding it to your `langium-config.json` file:
 
 ### General Improvements
 
-* Various improvements to the type generator/validator. ([#942](https://github.com/langium/langium/pull/942), [#946](https://github.com/langium/langium/pull/946), [#947](https://github.com/langium/langium/pull/947), [#950](https://github.com/langium/langium/pull/950), [#973](https://github.com/langium/langium/pull/973), [#1003](https://github.com/langium/langium/pull/1003))
+* Various improvements to the type generator/validator. ([#942](https://github.com/eclipse-langium/langium/pull/942), [#946](https://github.com/eclipse-langium/langium/pull/946), [#947](https://github.com/eclipse-langium/langium/pull/947), [#950](https://github.com/eclipse-langium/langium/pull/950), [#973](https://github.com/eclipse-langium/langium/pull/973), [#1003](https://github.com/eclipse-langium/langium/pull/1003))
 
 ---
 
 ## v1.1.0 (Feb. 2023)
 
-* Various improvements to the generated AST types ([#845](https://github.com/langium/langium/pull/845)).
-* The `--watch` mode now also watches referenced grammars, not only those directly used in the langium config file ([#908](https://github.com/langium/langium/pull/908)).
+* Various improvements to the generated AST types ([#845](https://github.com/eclipse-langium/langium/pull/845)).
+* The `--watch` mode now also watches referenced grammars, not only those directly used in the langium config file ([#908](https://github.com/eclipse-langium/langium/pull/908)).
 
 ---
 
 ## v1.0.0 (Dec. 2022) 🎉
 
- * New command `extract-types` generates type declarations to be used in your grammar file ([#754](https://github.com/langium/langium/pull/754)). This utility can be used to move from _inferred_ types to _declared_ types, which makes sense when your language project becomes more mature.
- * New reference format in JSON-serialized grammars ([#787](https://github.com/langium/langium/pull/787)).
+ * New command `extract-types` generates type declarations to be used in your grammar file ([#754](https://github.com/eclipse-langium/langium/pull/754)). This utility can be used to move from _inferred_ types to _declared_ types, which makes sense when your language project becomes more mature.
+ * New reference format in JSON-serialized grammars ([#787](https://github.com/eclipse-langium/langium/pull/787)).
  * Adapted to version `1.0.0` of the Langium core library.
 
 ---
 
 ## v0.5.0 (Oct. 2022)
 
- * Added an option to generate syntax highlighting in the [Monarch format](https://microsoft.github.io/monaco-editor/monarch.html) ([#620](https://github.com/langium/langium/pull/620)).
+ * Added an option to generate syntax highlighting in the [Monarch format](https://microsoft.github.io/monaco-editor/monarch.html) ([#620](https://github.com/eclipse-langium/langium/pull/620)).
  * Adapted to version `0.5.0` of the Langium core library.
 
 ---
@@ -114,15 +114,15 @@ This release brings lots of bug fixes and is adapted to version `0.4.0` of the L
 
 ### General Improvements
 
- * Added support for importing other grammar files to state explicitly which rules should be included in your grammar ([#311](https://github.com/langium/langium/pull/311)).
- * Added support for explicit type declarations in the grammar ([#406](https://github.com/langium/langium/pull/406)).
- * Improved generated TextMate syntax highlighting ([#289](https://github.com/langium/langium/pull/289), [#293](https://github.com/langium/langium/pull/293), [#312](https://github.com/langium/langium/pull/312)).
- * Added support for case-insensitive parsing of keywords ([#316](https://github.com/langium/langium/pull/316)).
- * When parser validation errors occur, the file path and line number of the corresponding grammar rule is printed out ([#372](https://github.com/langium/langium/pull/372)).
+ * Added support for importing other grammar files to state explicitly which rules should be included in your grammar ([#311](https://github.com/eclipse-langium/langium/pull/311)).
+ * Added support for explicit type declarations in the grammar ([#406](https://github.com/eclipse-langium/langium/pull/406)).
+ * Improved generated TextMate syntax highlighting ([#289](https://github.com/eclipse-langium/langium/pull/289), [#293](https://github.com/eclipse-langium/langium/pull/293), [#312](https://github.com/eclipse-langium/langium/pull/312)).
+ * Added support for case-insensitive parsing of keywords ([#316](https://github.com/eclipse-langium/langium/pull/316)).
+ * When parser validation errors occur, the file path and line number of the corresponding grammar rule is printed out ([#372](https://github.com/eclipse-langium/langium/pull/372)).
 
 ### Breaking Changes
 
- * In order to support multiple languages running in the same language server, the Langium configuration format was changed ([#311](https://github.com/langium/langium/pull/311)). It now looks like this:
+ * In order to support multiple languages running in the same language server, the Langium configuration format was changed ([#311](https://github.com/eclipse-langium/langium/pull/311)). It now looks like this:
    ```
    {
      "projectName": "Arithmetics",
@@ -145,14 +145,14 @@ This release brings lots of bug fixes and is adapted to version `0.4.0` of the L
 
 ### General Improvements
 
- * We no longer generate code for the parser, but derive it from the serialized grammar instead ([#169](https://github.com/langium/langium/pull/169)).
- * The target folder is deleted before new files are generated ([#180](https://github.com/langium/langium/pull/180)). In case the target folder contains any files that are _not_ regenerated, the CLI shows a question before deleting anything.
- * The language configuration used by `langium-cli` is now read from a separate file `langium-config.json` by default ([#158](https://github.com/langium/langium/pull/158)). Embedding it in `package.json` is still supported.
- * Added the [Chevrotain parser configuration](https://chevrotain.io/documentation/9_1_0/interfaces/IParserConfig.html) to the Langium configuration (`chevrotainParserConfig` property, [#248](https://github.com/langium/langium/pull/248)). Among other things, this enables setting the [maximum lookahead](https://chevrotain.io/documentation/9_1_0/interfaces/IParserConfig.html#maxLookahead).
- * The parser validation of Chevrotain is run as part of `langium-cli` to provide early feedback ([#253](https://github.com/langium/langium/pull/253)).
- * The JSON content of the grammar is written to a TypeScript file instead of a `.json` file, simplifiying the build process ([#142](https://github.com/langium/langium/pull/142)).
- * Some of the language meta data (language id and file extensions) are generated so they are available at runtime ([#170](https://github.com/langium/langium/pull/170)).
+ * We no longer generate code for the parser, but derive it from the serialized grammar instead ([#169](https://github.com/eclipse-langium/langium/pull/169)).
+ * The target folder is deleted before new files are generated ([#180](https://github.com/eclipse-langium/langium/pull/180)). In case the target folder contains any files that are _not_ regenerated, the CLI shows a question before deleting anything.
+ * The language configuration used by `langium-cli` is now read from a separate file `langium-config.json` by default ([#158](https://github.com/eclipse-langium/langium/pull/158)). Embedding it in `package.json` is still supported.
+ * Added the [Chevrotain parser configuration](https://chevrotain.io/documentation/9_1_0/interfaces/IParserConfig.html) to the Langium configuration (`chevrotainParserConfig` property, [#248](https://github.com/eclipse-langium/langium/pull/248)). Among other things, this enables setting the [maximum lookahead](https://chevrotain.io/documentation/9_1_0/interfaces/IParserConfig.html#maxLookahead).
+ * The parser validation of Chevrotain is run as part of `langium-cli` to provide early feedback ([#253](https://github.com/eclipse-langium/langium/pull/253)).
+ * The JSON content of the grammar is written to a TypeScript file instead of a `.json` file, simplifiying the build process ([#142](https://github.com/eclipse-langium/langium/pull/142)).
+ * Some of the language meta data (language id and file extensions) are generated so they are available at runtime ([#170](https://github.com/eclipse-langium/langium/pull/170)).
 
 ### Breaking Changes
 
- * The `extensions` field in the Langium configuration was renamed to `fileExtensions` ([#173](https://github.com/langium/langium/pull/173)).
+ * The `extensions` field in the Langium configuration was renamed to `fileExtensions` ([#173](https://github.com/eclipse-langium/langium/pull/173)).

--- a/packages/langium-railroad/CHANGELOG.md
+++ b/packages/langium-railroad/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### EcmaScript Modules (ESM)
 
-This package is now compiling to ESM only, refer to [this changelog entry](https://github.com/langium/langium/blob/main/packages/langium/CHANGELOG.md#ecmascript-modules-esm)
+This package is now compiling to ESM only, refer to [this changelog entry](https://github.com/eclipse-langium/langium/blob/main/packages/langium/CHANGELOG.md#ecmascript-modules-esm)
 
 ## v1.3.0 (Aug. 2023)
 

--- a/packages/langium-vscode/CHANGELOG.md
+++ b/packages/langium-vscode/CHANGELOG.md
@@ -2,45 +2,45 @@
 
 ## v2.0.0 (Aug. 2023)
 
-* Includes a command to open a railroad syntax diagram for the currently selected langium grammar. Use the `Show Railroad Syntax Diagram` command or the corresponding button in the editor title bar to open the diagram ([#1075](https://github.com/langium/langium/pull/1075)).
-* Improvements to validation regarding cyclic type usage ([#1130](https://github.com/langium/langium/pull/1130)).
-* The grammar language can now resolve grammar imports transitively ([#1113](https://github.com/langium/langium/pull/1113)).
+* Includes a command to open a railroad syntax diagram for the currently selected langium grammar. Use the `Show Railroad Syntax Diagram` command or the corresponding button in the editor title bar to open the diagram ([#1075](https://github.com/eclipse-langium/langium/pull/1075)).
+* Improvements to validation regarding cyclic type usage ([#1130](https://github.com/eclipse-langium/langium/pull/1130)).
+* The grammar language can now resolve grammar imports transitively ([#1113](https://github.com/eclipse-langium/langium/pull/1113)).
 
 ## v1.2.0 (May. 2023)
 
-* Various improvements to the type generator/validator ([#942](https://github.com/langium/langium/pull/942), [#946](https://github.com/langium/langium/pull/946), [#947](https://github.com/langium/langium/pull/947), [#950](https://github.com/langium/langium/pull/950), [#973](https://github.com/langium/langium/pull/973), [#1003](https://github.com/langium/langium/pull/1003)).
+* Various improvements to the type generator/validator ([#942](https://github.com/eclipse-langium/langium/pull/942), [#946](https://github.com/eclipse-langium/langium/pull/946), [#947](https://github.com/eclipse-langium/langium/pull/947), [#950](https://github.com/eclipse-langium/langium/pull/950), [#973](https://github.com/eclipse-langium/langium/pull/973), [#1003](https://github.com/eclipse-langium/langium/pull/1003)).
 
 ## v1.1.0 (Feb. 2023)
 
-* Various improvements to validation of type definitions ([#845](https://github.com/langium/langium/pull/845)).
+* Various improvements to validation of type definitions ([#845](https://github.com/eclipse-langium/langium/pull/845)).
 
 ## v1.0.0 (Dec. 2022) 🎉
 
- * Improved linking of types ([#763](https://github.com/langium/langium/pull/763)).
- * Various improvements around the inference and validation of types ([#819](https://github.com/langium/langium/pull/819)).
- * White space strings can be used in terminal rules ([#771](https://github.com/langium/langium/pull/771)).
- * Keywords of the grammar language can be used as property names ([#811](https://github.com/langium/langium/pull/811)).
- * Reserved words of the JavaScript runtime can no longer be used in grammar definitions ([#749](https://github.com/langium/langium/pull/749)).
- * The name of a terminal rule must not clash with a keyword ([#820](https://github.com/langium/langium/pull/820)).
- * The type of a property must not combine a cross-reference with something else ([#826](https://github.com/langium/langium/pull/826)).
+ * Improved linking of types ([#763](https://github.com/eclipse-langium/langium/pull/763)).
+ * Various improvements around the inference and validation of types ([#819](https://github.com/eclipse-langium/langium/pull/819)).
+ * White space strings can be used in terminal rules ([#771](https://github.com/eclipse-langium/langium/pull/771)).
+ * Keywords of the grammar language can be used as property names ([#811](https://github.com/eclipse-langium/langium/pull/811)).
+ * Reserved words of the JavaScript runtime can no longer be used in grammar definitions ([#749](https://github.com/eclipse-langium/langium/pull/749)).
+ * The name of a terminal rule must not clash with a keyword ([#820](https://github.com/eclipse-langium/langium/pull/820)).
+ * The type of a property must not combine a cross-reference with something else ([#826](https://github.com/eclipse-langium/langium/pull/826)).
 
 ---
 
 ## v0.5.0 (Oct. 2022)
 
- * Support _find references_ for properties of declared types ([#528](https://github.com/langium/langium/pull/528)).
- * Support _go to definition_ for grammar imports ([#613](https://github.com/langium/langium/pull/613)).
- * Highlight usages of declared types ([#531](https://github.com/langium/langium/pull/531)).
- * Added a code action to add new parser rule ([#543](https://github.com/langium/langium/pull/543)).
- * Various improvements around grammar types ([#548](https://github.com/langium/langium/pull/548), [#551](https://github.com/langium/langium/pull/551), [#586](https://github.com/langium/langium/pull/586), [#670](https://github.com/langium/langium/pull/670), [#705](https://github.com/langium/langium/pull/705)).
+ * Support _find references_ for properties of declared types ([#528](https://github.com/eclipse-langium/langium/pull/528)).
+ * Support _go to definition_ for grammar imports ([#613](https://github.com/eclipse-langium/langium/pull/613)).
+ * Highlight usages of declared types ([#531](https://github.com/eclipse-langium/langium/pull/531)).
+ * Added a code action to add new parser rule ([#543](https://github.com/eclipse-langium/langium/pull/543)).
+ * Various improvements around grammar types ([#548](https://github.com/eclipse-langium/langium/pull/548), [#551](https://github.com/eclipse-langium/langium/pull/551), [#586](https://github.com/eclipse-langium/langium/pull/586), [#670](https://github.com/eclipse-langium/langium/pull/670), [#705](https://github.com/eclipse-langium/langium/pull/705)).
 
 ---
 
 ## v0.4.0 (Jun. 2022)
 
- * Hover pop-up shows information for cross-references ([#473](https://github.com/langium/langium/pull/473)).
- * Formatting of grammar files is now available ([#479](https://github.com/langium/langium/pull/479)).
- * You can "Go to Definition" on property assignments where the return type is explicitly declared ([#505](https://github.com/langium/langium/pull/505)).
+ * Hover pop-up shows information for cross-references ([#473](https://github.com/eclipse-langium/langium/pull/473)).
+ * Formatting of grammar files is now available ([#479](https://github.com/eclipse-langium/langium/pull/479)).
+ * You can "Go to Definition" on property assignments where the return type is explicitly declared ([#505](https://github.com/eclipse-langium/langium/pull/505)).
  * Improved validation and general handling of inferred and declared types.
 
 ---
@@ -49,12 +49,12 @@
 
 This release brought several changes to the grammar language:
 
- * Added support for importing other grammar files to state explicitly which rules should be included in your grammar ([#311](https://github.com/langium/langium/pull/311)).
+ * Added support for importing other grammar files to state explicitly which rules should be included in your grammar ([#311](https://github.com/eclipse-langium/langium/pull/311)).
    ```
    import './expressions';
    ```
    This makes all declarations of the file `expressions.langium` available in the current grammar.
- * Added support for explicit type declarations in the grammar ([#406](https://github.com/langium/langium/pull/406)).
+ * Added support for explicit type declarations in the grammar ([#406](https://github.com/eclipse-langium/langium/pull/406)).
    ```
    interface Entity {
       name: string
@@ -65,8 +65,8 @@ This release brought several changes to the grammar language:
    type Symbol = Entity | PackageDeclaration | DataType | Feature
    ```
    The `interface` form describes the properties of an AST node type. The `@` character used at the `superType` property above denotes a cross-reference to a node of type `Entity`. The `type` form creates _union types_, i.e. an alternative of other declared or inferred types.
- * In addition to regular expressions, terminals now feature an [_extended backus-naur form_](https://langium.org/docs/grammar-language/#more-on-terminal-rules) that enables composition of terminal rules ([#288](https://github.com/langium/langium/pull/288)).
- * The `hidden` keyword of the grammar language is now used as modifier for terminals instead of following the top-level grammar declaration ([#288](https://github.com/langium/langium/pull/288)).
+ * In addition to regular expressions, terminals now feature an [_extended backus-naur form_](https://langium.org/docs/grammar-language/#more-on-terminal-rules) that enables composition of terminal rules ([#288](https://github.com/eclipse-langium/langium/pull/288)).
+ * The `hidden` keyword of the grammar language is now used as modifier for terminals instead of following the top-level grammar declaration ([#288](https://github.com/eclipse-langium/langium/pull/288)).
    Instead of
    ```
    grammar Foo
@@ -80,17 +80,17 @@ This release brought several changes to the grammar language:
 
    hidden terminal WS: /\s+/;
    ```
- * Introduced a new `entry` keyword to explicitly mark the entry rule of the parser ([#305](https://github.com/langium/langium/pull/305)). Previously the first grammar rule was assumed to be the entry rule.
- * Changed the syntax of cross-references in the grammar ([#306](https://github.com/langium/langium/pull/306)). Instead of `property=[Type|TOKEN]`, you now write `property=[Type:TOKEN]`.
+ * Introduced a new `entry` keyword to explicitly mark the entry rule of the parser ([#305](https://github.com/eclipse-langium/langium/pull/305)). Previously the first grammar rule was assumed to be the entry rule.
+ * Changed the syntax of cross-references in the grammar ([#306](https://github.com/eclipse-langium/langium/pull/306)). Instead of `property=[Type|TOKEN]`, you now write `property=[Type:TOKEN]`.
 
 ---
 
 ## v0.2.0 (Nov. 2021)
 
  * Added features to the grammar editor:
-    * Folding ([#178](https://github.com/langium/langium/pull/178))
-    * Hover ([#182](https://github.com/langium/langium/pull/182))
-    * Code actions ([#190](https://github.com/langium/langium/pull/190))
-    * Renaming ([#191](https://github.com/langium/langium/pull/191))
- * Configured bracket matching for the editor ([#225](https://github.com/langium/langium/pull/225)).
- * Added JSON schema for `langium-config.json` files to support editing the Langium configuration ([#240](https://github.com/langium/langium/pull/240)).
+    * Folding ([#178](https://github.com/eclipse-langium/langium/pull/178))
+    * Hover ([#182](https://github.com/eclipse-langium/langium/pull/182))
+    * Code actions ([#190](https://github.com/eclipse-langium/langium/pull/190))
+    * Renaming ([#191](https://github.com/eclipse-langium/langium/pull/191))
+ * Configured bracket matching for the editor ([#225](https://github.com/eclipse-langium/langium/pull/225)).
+ * Added JSON schema for `langium-config.json` files to support editing the Langium configuration ([#240](https://github.com/eclipse-langium/langium/pull/240)).

--- a/packages/langium-vscode/README.md
+++ b/packages/langium-vscode/README.md
@@ -18,4 +18,4 @@ This extension contributes support for the [Langium](https://langium.org) gramma
 
 Langium grammar files can be visualised as syntax diagrams using the *Show Railroad Syntax Diagram* button that appears in the tab bar of `.langium` files.
 
-![Example Syntax Diagram](https://github.com/langium/langium/assets/4377073/fe50828b-2a2a-474e-b065-8a05b3ce23cf)
+![Example Syntax Diagram](https://github.com/eclipse-langium/langium/assets/4377073/fe50828b-2a2a-474e-b065-8a05b3ce23cf)

--- a/packages/langium-vscode/src/extension.ts
+++ b/packages/langium-vscode/src/extension.ts
@@ -16,7 +16,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     client = await startLanguageClient(context);
     registerRailroadWebview(client);
     // cs: TODO rework and update the template decoration feature, if feasible
-    //  see also https://github.com/langium/langium/issues/841
+    //  see also https://github.com/eclipse-langium/langium/issues/841
     // configureTemplateDecoration(context);
 }
 
@@ -75,7 +75,7 @@ async function startLanguageClient(context: vscode.ExtensionContext): Promise<La
 const DELAY = 100; // delay in ms until a render can be cancelled on subsequent document changes
 
 // cs: TODO
-// @ts-expect-error: deactivated the usage of this feature for Langium v1.0 (https://github.com/langium/langium/issues/841)
+// @ts-expect-error: deactivated the usage of this feature for Langium v1.0 (https://github.com/eclipse-langium/langium/issues/841)
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 function configureTemplateDecoration(context: vscode.ExtensionContext) {
     // define decoration type

--- a/packages/langium/CHANGELOG.md
+++ b/packages/langium/CHANGELOG.md
@@ -22,22 +22,22 @@ You can find a small instruction manual on how to migrate TypeScript projects to
 
 Note that the newest version of the yeoman generator contains a ready-to-use bundler configuration.
 Adopters can use the generated project as a basis for upgrading to 2.0.
-We also have [a guide available on our website](https://langium.org/guides/code-bundling/) that goes into more detail on this topic. If you have any questions on this topic, feel free to ask us on the [GitHub Discussions Board](https://github.com/langium/langium/discussions).
+We also have [a guide available on our website](https://langium.org/guides/code-bundling/) that goes into more detail on this topic. If you have any questions on this topic, feel free to ask us on the [GitHub Discussions Board](https://github.com/eclipse-langium/langium/discussions).
 
 ### General Improvements
 
-* The `DefaultDocumentBuilder` has been refactored to allow for more flexible and fine-grained validation behavior. ([#1094](https://github.com/langium/langium/pull/1094)).
+* The `DefaultDocumentBuilder` has been refactored to allow for more flexible and fine-grained validation behavior. ([#1094](https://github.com/eclipse-langium/langium/pull/1094)).
 
 ### Breaking Changes
 
-* The `CodeLensProvider`, `DocumentLinkProvider` and `InlayHintProvider` services were moved from the shared LSP services container to the language specific services container. Additionally, their `resolve` methods have been removed ([#1107](https://github.com/langium/langium/pull/1107)). 
-* Deprecated a few properties available on CST nodes. They have been renamed and their old property names will be deleted in a future version ([#1131](https://github.com/langium/langium/pull/1131)):
+* The `CodeLensProvider`, `DocumentLinkProvider` and `InlayHintProvider` services were moved from the shared LSP services container to the language specific services container. Additionally, their `resolve` methods have been removed ([#1107](https://github.com/eclipse-langium/langium/pull/1107)). 
+* Deprecated a few properties available on CST nodes. They have been renamed and their old property names will be deleted in a future version ([#1131](https://github.com/eclipse-langium/langium/pull/1131)):
     * `CstNode#parent` -> `container`
     * `CstNode#feature` -> `grammarSource`
     * `CstNode#element` -> `astNode`
     * `CompositeCstNode#children` -> `content`
-* The `IndexManager#getAffectedDocuments` has been changed to `isAffected`. Instead of returning a stream of all affected documents of a change, it now only returns whether a specified document is affected by the change of a set of documents ([#1094](https://github.com/langium/langium/pull/1094)).
-* The `BuildOptions#validationChecks` property has been replaced with `validation?: boolean | ValidationOptions` ([#1094](https://github.com/langium/langium/pull/1094)).
+* The `IndexManager#getAffectedDocuments` has been changed to `isAffected`. Instead of returning a stream of all affected documents of a change, it now only returns whether a specified document is affected by the change of a set of documents ([#1094](https://github.com/eclipse-langium/langium/pull/1094)).
+* The `BuildOptions#validationChecks` property has been replaced with `validation?: boolean | ValidationOptions` ([#1094](https://github.com/eclipse-langium/langium/pull/1094)).
 
 ---
 
@@ -61,10 +61,10 @@ Langium provides 2 new classes with [#1123](https://github.com/eclipse-langium/l
 
 ### General Improvements
 
-* The `DefaultCompletionProvider` has received some improvements and should be even more accurate now ([#1106](https://github.com/langium/langium/pull/1106), [#1138](https://github.com/langium/langium/pull/1138)).
-* Various performance improvements related to scoping and linking ([#1091](https://github.com/langium/langium/pull/1091), [#1121](https://github.com/langium/langium/pull/1121)).
-* The new `CommentProvider` serves as a way to override how the comment of an AST node is computed ([#1095](https://github.com/langium/langium/pull/1095)).
-* The LSP `workspace/symbol` request is now resolved by the `WorkspaceSymbolProvider` ([#1100](https://github.com/langium/langium/pull/1100)).
+* The `DefaultCompletionProvider` has received some improvements and should be even more accurate now ([#1106](https://github.com/eclipse-langium/langium/pull/1106), [#1138](https://github.com/eclipse-langium/langium/pull/1138)).
+* Various performance improvements related to scoping and linking ([#1091](https://github.com/eclipse-langium/langium/pull/1091), [#1121](https://github.com/eclipse-langium/langium/pull/1121)).
+* The new `CommentProvider` serves as a way to override how the comment of an AST node is computed ([#1095](https://github.com/eclipse-langium/langium/pull/1095)).
+* The LSP `workspace/symbol` request is now resolved by the `WorkspaceSymbolProvider` ([#1100](https://github.com/eclipse-langium/langium/pull/1100)).
 * Properties in guarded groups are now properly typed as optional ([#1116](https://github.com/eclipse-langium/langium/pull/1116)).
 * Some generated regular expressions are now more accurate ([#1109](https://github.com/eclipse-langium/langium/pull/1109)).
 * Generated language metadata is now being typed as `const` ([#1111](https://github.com/eclipse-langium/langium/pull/1111)).
@@ -76,20 +76,20 @@ Langium provides 2 new classes with [#1123](https://github.com/eclipse-langium/l
 
 ## v1.2.1 (Jun. 2023)
 
-Fixed a minor generator issue ([#1043](https://github.com/langium/langium/pull/1043)).
+Fixed a minor generator issue ([#1043](https://github.com/eclipse-langium/langium/pull/1043)).
 
 ## v1.2.0 (Apr. 2023)
 
 ### General Improvements
 
-* Improvements to the language testing process ([#1002](https://github.com/langium/langium/pull/1002), [#1008](https://github.com/langium/langium/pull/1008))
-* Fixed an issue related to cross references in the completion provider. ([#1004](https://github.com/langium/langium/pull/1004))
-* Fixed an issue related to document highlighting LSP requests for elements in other files. ([#1000](https://github.com/langium/langium/pull/1000))
+* Improvements to the language testing process ([#1002](https://github.com/eclipse-langium/langium/pull/1002), [#1008](https://github.com/eclipse-langium/langium/pull/1008))
+* Fixed an issue related to cross references in the completion provider. ([#1004](https://github.com/eclipse-langium/langium/pull/1004))
+* Fixed an issue related to document highlighting LSP requests for elements in other files. ([#1000](https://github.com/eclipse-langium/langium/pull/1000))
 
 ### Breaking Changes
 
-* The `DefaultReferences` service has had a few protected methods removed. They are no longer necessary. ([#1000](https://github.com/langium/langium/pull/1000))
-* The `expectFunction` exported from `langium/test` is now deprecated and will be removed in a future version. It is no longer necessary to use, as Langium will simply use the `node:assert` package for testing. ([#1008](https://github.com/langium/langium/pull/1008))
+* The `DefaultReferences` service has had a few protected methods removed. They are no longer necessary. ([#1000](https://github.com/eclipse-langium/langium/pull/1000))
+* The `expectFunction` exported from `langium/test` is now deprecated and will be removed in a future version. It is no longer necessary to use, as Langium will simply use the `node:assert` package for testing. ([#1008](https://github.com/eclipse-langium/langium/pull/1008))
 
 ## v1.1.0 (Feb. 2023)
 
@@ -98,7 +98,7 @@ Fixed a minor generator issue ([#1043](https://github.com/langium/langium/pull/1
 Langium now features built-in [JSDoc](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html) support.
 The feature parses comment nodes that belong to a given AST node and returns structured information that can be used for further computations or printed to markdown for language server functionalities.
 
-The recommended way to use the feature is to invoke the new [`DocumentationProviderService`](https://github.com/langium/langium/blob/9493cdb10de0c9a79195485d5bd0208d20b55ec6/packages/langium/src/documentation/documentation-provider.ts).
+The recommended way to use the feature is to invoke the new [`DocumentationProviderService`](https://github.com/eclipse-langium/langium/blob/9493cdb10de0c9a79195485d5bd0208d20b55ec6/packages/langium/src/documentation/documentation-provider.ts).
 For more complex use cases, you can call `parseJSDoc` directly.
 
 ### Generator Tracing
@@ -108,18 +108,18 @@ Tracing allows developers to connect the generated statements with the position 
 
 This can be used to build [source maps](https://firefox-source-docs.mozilla.org/devtools-user/debugger/how_to/use_a_source_map/index.html) (known from the TypeScript compiler) or other source mappings formats.
 
-Usage of the tracing API can be seen [here](https://github.com/langium/langium/blob/9493cdb10de0c9a79195485d5bd0208d20b55ec6/packages/langium/test/generator/generation-tracing.test.ts).
+Usage of the tracing API can be seen [here](https://github.com/eclipse-langium/langium/blob/9493cdb10de0c9a79195485d5bd0208d20b55ec6/packages/langium/test/generator/generation-tracing.test.ts).
 
 ### Other New Features
 
-* Support for the language server inlay hint API ([#906](https://github.com/langium/langium/pull/906)).
-* Terminal definitions can now use positive and negative lookahead for more fine-grained lexer behavior ([#917](https://github.com/langium/langium/pull/917)).
+* Support for the language server inlay hint API ([#906](https://github.com/eclipse-langium/langium/pull/906)).
+* Terminal definitions can now use positive and negative lookahead for more fine-grained lexer behavior ([#917](https://github.com/eclipse-langium/langium/pull/917)).
 
 ### General Improvements
 
-* Improved default handling for escaped characters in strings ([#888](https://github.com/langium/langium/pull/888)).
-* Made the completion provider more resilient to errors in the input document ([#854](https://github.com/langium/langium/pull/854)).
-* Completion providers can now return server capability options (#[935](https://github.com/langium/langium/pull/935)).
+* Improved default handling for escaped characters in strings ([#888](https://github.com/eclipse-langium/langium/pull/888)).
+* Made the completion provider more resilient to errors in the input document ([#854](https://github.com/eclipse-langium/langium/pull/854)).
+* Completion providers can now return server capability options (#[935](https://github.com/eclipse-langium/langium/pull/935)).
 
 ### Breaking Changes
 
@@ -128,8 +128,8 @@ Usage of the tracing API can be seen [here](https://github.com/langium/langium/b
 
 ## v1.0.1 (Dec. 2022)
 
- * Add type validation with respect to the hierarchy ([#840](https://github.com/langium/langium/pull/840))
- * Correctly sort types topologically ([#850](https://github.com/langium/langium/pull/850))
+ * Add type validation with respect to the hierarchy ([#840](https://github.com/eclipse-langium/langium/pull/840))
+ * Correctly sort types topologically ([#850](https://github.com/eclipse-langium/langium/pull/850))
 
 ## v1.0.0 (Dec. 2022) 🎉
 
@@ -147,30 +147,30 @@ You can still switch back to the _LL(k)_ algorithm that is shipped with Chevrota
 
 ### Extended Code Generator Support
 
-There is a new API to support generating code from your AST ([#825](https://github.com/langium/langium/pull/825)). It works by constructing a tree structure (`GeneratorNode`) that gathers all the text snippets in its leafs. The tree can be serialized with the exported `toString` function.
+There is a new API to support generating code from your AST ([#825](https://github.com/eclipse-langium/langium/pull/825)). It works by constructing a tree structure (`GeneratorNode`) that gathers all the text snippets in its leafs. The tree can be serialized with the exported `toString` function.
 
-The code generator infrastructure also brings two template string tag functions: `expandToString` removes leading whitespace to produce well-readable output code as a string, and `expandToNode` does the same while creating a `GeneratorNode` tree. A good example of the usefulness of these functions is in the [C++ code generator of the statemachine language](https://github.com/langium/langium/blob/main/examples/statemachine/src/cli/generator.ts).
+The code generator infrastructure also brings two template string tag functions: `expandToString` removes leading whitespace to produce well-readable output code as a string, and `expandToNode` does the same while creating a `GeneratorNode` tree. A good example of the usefulness of these functions is in the [C++ code generator of the statemachine language](https://github.com/eclipse-langium/langium/blob/main/examples/statemachine/src/cli/generator.ts).
 
 In a later release, we are going to add tracing support to generator trees. This will enable generating source maps, which are the basis for debugging in your language.
 
 ### Other New Features
 
- * Added `Lexer` service to enable customizing the lexer ([#721](https://github.com/langium/langium/pull/721)).
- * Added support for [code lens](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_codeLens) ([#722](https://github.com/langium/langium/pull/722)).
- * Added support for [go to declaration](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_declaration) ([#734](https://github.com/langium/langium/pull/734)).
+ * Added `Lexer` service to enable customizing the lexer ([#721](https://github.com/eclipse-langium/langium/pull/721)).
+ * Added support for [code lens](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_codeLens) ([#722](https://github.com/eclipse-langium/langium/pull/722)).
+ * Added support for [go to declaration](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_declaration) ([#734](https://github.com/eclipse-langium/langium/pull/734)).
 
 ### General Improvements
 
- * Improved completion API and implemented fuzzy matching ([#739](https://github.com/langium/langium/pull/739)).
- * Simplified programmatic construction of ASTs with references ([#774](https://github.com/langium/langium/pull/774)).
- * New reference format in JSON serializer enables to export ASTs to other processes or applications ([#787](https://github.com/langium/langium/pull/787)).
- * The `LangiumDocumentFactory` can now update the content of a `LangiumDocument` by reparsing its text ([#801](https://github.com/langium/langium/pull/801)). This means that an instance of a document remains valid after a text change.
+ * Improved completion API and implemented fuzzy matching ([#739](https://github.com/eclipse-langium/langium/pull/739)).
+ * Simplified programmatic construction of ASTs with references ([#774](https://github.com/eclipse-langium/langium/pull/774)).
+ * New reference format in JSON serializer enables to export ASTs to other processes or applications ([#787](https://github.com/eclipse-langium/langium/pull/787)).
+ * The `LangiumDocumentFactory` can now update the content of a `LangiumDocument` by reparsing its text ([#801](https://github.com/eclipse-langium/langium/pull/801)). This means that an instance of a document remains valid after a text change.
 
 ### Breaking Changes
 
- * Changed the generated `{LanguageName}AstType` (in `ast.ts`) from an enumeration of string types to an object type mapping AST type names to their type declarations ([#738](https://github.com/langium/langium/pull/738)).
- * Changed the customization API of `DefaultCompletionProvider` ([#739](https://github.com/langium/langium/pull/739)).
- * Reworked the code generator API ([#825](https://github.com/langium/langium/pull/825)).
+ * Changed the generated `{LanguageName}AstType` (in `ast.ts`) from an enumeration of string types to an object type mapping AST type names to their type declarations ([#738](https://github.com/eclipse-langium/langium/pull/738)).
+ * Changed the customization API of `DefaultCompletionProvider` ([#739](https://github.com/eclipse-langium/langium/pull/739)).
+ * Reworked the code generator API ([#825](https://github.com/eclipse-langium/langium/pull/825)).
 
 ---
 
@@ -178,31 +178,31 @@ In a later release, we are going to add tracing support to generator trees. This
 
 ### New Features
 
- * Added support for [configuration changes](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_didChangeConfiguration) ([#519](https://github.com/langium/langium/pull/519)). This can be used to synchronize the language server with VS Code settings.
- * Added support for [executing commands](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_executeCommand) ([#592](https://github.com/langium/langium/pull/592)).
- * Added support for [signature help](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_signatureHelp) ([#612](https://github.com/langium/langium/pull/612)).
- * Added support for [go to type definition](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_typeDefinition) ([#618](https://github.com/langium/langium/pull/618)).
- * Added support for [go to implementation](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_implementation) ([#627](https://github.com/langium/langium/pull/627)).
- * Added support for [call hierarchy](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#callHierarchy_incomingCalls) ([#643](https://github.com/langium/langium/pull/643)).
- * Added support for [document links](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_documentLink) ([#688](https://github.com/langium/langium/pull/688)).
+ * Added support for [configuration changes](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_didChangeConfiguration) ([#519](https://github.com/eclipse-langium/langium/pull/519)). This can be used to synchronize the language server with VS Code settings.
+ * Added support for [executing commands](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_executeCommand) ([#592](https://github.com/eclipse-langium/langium/pull/592)).
+ * Added support for [signature help](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_signatureHelp) ([#612](https://github.com/eclipse-langium/langium/pull/612)).
+ * Added support for [go to type definition](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_typeDefinition) ([#618](https://github.com/eclipse-langium/langium/pull/618)).
+ * Added support for [go to implementation](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_implementation) ([#627](https://github.com/eclipse-langium/langium/pull/627)).
+ * Added support for [call hierarchy](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#callHierarchy_incomingCalls) ([#643](https://github.com/eclipse-langium/langium/pull/643)).
+ * Added support for [document links](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_documentLink) ([#688](https://github.com/eclipse-langium/langium/pull/688)).
 
 ### General Improvements
 
- * Improved handling of language server initialization and document changes ([#549](https://github.com/langium/langium/pull/549), [#553](https://github.com/langium/langium/pull/553), [#558](https://github.com/langium/langium/pull/558), [#593](https://github.com/langium/langium/pull/593)).
- * Refactored parts of the code so [Langium can run in the browser](https://www.typefox.io/blog/langium-web-browser) ([#568](https://github.com/langium/langium/pull/568)).
- * Reimplemented the completion provider for more reliable results ([#623](https://github.com/langium/langium/pull/623)).
- * Added a method `createScopeForNodes` to the `DefaultScopeProvider` class to be used in customizing subclasses ([#665](https://github.com/langium/langium/pull/665)). The method can create a stream-based scope from a collection (array, stream etc.) of AST nodes.
- * The default completion service hides non-alphabetic keywords like `.`, `(`, `+` etc. ([#697](https://github.com/langium/langium/pull/697)).
+ * Improved handling of language server initialization and document changes ([#549](https://github.com/eclipse-langium/langium/pull/549), [#553](https://github.com/eclipse-langium/langium/pull/553), [#558](https://github.com/eclipse-langium/langium/pull/558), [#593](https://github.com/eclipse-langium/langium/pull/593)).
+ * Refactored parts of the code so [Langium can run in the browser](https://www.typefox.io/blog/langium-web-browser) ([#568](https://github.com/eclipse-langium/langium/pull/568)).
+ * Reimplemented the completion provider for more reliable results ([#623](https://github.com/eclipse-langium/langium/pull/623)).
+ * Added a method `createScopeForNodes` to the `DefaultScopeProvider` class to be used in customizing subclasses ([#665](https://github.com/eclipse-langium/langium/pull/665)). The method can create a stream-based scope from a collection (array, stream etc.) of AST nodes.
+ * The default completion service hides non-alphabetic keywords like `.`, `(`, `+` etc. ([#697](https://github.com/eclipse-langium/langium/pull/697)).
 
 ### Breaking Changes
 
- * Renamed "preprocessing" phase of the document builder to "scope computation" ([#622](https://github.com/langium/langium/pull/622)). Accordingly, the `Processed` document state was renamed to `ComputedScopes`.
- * Changed signature of the `ScopeProvider` service: the method `getScope(node: AstNode, referenceId: string)` now has a single argument `getScope(context: ReferenceInfo)` ([#641](https://github.com/langium/langium/pull/641)). If you have overridden that service, you need to update the signature; you can get the AST node via `context.container`.
- * Moved the `createDescriptions` method used for indexing from the `AstNodeDescriptionProvider` service to `ScopeComputation` and renamed it to `computeExports` ([#664](https://github.com/langium/langium/pull/664)). If you have overridden that method, you need to move it to a different class accordingly.
- * Renamed the `computeScope` method of the `ScopeComputation` service to `computeLocalScopes` ([#664](https://github.com/langium/langium/pull/664)). If you have overridden that method, you need to rename it accordingly.
- * Moved the `CompletionProvider` service declaration from the group `lsp.completion` to `lsp` ([#623](https://github.com/langium/langium/pull/623)). This needs to be changed in your dependency injection module in case you have overridden that service.
- * Removed several declarations from the package index because they are meant to be used by the Langium Grammar language implementation ([#689](https://github.com/langium/langium/pull/689), [#703](https://github.com/langium/langium/pull/703)).
- * Definitions of the Langium Grammar language are wrapped in the `GrammarAST` namespace ([#703](https://github.com/langium/langium/pull/703)).
+ * Renamed "preprocessing" phase of the document builder to "scope computation" ([#622](https://github.com/eclipse-langium/langium/pull/622)). Accordingly, the `Processed` document state was renamed to `ComputedScopes`.
+ * Changed signature of the `ScopeProvider` service: the method `getScope(node: AstNode, referenceId: string)` now has a single argument `getScope(context: ReferenceInfo)` ([#641](https://github.com/eclipse-langium/langium/pull/641)). If you have overridden that service, you need to update the signature; you can get the AST node via `context.container`.
+ * Moved the `createDescriptions` method used for indexing from the `AstNodeDescriptionProvider` service to `ScopeComputation` and renamed it to `computeExports` ([#664](https://github.com/eclipse-langium/langium/pull/664)). If you have overridden that method, you need to move it to a different class accordingly.
+ * Renamed the `computeScope` method of the `ScopeComputation` service to `computeLocalScopes` ([#664](https://github.com/eclipse-langium/langium/pull/664)). If you have overridden that method, you need to rename it accordingly.
+ * Moved the `CompletionProvider` service declaration from the group `lsp.completion` to `lsp` ([#623](https://github.com/eclipse-langium/langium/pull/623)). This needs to be changed in your dependency injection module in case you have overridden that service.
+ * Removed several declarations from the package index because they are meant to be used by the Langium Grammar language implementation ([#689](https://github.com/eclipse-langium/langium/pull/689), [#703](https://github.com/eclipse-langium/langium/pull/703)).
+ * Definitions of the Langium Grammar language are wrapped in the `GrammarAST` namespace ([#703](https://github.com/eclipse-langium/langium/pull/703)).
 
 ---
 
@@ -210,7 +210,7 @@ In a later release, we are going to add tracing support to generator trees. This
 
 ### Formatting
 
-Langium now features an API to configure formatting of your language ([#479](https://github.com/langium/langium/pull/479)). To use this feature, you need to implement a subclass of `AbstractFormatter` and register it to the `lsp.Formatter` service:
+Langium now features an API to configure formatting of your language ([#479](https://github.com/eclipse-langium/langium/pull/479)). To use this feature, you need to implement a subclass of `AbstractFormatter` and register it to the `lsp.Formatter` service:
 ```typescript
 export class MyDSLFormatter extends AbstractFormatter {
     protected format(node: AstNode): void {
@@ -226,15 +226,15 @@ const bracesClose = formatter.keyword('}');
 bracesClose.prepend(Formatting.newLine());
 ```
 
-See the [domain model formatter](https://github.com/langium/langium/blob/main/examples/domainmodel/src/language-server/domain-model-formatter.ts) for a full example.
+See the [domain model formatter](https://github.com/eclipse-langium/langium/blob/main/examples/domainmodel/src/language-server/domain-model-formatter.ts) for a full example.
 
 ### Further Improvements
 
- * [Unordered groups](https://langium.org/docs/grammar-language/#unordered-groups) are supported in the grammar ([#522](https://github.com/langium/langium/pull/522)).
- * `Date` and `bigint` data types are supported in the grammar ([#508](https://github.com/langium/langium/pull/508)).
- * AST properties of type `boolean` are initialized to `false` even when they are not assigned a value during parsing ([#469](https://github.com/langium/langium/pull/469)).
- * The JavaScript code compiled from the TypeScript sources is now compatible to ES2017 (previously ES2015), so `async` and `await` keywords are preserved ([#495](https://github.com/langium/langium/pull/495)).
- * An API for testing validation checks is now available ([#506](https://github.com/langium/langium/pull/506)).
+ * [Unordered groups](https://langium.org/docs/grammar-language/#unordered-groups) are supported in the grammar ([#522](https://github.com/eclipse-langium/langium/pull/522)).
+ * `Date` and `bigint` data types are supported in the grammar ([#508](https://github.com/eclipse-langium/langium/pull/508)).
+ * AST properties of type `boolean` are initialized to `false` even when they are not assigned a value during parsing ([#469](https://github.com/eclipse-langium/langium/pull/469)).
+ * The JavaScript code compiled from the TypeScript sources is now compatible to ES2017 (previously ES2015), so `async` and `await` keywords are preserved ([#495](https://github.com/eclipse-langium/langium/pull/495)).
+ * An API for testing validation checks is now available ([#506](https://github.com/eclipse-langium/langium/pull/506)).
 
 ---
 
@@ -242,7 +242,7 @@ See the [domain model formatter](https://github.com/langium/langium/blob/main/ex
 
 ### Multi-Language Support
 
-Langium now supports multiple languages running in the same language server ([#311](https://github.com/langium/langium/pull/311)). This works by splitting the dependency injection container in two sets of services: the _shared_ services and the _language-specific_ services. When an LSP request is received from the client, the `ServiceRegistry` is used to decide which language is responsible for a given document by looking at its file extension.
+Langium now supports multiple languages running in the same language server ([#311](https://github.com/eclipse-langium/langium/pull/311)). This works by splitting the dependency injection container in two sets of services: the _shared_ services and the _language-specific_ services. When an LSP request is received from the client, the `ServiceRegistry` is used to decide which language is responsible for a given document by looking at its file extension.
 
 A grammar file can use declarations from other grammar files by importing them. This is useful for organizing large grammars and for using common grammar rules in multiple languages. Imports are written with a relative path similarly to TypeScript:
 ```
@@ -250,11 +250,11 @@ import './expressions';
 ```
 This makes all declarations of the file `expressions.langium` available in the current grammar.
 
-The `grammar` declaration at the beginning of a grammar file is now optional unless the file is used as entry point for the language ([#381](https://github.com/langium/langium/pull/381)).
+The `grammar` declaration at the beginning of a grammar file is now optional unless the file is used as entry point for the language ([#381](https://github.com/eclipse-langium/langium/pull/381)).
 
 ### Type Declarations in the Grammar
 
-Langium is able to infer TypeScript types from your grammar rules by looking at the property assignments, actions and rule calls. This is very useful for the initial development of your language syntax, supporting rapid prototyping. For more mature language projects, however, it is advisable to declare the AST types explicitly because a large part of your code base depends on it: type system, validation, code generator etc. We introduced a new syntax so you can declare types directly in the grammar language and use them in your grammar rules ([#406](https://github.com/langium/langium/pull/406)).
+Langium is able to infer TypeScript types from your grammar rules by looking at the property assignments, actions and rule calls. This is very useful for the initial development of your language syntax, supporting rapid prototyping. For more mature language projects, however, it is advisable to declare the AST types explicitly because a large part of your code base depends on it: type system, validation, code generator etc. We introduced a new syntax so you can declare types directly in the grammar language and use them in your grammar rules ([#406](https://github.com/eclipse-langium/langium/pull/406)).
 
 The syntax is very similar to TypeScript:
 ```
@@ -268,26 +268,26 @@ type Symbol = Entity | PackageDeclaration | DataType | Feature
 ```
 The `interface` form describes the properties of an AST node type. The `@` character used at the `superType` property above denotes a cross-reference to a node of type `Entity`. The `type` form creates _union types_, i.e. an alternative of other declared or inferred types. These are transferred almost identically to TypeScript, where they have [their usual meaning](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html).
 
-Parser rules which use the `returns` directive to infer a new type should now use the `infers` keyword instead. Using `returns` is only valid for explicitly declared types ([#438](https://github.com/langium/langium/pull/438)). Actions need to add the `infer` keyword in front of the type if it is not explicitly declared.
+Parser rules which use the `returns` directive to infer a new type should now use the `infers` keyword instead. Using `returns` is only valid for explicitly declared types ([#438](https://github.com/eclipse-langium/langium/pull/438)). Actions need to add the `infer` keyword in front of the type if it is not explicitly declared.
 
 ### New Sprotty Integration
 
-A new package `langium-sprotty` is available to enable [Sprotty](https://github.com/eclipse/sprotty)-powered diagrams generated from a Langium DSL ([#308](https://github.com/langium/langium/pull/308)). An example is presented [in this blog post](https://www.typefox.io/blog/langium-meets-sprotty-combining-text-and-diagrams-in-vs-code).
+A new package `langium-sprotty` is available to enable [Sprotty](https://github.com/eclipse/sprotty)-powered diagrams generated from a Langium DSL ([#308](https://github.com/eclipse-langium/langium/pull/308)). An example is presented [in this blog post](https://www.typefox.io/blog/langium-meets-sprotty-combining-text-and-diagrams-in-vs-code).
 
 ### Further Improvements
 
- * In addition to regular expressions, terminals now feature an [_extended backus-naur form_](https://langium.org/docs/grammar-language/#more-on-terminal-rules) that enables composition of terminal rules ([#288](https://github.com/langium/langium/pull/288)).
- * We no longer assume that a terminal rule named `ID` is present when a cross-reference is defined without an explicit token ([#341](https://github.com/langium/langium/pull/341)). Instead, we derive the terminal or data type rule to use for the cross-reference from an assignment to the `name` property in the referenced grammar rule. This is not always possible, so in certain cases the cross-reference token must be stated explicitly, which is enforced by a validation.
- * Added an API for [semantic token highlighting](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_semanticTokens) ([#345](https://github.com/langium/langium/pull/345)).
- * Implemented support for [guarded parser rules](https://langium.org/docs/grammar-language/#guarded-rules) ([#346](https://github.com/langium/langium/pull/346), [#422](https://github.com/langium/langium/pull/422)).
- * Added `$containerProperty` and `$containerIndex` properties to `AstNode`, enabling the inclusion of programmatically created documents in the index ([#354](https://github.com/langium/langium/pull/354)).
- * Added a new `WorkspaceManager` service to be overridden if you want to specialize where the source files are found or to add programmatic documents to the index ([#377](https://github.com/langium/langium/pull/377)).
- * Extracted file system access to a single service to minimize dependencies to Node.js ([#405](https://github.com/langium/langium/pull/405)). This will ease using Langium in a web browser.
- * Added ability to use a multi-mode lexer ([#398](https://github.com/langium/langium/pull/398)).
+ * In addition to regular expressions, terminals now feature an [_extended backus-naur form_](https://langium.org/docs/grammar-language/#more-on-terminal-rules) that enables composition of terminal rules ([#288](https://github.com/eclipse-langium/langium/pull/288)).
+ * We no longer assume that a terminal rule named `ID` is present when a cross-reference is defined without an explicit token ([#341](https://github.com/eclipse-langium/langium/pull/341)). Instead, we derive the terminal or data type rule to use for the cross-reference from an assignment to the `name` property in the referenced grammar rule. This is not always possible, so in certain cases the cross-reference token must be stated explicitly, which is enforced by a validation.
+ * Added an API for [semantic token highlighting](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_semanticTokens) ([#345](https://github.com/eclipse-langium/langium/pull/345)).
+ * Implemented support for [guarded parser rules](https://langium.org/docs/grammar-language/#guarded-rules) ([#346](https://github.com/eclipse-langium/langium/pull/346), [#422](https://github.com/eclipse-langium/langium/pull/422)).
+ * Added `$containerProperty` and `$containerIndex` properties to `AstNode`, enabling the inclusion of programmatically created documents in the index ([#354](https://github.com/eclipse-langium/langium/pull/354)).
+ * Added a new `WorkspaceManager` service to be overridden if you want to specialize where the source files are found or to add programmatic documents to the index ([#377](https://github.com/eclipse-langium/langium/pull/377)).
+ * Extracted file system access to a single service to minimize dependencies to Node.js ([#405](https://github.com/eclipse-langium/langium/pull/405)). This will ease using Langium in a web browser.
+ * Added ability to use a multi-mode lexer ([#398](https://github.com/eclipse-langium/langium/pull/398)).
 
 ### Breaking Changes
 
- * The `hidden` keyword of the grammar language is now used as modifier for terminals instead of following the top-level grammar declaration ([#288](https://github.com/langium/langium/pull/288)).
+ * The `hidden` keyword of the grammar language is now used as modifier for terminals instead of following the top-level grammar declaration ([#288](https://github.com/eclipse-langium/langium/pull/288)).
    Instead of
    ```
    grammar Foo
@@ -301,12 +301,12 @@ A new package `langium-sprotty` is available to enable [Sprotty](https://github.
 
    hidden terminal WS: /\s+/;
    ```
- * Introduced a new `entry` keyword to explicitly mark the entry rule of the parser ([#305](https://github.com/langium/langium/pull/305)). Previously the first grammar rule was assumed to be the entry rule.
- * Changed the syntax of cross-references in the grammar ([#306](https://github.com/langium/langium/pull/306)). Instead of `property=[Type|TOKEN]`, you now write `property=[Type:TOKEN]`.
- * Parser rules with a non-primitive `returns` type must be changed to use the `infers` keyword instead ([#438](https://github.com/langium/langium/pull/438), [#445](https://github.com/langium/langium/pull/445)), unless the type is declared explicitly.
- * Actions in parser rules need the `infer` keyword ([#438](https://github.com/langium/langium/pull/438)), unless the type is declared explicitly.
- * Some dependency injection services were moved to the new _shared services_ container ([#311](https://github.com/langium/langium/pull/311)), especially the `LangiumDocuments` and `DocumentBuilder`.
- * Numerous breaking API improvements that cannot be all mentioned here. If you're unsure how to migrate your code, please ask in [Discussions](https://github.com/langium/langium/discussions).
+ * Introduced a new `entry` keyword to explicitly mark the entry rule of the parser ([#305](https://github.com/eclipse-langium/langium/pull/305)). Previously the first grammar rule was assumed to be the entry rule.
+ * Changed the syntax of cross-references in the grammar ([#306](https://github.com/eclipse-langium/langium/pull/306)). Instead of `property=[Type|TOKEN]`, you now write `property=[Type:TOKEN]`.
+ * Parser rules with a non-primitive `returns` type must be changed to use the `infers` keyword instead ([#438](https://github.com/eclipse-langium/langium/pull/438), [#445](https://github.com/eclipse-langium/langium/pull/445)), unless the type is declared explicitly.
+ * Actions in parser rules need the `infer` keyword ([#438](https://github.com/eclipse-langium/langium/pull/438)), unless the type is declared explicitly.
+ * Some dependency injection services were moved to the new _shared services_ container ([#311](https://github.com/eclipse-langium/langium/pull/311)), especially the `LangiumDocuments` and `DocumentBuilder`.
+ * Numerous breaking API improvements that cannot be all mentioned here. If you're unsure how to migrate your code, please ask in [Discussions](https://github.com/eclipse-langium/langium/discussions).
 
 ### Migrating from v0.2.0
 
@@ -358,34 +358,34 @@ A new package `langium-sprotty` is available to enable [Sprotty](https://github.
 
 ### Cross-File Linking
 
-Cross-references can now be resolved between files. This works by introducing an _indexing_ phase where exported symbols are gathered from each document and made available in the _global scope_ ([#172](https://github.com/langium/langium/pull/172)). The default implementation exports the top-level AST elements that have a `name` property (the elements directly contained by the root of the AST), but this can be customized. The `ScopeProvider` service used to resolve cross-references first looks into locally defined symbols (from the same document), and falls back to the global scope when there is no local matching symbol.
+Cross-references can now be resolved between files. This works by introducing an _indexing_ phase where exported symbols are gathered from each document and made available in the _global scope_ ([#172](https://github.com/eclipse-langium/langium/pull/172)). The default implementation exports the top-level AST elements that have a `name` property (the elements directly contained by the root of the AST), but this can be customized. The `ScopeProvider` service used to resolve cross-references first looks into locally defined symbols (from the same document), and falls back to the global scope when there is no local matching symbol.
 
-The language server listens for file changes and updates documents and their exported symbols whenever a modification is reported by the client ([#271](https://github.com/langium/langium/pull/271), [#278](https://github.com/langium/langium/pull/278)).
+The language server listens for file changes and updates documents and their exported symbols whenever a modification is reported by the client ([#271](https://github.com/eclipse-langium/langium/pull/271), [#278](https://github.com/eclipse-langium/langium/pull/278)).
 
 ### Asynchronous Processing
 
-All LSP message processing is now potentially asynchronous, which enables longer-running operations to be cancelled ([#244](https://github.com/langium/langium/pull/244), [#269](https://github.com/langium/langium/pull/269)). This works by calling the utility function `interruptAndCheck`, which uses [`setImmediate`](https://nodejs.org/docs/latest-v15.x/api/timers.html#timers_setimmediate_callback_args) to interrupt the current execution so other incoming messages can be processed, and throws the `OperationCanceled` symbol when cancellation is indicated.
+All LSP message processing is now potentially asynchronous, which enables longer-running operations to be cancelled ([#244](https://github.com/eclipse-langium/langium/pull/244), [#269](https://github.com/eclipse-langium/langium/pull/269)). This works by calling the utility function `interruptAndCheck`, which uses [`setImmediate`](https://nodejs.org/docs/latest-v15.x/api/timers.html#timers_setimmediate_callback_args) to interrupt the current execution so other incoming messages can be processed, and throws the `OperationCanceled` symbol when cancellation is indicated.
 
 This is particularly important for the `DocumentBuilder` service, which is used to update documents and the index when change notifications are received. Cancellation ensures that the language server does not do unnecessary work when the user is modifying a document in a large workspace.
 
 ### Interpreted Parser
 
-The parser is no longer generated by `langium-cli`, but constructed in-memory when the Langium application starts ([#169](https://github.com/langium/langium/pull/169)). This works by interpreting the grammar and building the parser via [Chevrotain](https://chevrotain.io/docs/)'s API. As a result, the whole infrastructure could be greatly simplified and now allows more fine-grained control over the lexing and parsing steps.
+The parser is no longer generated by `langium-cli`, but constructed in-memory when the Langium application starts ([#169](https://github.com/eclipse-langium/langium/pull/169)). This works by interpreting the grammar and building the parser via [Chevrotain](https://chevrotain.io/docs/)'s API. As a result, the whole infrastructure could be greatly simplified and now allows more fine-grained control over the lexing and parsing steps.
 
 ### Further Improvements
 
- * Introduced a testing API that enables unit tests for LSP features of your language ([#179](https://github.com/langium/langium/pull/179)).
+ * Introduced a testing API that enables unit tests for LSP features of your language ([#179](https://github.com/eclipse-langium/langium/pull/179)).
  * Added API and default implementation for more LSP features:
-    * [Folding](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_foldingRange) ([#178](https://github.com/langium/langium/pull/178))
-    * [Hover](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_hover) ([#182](https://github.com/langium/langium/pull/182))
-    * [Code actions](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_codeAction) ([#190](https://github.com/langium/langium/pull/190))
-    * [Renaming](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_rename) ([#191](https://github.com/langium/langium/pull/191))
- * Terminal rules for comments are automatically detected and considered in syntax highlighting and other features ([#247](https://github.com/langium/langium/pull/247)).
- * You can now override the default linking of cross-references and generate custom error messages ([#256](https://github.com/langium/langium/pull/256), [#274](https://github.com/langium/langium/pull/274)), for example to realize function overloading.
+    * [Folding](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_foldingRange) ([#178](https://github.com/eclipse-langium/langium/pull/178))
+    * [Hover](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_hover) ([#182](https://github.com/eclipse-langium/langium/pull/182))
+    * [Code actions](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_codeAction) ([#190](https://github.com/eclipse-langium/langium/pull/190))
+    * [Renaming](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_rename) ([#191](https://github.com/eclipse-langium/langium/pull/191))
+ * Terminal rules for comments are automatically detected and considered in syntax highlighting and other features ([#247](https://github.com/eclipse-langium/langium/pull/247)).
+ * You can now override the default linking of cross-references and generate custom error messages ([#256](https://github.com/eclipse-langium/langium/pull/256), [#274](https://github.com/eclipse-langium/langium/pull/274)), for example to realize function overloading.
 
 ### Breaking Changes
 
- * The API for generating code was improved ([#122](https://github.com/langium/langium/pull/122)).
- * The `GrammarAccess` service was removed because it was used mainly by the discontinued generated parser ([#169](https://github.com/langium/langium/pull/169)).
- * We now use the URI object from `vscode-uri` instead of plain strings ([#221](https://github.com/langium/langium/pull/221)).
- * Enhanced `Stream` API and removed `ArrayLikeStream` ([#257](https://github.com/langium/langium/pull/257)).
+ * The API for generating code was improved ([#122](https://github.com/eclipse-langium/langium/pull/122)).
+ * The `GrammarAccess` service was removed because it was used mainly by the discontinued generated parser ([#169](https://github.com/eclipse-langium/langium/pull/169)).
+ * We now use the URI object from `vscode-uri` instead of plain strings ([#221](https://github.com/eclipse-langium/langium/pull/221)).
+ * Enhanced `Stream` API and removed `ArrayLikeStream` ([#257](https://github.com/eclipse-langium/langium/pull/257)).

--- a/packages/langium/README.md
+++ b/packages/langium/README.md
@@ -47,4 +47,4 @@ The main code of Langium consists of a set of services that are connected via de
 
 ## Examples
 
-The source repository of Langium includes [examples](https://github.com/langium/langium/tree/main/examples) that demonstrate different use cases.
+The source repository of Langium includes [examples](https://github.com/eclipse-langium/langium/tree/main/examples) that demonstrate different use cases.

--- a/packages/langium/test/grammar/type-system/inferred-types.test.ts
+++ b/packages/langium/test/grammar/type-system/inferred-types.test.ts
@@ -440,7 +440,7 @@ describe('expression rules with inferred and declared interfaces', () => {
         `);
     });
 
-    // todo make tests like in this PR: https://github.com/langium/langium/pull/670
+    // todo make tests like in this PR: https://github.com/eclipse-langium/langium/pull/670
     // the PR #670 fixes the demonstrated bug, but cancels type inferrence for declared actions
     // we should fix the issue another way
     async function checkTypes(grammar: string): Promise<void> {
@@ -799,7 +799,7 @@ describe('types of `$container` and `$type` are correct', () => {
     });
 });
 
-// https://github.com/langium/langium/issues/744
+// https://github.com/eclipse-langium/langium/issues/744
 describe('generated types from declared types include all of them', () => {
 
     test('using declared types has no impact on the generated types', async () => {
@@ -830,7 +830,7 @@ describe('generated types from declared types include all of them', () => {
 
 });
 
-// TODO @msujew: Test case for https://github.com/langium/langium/issues/775
+// TODO @msujew: Test case for https://github.com/eclipse-langium/langium/issues/775
 // describe('type merging runs in non-exponential time', () => {
 //
 //     test('grammar with many optional groups is processed correctly', async () => {

--- a/packages/langium/test/grammar/type-system/type-validator.test.ts
+++ b/packages/langium/test/grammar/type-system/type-validator.test.ts
@@ -484,7 +484,7 @@ describe('Property type is not a mix of cross-ref and non-cross-ref types.', () 
     });
 });
 
-// https://github.com/langium/langium/issues/823
+// https://github.com/eclipse-langium/langium/issues/823
 describe('Property types validation takes in account types hierarchy', () => {
 
     test('Type aliases can be assigned to primitive types.', async () => {

--- a/packages/langium/test/validation/document-validator.test.ts
+++ b/packages/langium/test/validation/document-validator.test.ts
@@ -11,7 +11,7 @@ import { Position, Range } from 'vscode-languageserver';
 import { createServicesForGrammar } from 'langium';
 import { validationHelper } from 'langium/test';
 
-// Related to https://github.com/langium/langium/issues/571
+// Related to https://github.com/eclipse-langium/langium/issues/571
 describe('Parser error is thrown on resynced token with NaN position', () => {
 
     const grammar = `grammar HelloWorld


### PR DESCRIPTION
Most links were outdated, with some like the build pipeline straight up just not working. Also added a paragraph about the ECA that needs to be signed.