### PR TITLE
set diagram server manager fields to protected

### DIFF
--- a/packages/langium-sprotty/src/diagram-server-manager.ts
+++ b/packages/langium-sprotty/src/diagram-server-manager.ts
@@ -38,8 +38,8 @@ export class DefaultDiagramServerManager implements DiagramServerManager {
     protected readonly diagramServerFactory: (clientId: string, options?: DiagramOptions) => DiagramServer;
     protected readonly diagramServerMap: Map<string, DiagramServer> = new Map();
 
-    private changedUris: URI[] = [];
-    private outdatedDocuments: Map<LangiumDocument, DiagramServer> = new Map();
+    protected changedUris: URI[] = [];
+    protected outdatedDocuments: Map<LangiumDocument, DiagramServer> = new Map();
 
     constructor(services: LangiumSprottySharedServices) {
         this.connection = services.lsp.Connection;


### PR DESCRIPTION
It does not make sense to have `changedUris` and `outdatedDocuments` fields as private, since if I want to extend the default class and change the behavior of lets say `documentsUpdated()` method, I have to re-implement everything.