### PR TITLE
Show all railroad rules in railroad preview

### DIFF
--- a/packages/langium-cli/langium-config-schema.json
+++ b/packages/langium-cli/langium-config-schema.json
@@ -107,6 +107,10 @@
                             "description": "The output path to the generated railroad diagrams",
                             "type": "string"
                         },
+                        "css": {
+                            "description": "File path containing css that will be included in the generated svg/html files",
+                            "type": "string"
+                        },
                         "mode": {
                             "description": "Whether to print diagrams all into a single html file or in separate svg files",
                             "type": {
@@ -153,7 +157,7 @@
             "type": "string"
         },
         "importExtension": {
-            "description": "File extension used for TypeScript import statements. Empty by default",
+            "description": "File extension used for TypeScript import statements. `.js` by default",
             "type": "string"
         },
         "mode": {

--- a/packages/langium-cli/src/package.ts
+++ b/packages/langium-cli/src/package.ts
@@ -68,6 +68,8 @@ export interface LangiumLanguageConfig {
         out: string;
         /** Whether to print diagrams all into a single html file or in separate svg files */
         mode?: 'html' | 'svg';
+        /** Path to a css file that will be included in the generated output files */
+        css?: string;
     }
     /** Configure the chevrotain parser for a single language */
     chevrotainParserConfig?: IParserConfig


### PR DESCRIPTION
Closes https://github.com/eclipse-langium/langium/issues/1174

Includes referenced parser rules from other referenced grammars in the railroad syntax preview in vscode. Currently, it only shows grammar rules from the opened file without any imports. This change adds imported rules to the bottom of the file.

Also adds the ability to add a path to a css file that gets included into the generated railroad syntax diagram file.