### PR TITLE
Improve next element computation in completion

### DIFF
--- a/packages/langium/src/lsp/completion/follow-element-computation.ts
+++ b/packages/langium/src/lsp/completion/follow-element-computation.ts
@@ -146,7 +146,12 @@ function findFirstFeaturesInternal(options: { next: NextFeature, cardinalities: 
             .map(e => modifyCardinality(e, feature.cardinality, cardinalities));
     } else if (ast.isAlternatives(feature) || ast.isUnorderedGroup(feature)) {
         return feature.elements.flatMap(e => findFirstFeaturesInternal({
-            next: { feature: e, new: false, type },
+            next: {
+                feature: e,
+                new: false,
+                type,
+                property: next.property
+            },
             cardinalities,
             visited,
             plus
@@ -178,7 +183,7 @@ function findFirstFeaturesInternal(options: { next: NextFeature, cardinalities: 
         const ruleCallNext = {
             feature: rule.definition,
             new: true,
-            type: rule.fragment ? undefined : getExplicitRuleType(rule) ?? rule.name,
+            type: rule.fragment || rule.dataType ? undefined : (getExplicitRuleType(rule) ?? rule.name),
             property: next.property
         };
         return findFirstFeaturesInternal({ next: ruleCallNext, cardinalities, visited, plus })

--- a/packages/langium/src/parser/langium-parser.ts
+++ b/packages/langium/src/parser/langium-parser.ts
@@ -17,7 +17,7 @@ import { defaultParserErrorProvider, EmbeddedActionsParser, LLkLookaheadStrategy
 import { LLStarLookaheadStrategy } from 'chevrotain-allstar';
 import { isAssignment, isCrossReference, isKeyword } from '../grammar/generated/ast.js';
 import { getTypeName, isDataTypeRule } from '../grammar/internal-grammar-util.js';
-import { getContainerOfType, linkContentToContainer } from '../utils/ast-util.js';
+import { assignMandatoryAstProperties, getContainerOfType, linkContentToContainer } from '../utils/ast-util.js';
 import { CstNodeBuilder } from './cst-node-builder.js';
 
 export type ParseResult<T = AstNode> = {
@@ -275,21 +275,9 @@ export class LangiumParser extends AbstractLangiumParser {
         if (isDataTypeNode(obj)) {
             return this.converter.convert(obj.value, obj.$cstNode);
         } else {
-            this.assignMandatoryProperties(obj);
+            assignMandatoryAstProperties(this.astReflection, obj);
         }
         return obj;
-    }
-
-    private assignMandatoryProperties(obj: any): void {
-        const typeMetaData = this.astReflection.getTypeMetaData(obj.$type);
-        for (const mandatoryProperty of typeMetaData.mandatory) {
-            const value = obj[mandatoryProperty.name];
-            if (mandatoryProperty.type === 'array' && !Array.isArray(value)) {
-                obj[mandatoryProperty.name] = [];
-            } else if (mandatoryProperty.type === 'boolean' && value === undefined) {
-                obj[mandatoryProperty.name] = false;
-            }
-        }
     }
 
     private getAssignment(feature: AbstractElement): AssignmentElement {

--- a/packages/langium/src/utils/ast-util.ts
+++ b/packages/langium/src/utils/ast-util.ts
@@ -5,7 +5,7 @@
  ******************************************************************************/
 
 import type { Range } from 'vscode-languageserver';
-import type { AstNode, CstNode, GenericAstNode, Reference, ReferenceInfo } from '../syntax-tree.js';
+import type { AstNode, AstReflection, CstNode, GenericAstNode, Reference, ReferenceInfo } from '../syntax-tree.js';
 import type { Stream, TreeStream } from '../utils/stream.js';
 import type { LangiumDocument } from '../workspace/documents.js';
 import { isAstNode, isReference } from '../syntax-tree.js';
@@ -230,6 +230,25 @@ export function findLocalReferences(targetNode: AstNode, lookup = getDocument(ta
         });
     });
     return stream(refs);
+}
+
+/**
+ * Assigns all mandatory AST properties to the specified node.
+ *
+ * @param reflection Reflection object used to gather mandatory properties for the node.
+ * @param node Specified node is modified in place and properties are directly assigned.
+ */
+export function assignMandatoryAstProperties(reflection: AstReflection, node: AstNode): void {
+    const typeMetaData = reflection.getTypeMetaData(node.$type);
+    const genericNode = node as GenericAstNode;
+    for (const mandatoryProperty of typeMetaData.mandatory) {
+        const value = genericNode[mandatoryProperty.name];
+        if (mandatoryProperty.type === 'array' && !Array.isArray(value)) {
+            genericNode[mandatoryProperty.name] = [];
+        } else if (mandatoryProperty.type === 'boolean' && value === undefined) {
+            genericNode[mandatoryProperty.name] = false;
+        }
+    }
 }
 
 /**


### PR DESCRIPTION
Closes https://github.com/eclipse-langium/langium/issues/1203

Improves the completion algorithm in two ways:
1. Correctly propagates the current `NextFeature#property` variable through alternatives (related to the linked issue)
2. Fixes the way in which we create new AST nodes during cross reference completion. Previously, the `new` property wasn't set correctly, which led to cross reference completion on "stale" elements. This change simplifies (and also improves) the computation by only using the `type` property.

Both changes aren't trivial to (automatically) test and require debugging to accurately pinpoint the actual changes in the completion algorithm.