### PR TITLE
Add semantic token type `decorator`

### DIFF
--- a/packages/langium/src/lsp/semantic-token-provider.ts
+++ b/packages/langium/src/lsp/semantic-token-provider.ts
@@ -39,7 +39,8 @@ export const AllSemanticTokenTypes: Record<string, number> = {
     [SemanticTokenTypes.struct]: 18,
     [SemanticTokenTypes.type]: 19,
     [SemanticTokenTypes.typeParameter]: 20,
-    [SemanticTokenTypes.variable]: 21
+    [SemanticTokenTypes.variable]: 21,
+    [SemanticTokenTypes.decorator]: 22
 };
 
 export const AllSemanticTokenModifiers: Record<string, number> = {
@@ -452,4 +453,3 @@ export namespace SemanticTokensDecoder {
         return res;
     }
 }
-


### PR DESCRIPTION
Adds the missing entry for `SemanticTokenTypes.decorator` to `AllSemanticTokenTypes`. Otherwise, `AllSemanticTokenTypes` and `AllSemanticTokenModifiers` were complete.