### PR TITLE
Update language server libraries to version 9.0

### DIFF
--- a/examples/arithmetics/package.json
+++ b/examples/arithmetics/package.json
@@ -70,8 +70,8 @@
         "chalk": "~5.3.0",
         "commander": "~11.0.0",
         "langium": "~2.0.0",
-        "vscode-languageclient": "~8.1.0",
-        "vscode-languageserver": "~8.1.0"
+        "vscode-languageclient": "~9.0.1",
+        "vscode-languageserver": "~9.0.1"
     },
     "devDependencies": {
         "langium-cli": "~2.0.0"

--- a/examples/domainmodel/package.json
+++ b/examples/domainmodel/package.json
@@ -62,8 +62,8 @@
         "commander": "~11.0.0",
         "langium": "~2.0.0",
         "lodash": "~4.17.21",
-        "vscode-languageclient": "~8.1.0",
-        "vscode-languageserver": "~8.1.0"
+        "vscode-languageclient": "~9.0.1",
+        "vscode-languageserver": "~9.0.1"
     },
     "devDependencies": {
         "langium-cli": "~2.0.0"

--- a/examples/requirements/package.json
+++ b/examples/requirements/package.json
@@ -73,8 +73,8 @@
         "commander": "~11.0.0",
         "langium": "~2.0.0",
         "lodash": "~4.17.21",
-        "vscode-languageclient": "~8.1.0",
-        "vscode-languageserver": "~8.1.0"
+        "vscode-languageclient": "~9.0.1",
+        "vscode-languageserver": "~9.0.1"
     },
     "devDependencies": {
         "langium-cli": "~2.0.0"

--- a/examples/requirements/package.json
+++ b/examples/requirements/package.json
@@ -72,7 +72,6 @@
         "chalk": "~5.3.0",
         "commander": "~11.0.0",
         "langium": "~2.0.0",
-        "lodash": "~4.17.21",
         "vscode-languageclient": "~9.0.1",
         "vscode-languageserver": "~9.0.1"
     },

--- a/examples/statemachine/package.json
+++ b/examples/statemachine/package.json
@@ -60,7 +60,9 @@
         "chalk": "~5.3.0",
         "commander": "~11.0.0",
         "langium": "~2.0.0",
-        "lodash": "^4.17.21"
+        "lodash": "^4.17.21",
+        "vscode-languageclient": "~9.0.1",
+        "vscode-languageserver": "~9.0.1"
     },
     "devDependencies": {
         "langium-cli": "~2.0.0"

--- a/examples/statemachine/package.json
+++ b/examples/statemachine/package.json
@@ -60,7 +60,6 @@
         "chalk": "~5.3.0",
         "commander": "~11.0.0",
         "langium": "~2.0.0",
-        "lodash": "^4.17.21",
         "vscode-languageclient": "~9.0.1",
         "vscode-languageserver": "~9.0.1"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,8 +37,8 @@
         "chalk": "~5.3.0",
         "commander": "~11.0.0",
         "langium": "~2.0.0",
-        "vscode-languageclient": "~8.1.0",
-        "vscode-languageserver": "~8.1.0"
+        "vscode-languageclient": "~9.0.1",
+        "vscode-languageserver": "~9.0.1"
       },
       "bin": {
         "arithmetics-cli": "bin/cli.js"
@@ -70,8 +70,8 @@
         "commander": "~11.0.0",
         "langium": "~2.0.0",
         "lodash": "~4.17.21",
-        "vscode-languageclient": "~8.1.0",
-        "vscode-languageserver": "~8.1.0"
+        "vscode-languageclient": "~9.0.1",
+        "vscode-languageserver": "~9.0.1"
       },
       "bin": {
         "domainmodel-cli": "bin/cli.js"
@@ -102,8 +102,8 @@
         "commander": "~11.0.0",
         "langium": "~2.0.0",
         "lodash": "~4.17.21",
-        "vscode-languageclient": "~8.1.0",
-        "vscode-languageserver": "~8.1.0"
+        "vscode-languageclient": "~9.0.1",
+        "vscode-languageserver": "~9.0.1"
       },
       "bin": {
         "requirements-and-tests-lang-cli": "bin/cli.js"
@@ -134,7 +134,9 @@
         "chalk": "~5.3.0",
         "commander": "~11.0.0",
         "langium": "~2.0.0",
-        "lodash": "^4.17.21"
+        "lodash": "^4.17.21",
+        "vscode-languageclient": "~9.0.1",
+        "vscode-languageserver": "~9.0.1"
       },
       "bin": {
         "statemachine-cli": "bin/cli.js"
@@ -6304,9 +6306,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.28",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.28.tgz",
-      "integrity": "sha512-Z7V5j0cq8oEKyejIKfpD8b4eBy9cwW2JWPk0+fB1HOAMsfHbnAXLLS+PfVWlzMSLQaWttKDt607I0XHmpE67Vw==",
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
       "dev": true,
       "funding": [
         {
@@ -8848,24 +8850,24 @@
       }
     },
     "node_modules/vscode-jsonrpc": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.1.0.tgz",
-      "integrity": "sha512-6TDy/abTQk+zDGYazgbIPc+4JoXdwC8NHU9Pbn4UJP1fehUyZmM4RHp5IthX7A6L5KS30PRui+j+tbbMMMafdw==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/vscode-languageclient": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-8.1.0.tgz",
-      "integrity": "sha512-GL4QdbYUF/XxQlAsvYWZRV3V34kOkpRlvV60/72ghHfsYFnS/v2MANZ9P6sHmxFcZKOse8O+L9G7Czg0NUWing==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-9.0.1.tgz",
+      "integrity": "sha512-JZiimVdvimEuHh5olxhxkht09m3JzUGwggb5eRUkzzJhZ2KjCN0nh55VfiED9oez9DyF8/fz1g1iBV3h+0Z2EA==",
       "dependencies": {
         "minimatch": "^5.1.0",
         "semver": "^7.3.7",
-        "vscode-languageserver-protocol": "3.17.3"
+        "vscode-languageserver-protocol": "3.17.5"
       },
       "engines": {
-        "vscode": "^1.67.0"
+        "vscode": "^1.82.0"
       }
     },
     "node_modules/vscode-languageclient/node_modules/brace-expansion": {
@@ -8888,34 +8890,34 @@
       }
     },
     "node_modules/vscode-languageserver": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-8.1.0.tgz",
-      "integrity": "sha512-eUt8f1z2N2IEUDBsKaNapkz7jl5QpskN2Y0G01T/ItMxBxw1fJwvtySGB9QMecatne8jFIWJGWI61dWjyTLQsw==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz",
+      "integrity": "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==",
       "dependencies": {
-        "vscode-languageserver-protocol": "3.17.3"
+        "vscode-languageserver-protocol": "3.17.5"
       },
       "bin": {
         "installServerIntoExtension": "bin/installServerIntoExtension"
       }
     },
     "node_modules/vscode-languageserver-protocol": {
-      "version": "3.17.3",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.3.tgz",
-      "integrity": "sha512-924/h0AqsMtA5yK22GgMtCYiMdCOtWTSGgUOkgEDX+wk2b0x4sAfLiO4NxBxqbiVtz7K7/1/RgVrVI0NClZwqA==",
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
       "dependencies": {
-        "vscode-jsonrpc": "8.1.0",
-        "vscode-languageserver-types": "3.17.3"
+        "vscode-jsonrpc": "8.2.0",
+        "vscode-languageserver-types": "3.17.5"
       }
     },
     "node_modules/vscode-languageserver-textdocument": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.8.tgz",
-      "integrity": "sha512-1bonkGqQs5/fxGT5UchTgjGVnfysL0O8v1AYMBjqTbWQTFn721zaPGDYFkOKtfDgFiSgXM3KwaG3FMGfW4Ed9Q=="
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.11.tgz",
+      "integrity": "sha512-X+8T3GoiwTVlJbicx/sIAF+yuJAqz8VvwJyoMVhwEMoEKE/fkDmrqUgDMyBECcM2A2frVZIUj5HI/ErRXCfOeA=="
     },
     "node_modules/vscode-languageserver-types": {
-      "version": "3.17.3",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.3.tgz",
-      "integrity": "sha512-SYU4z1dL0PyIMd4Vj8YOqFvHu7Hz/enbWtpfnVbJHU4Nd1YNYx8u0ennumc6h48GQNeOLxmwySmnADouT/AuZA=="
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg=="
     },
     "node_modules/vscode-uri": {
       "version": "3.0.7",
@@ -9972,8 +9974,8 @@
       "dependencies": {
         "chevrotain": "~11.0.3",
         "chevrotain-allstar": "~0.3.0",
-        "vscode-languageserver": "~8.1.0",
-        "vscode-languageserver-textdocument": "~1.0.8",
+        "vscode-languageserver": "~9.0.1",
+        "vscode-languageserver-textdocument": "~1.0.11",
         "vscode-uri": "~3.0.7"
       },
       "devDependencies": {
@@ -10039,7 +10041,7 @@
         "ignore": "~5.2.4",
         "langium": "2.0.1",
         "langium-railroad": "2.0.0",
-        "vscode-languageserver": "~8.1.0"
+        "vscode-languageserver": "~9.0.1"
       },
       "engines": {
         "vscode": "^1.67.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -101,7 +101,6 @@
         "chalk": "~5.3.0",
         "commander": "~11.0.0",
         "langium": "~2.0.0",
-        "lodash": "~4.17.21",
         "vscode-languageclient": "~9.0.1",
         "vscode-languageserver": "~9.0.1"
       },
@@ -134,7 +133,6 @@
         "chalk": "~5.3.0",
         "commander": "~11.0.0",
         "langium": "~2.0.0",
-        "lodash": "^4.17.21",
         "vscode-languageclient": "~9.0.1",
         "vscode-languageserver": "~9.0.1"
       },

--- a/packages/generator-langium/test/yeoman-generator.test.ts
+++ b/packages/generator-langium/test/yeoman-generator.test.ts
@@ -51,6 +51,8 @@ describe('Check yeoman generator works', () => {
                 result.assertFile(files);
                 result.assertJsonFileContent(targetRoot + '/hello-world/package.json', PACKAGE_JSON_EXPECTATION);
                 result.assertFileContent(targetRoot + '/hello-world/.vscode/tasks.json', TASKS_JSON_EXPECTATION);
+            }).finally(() => {
+                context.cleanTestDirectory(true);
             });
     }, 120_000);
 

--- a/packages/langium-vscode/package.json
+++ b/packages/langium-vscode/package.json
@@ -93,7 +93,7 @@
   "dependencies": {
     "langium": "2.0.1",
     "langium-railroad": "2.0.0",
-    "vscode-languageserver": "~8.1.0",
+    "vscode-languageserver": "~9.0.1",
     "ignore": "~5.2.4"
   },
   "volta": {

--- a/packages/langium/package.json
+++ b/packages/langium/package.json
@@ -60,8 +60,8 @@
   "dependencies": {
     "chevrotain": "~11.0.3",
     "chevrotain-allstar": "~0.3.0",
-    "vscode-languageserver": "~8.1.0",
-    "vscode-languageserver-textdocument": "~1.0.8",
+    "vscode-languageserver": "~9.0.1",
+    "vscode-languageserver-textdocument": "~1.0.11",
     "vscode-uri": "~3.0.7"
   },
   "devDependencies": {

--- a/packages/langium/test/parser/langium-parser-builder.test.ts
+++ b/packages/langium/test/parser/langium-parser-builder.test.ts
@@ -682,6 +682,7 @@ describe('Handling EOF', () => {
         const grammar = `
         grammar Test
         entry Main: greet='Hello!' EOF;
+        hidden terminal WS: /\\s+/;
         `;
         const services = await createLangiumGrammarServices(EmptyFileSystem);
         const output = await parseHelper(services.grammar)(grammar, {validation: true});
@@ -716,6 +717,7 @@ describe('Handling EOF', () => {
         const grammar = `
         grammar Test
         entry Main: greet='Hello!' EOF name='user!';
+        hidden terminal WS: /\\s+/;
         `;
         const services = await createServicesForGrammar({ grammar });
         const parse = parseHelper(services);


### PR DESCRIPTION
Closes https://github.com/eclipse-langium/langium/issues/1236

Updates our used version of `vscode-languageserver` and everything related to their newest versions.