### PR TITLE
generator api ('joinToNode') supplements

### DIFF
--- a/packages/langium/test/generator/generation-tracing.test.ts
+++ b/packages/langium/test/generator/generation-tracing.test.ts
@@ -532,7 +532,7 @@ describe('tracing using $cstNode or $textRegion', () => {
         const source = await parse2('AH "IH" OH 0815') as AstNode & { values: Array<string | number> };
         const { text, trace } = toStringAndTrace(
             expandToNode`
-                beginning ${ joinTracedToNode(source, 'values')(source.values, undefined, { separator: ' ' }) } end
+                beginning ${ joinTracedToNode(source, 'values')(source.values, { separator: ' ' }) } end
             `
         );
         persistSourceRegions(trace);

--- a/packages/langium/test/generator/template-node.test.ts
+++ b/packages/langium/test/generator/template-node.test.ts
@@ -5,7 +5,7 @@
  ******************************************************************************/
 
 import { describe, expect, test } from 'vitest';
-import { joinToNode, expandToNode as n, expandToString as s, stream, CompositeGeneratorNode, EOL, toString } from 'langium';
+import { joinToNode, expandToNode as n, expandToString as s, stream, CompositeGeneratorNode, EOL, toString, NL } from 'langium';
 
 // deactivate the eslint check 'no-unexpected-multiline' with the message
 //  'Unexpected newline between template tag and template literal', as that's done on purposes in tests below!
@@ -846,6 +846,41 @@ describe('Embedded forEach loops', () => {
             Footer:
         `);
     });
+    test('ForEach loop with empty iterable 2 (\'toGenerated\' === \'undefined\')', () => {
+        const node = n`
+            Data:
+              ${joinToNode([], undefined, { appendNewLineIfNotEmpty: true})}
+            Footer:
+        `;
+        const text = toString(node);
+        expect(text).toBe(s`
+            Data:
+            Footer:
+        `);
+    });
+    test('ForEach loop with empty iterable 3 (no \'toGenerated\')', () => {
+        const node = n`
+            Data:
+              ${joinToNode([], { appendNewLineIfNotEmpty: true})}
+            Footer:
+        `;
+        const text = toString(node);
+        expect(text).toBe(s`
+            Data:
+            Footer:
+        `);
+    });
+    test('ForEach loop with Array input (no \'toGenerated\', no \'options\')', () => {
+        const node = n`
+            Data:
+              ${joinToNode(['a', 'b'])}
+        `;
+        const text = toString(node);
+        expect(text).toBe(s`
+            Data:
+              ab
+        `);
+    });
     test('ForEach loop with separator and Array input', () => {
         const node = n`
             Data:
@@ -855,6 +890,64 @@ describe('Embedded forEach loops', () => {
         expect(text).toBe(s`
             Data:
               a, b
+        `);
+    });
+    test('ForEach loop with separator and Array input 2 (\'toGenerated\' === \'undefined\')', () => {
+        const node = n`
+            Data:
+              ${joinToNode(['a', 'b'], undefined, { separator: ', ' })}
+        `;
+        const text = toString(node);
+        expect(text).toBe(s`
+            Data:
+              a, b
+        `);
+    });
+    test('ForEach loop with separator and Array input 3 (no \'toGenerated\')', () => {
+        const node = n`
+            Data:
+              ${joinToNode(['a', 'b'], { separator: ', ' })}
+        `;
+        const text = toString(node);
+        expect(text).toBe(s`
+            Data:
+              a, b
+        `);
+    });
+    test('ForEach loop with separator and Array of generator nodes input', () => {
+        const node = n`
+            Data:
+              ${joinToNode([n`a`, ' b', NL], n => n, { separator: ',' })}
+        `;
+        const text = toString(node);
+        expect(text).toBe(s`
+            Data:
+              a, b,
+
+        `);
+    });
+    test('ForEach loop with separator and Array of generator nodes input 2 (\'toGenerated\' === \'undefined\')', () => {
+        const node = n`
+            Data:
+              ${joinToNode([n`a`, ' b', NL], undefined, { separator: ',' })}
+        `;
+        const text = toString(node);
+        expect(text).toBe(s`
+            Data:
+              a, b,
+
+        `);
+    });
+    test('ForEach loop with separator and Array of generator nodes input 3 (no \'toGenerated\')', () => {
+        const node = n`
+            Data:
+              ${joinToNode([n`a`, ' b', NL], { separator: ',' })}
+        `;
+        const text = toString(node);
+        expect(text).toBe(s`
+            Data:
+              a, b,
+
         `);
     });
     test('ForEach loop with element prefix and Array input', () => {
@@ -877,6 +970,17 @@ describe('Embedded forEach loops', () => {
         expect(text).toBe(s`
             Data:
               a, b
+        `);
+    });
+    test('ForEach loop with Stream input (no \'toGenerated\', no \'options\')', () => {
+        const node = n`
+            Data:
+              ${joinToNode(stream('a', 'b'))}
+        `;
+        const text = toString(node);
+        expect(text).toBe(s`
+            Data:
+              ab
         `);
     });
     test('ForEach loop with line breaks and Stream input', () => {

--- a/packages/langium/test/generator/template-node.test.ts
+++ b/packages/langium/test/generator/template-node.test.ts
@@ -953,6 +953,17 @@ describe('Embedded forEach loops', () => {
     test('ForEach loop with element prefix and Array input', () => {
         const node = n`
             Data:
+              ${joinToNode(['a', 'b'], String, { prefix: ',' })}
+        `;
+        const text = toString(node);
+        expect(text).toBe(s`
+            Data:
+              ,a,b
+        `);
+    });
+    test('ForEach loop with element prefix and Array input 2 (function)', () => {
+        const node = n`
+            Data:
               ${joinToNode(['a', 'b'], String, { prefix: (e, i) => i === 0 ? '': ', ' })}
         `;
         const text = toString(node);
@@ -962,6 +973,17 @@ describe('Embedded forEach loops', () => {
         `);
     });
     test('ForEach loop with element suffix and Set input', () => {
+        const node = n`
+            Data:
+              ${joinToNode(new Set(['a', 'b']), String, { suffix: ',' })}
+        `;
+        const text = toString(node);
+        expect(text).toBe(s`
+            Data:
+              a,b,
+        `);
+    });
+    test('ForEach loop with element suffix and Set input 2 (function)', () => {
         const node = n`
             Data:
               ${joinToNode(new Set(['a', 'b']), String, { suffix: (e, i, isLast) => isLast ? '': ', ' })}
@@ -996,6 +1018,18 @@ describe('Embedded forEach loops', () => {
             
         `);
     });
+    test('ForEach loop with line breaks and skip line break after last line and Stream input', () => {
+        const node = n`
+            Data:
+              ${joinToNode(stream(['a', 'b']), String, { appendNewLineIfNotEmpty: true, skipNewLineAfterLastItem: true})}
+        `;
+        const text = toString(node);
+        expect(text).toBe(s`
+            Data:
+              a
+              b
+        `);
+    });
     test('ForEach loop with separator, line breaks, and Stream input', () => {
         const node = n`
             Data:
@@ -1010,6 +1044,19 @@ describe('Embedded forEach loops', () => {
             
         `);
     });
+    test('ForEach loop with separator, line breaks and skip line break after last line, and Stream input', () => {
+        const node = n`
+            Data:
+              ${joinToNode(stream(['a', undefined, 'b']), String, { separator: ',', appendNewLineIfNotEmpty: true, skipNewLineAfterLastItem: true})}
+        `;
+        const text = toString(node);
+        expect(text).toBe(s`
+            Data:
+              a,
+              undefined,
+              b
+        `);
+    });
     test('ForEach loop with omitted `undefined`, separator, line breaks and Stream input', () => {
         const node = n`
             Data:
@@ -1021,6 +1068,18 @@ describe('Embedded forEach loops', () => {
               a,
               b
             
+        `);
+    });
+    test('ForEach loop with omitted `undefined`, separator, line breaks and skip line break after last line, and Stream input', () => {
+        const node = n`
+            Data:
+              ${joinToNode(stream(['a', undefined, 'b']), e => e && String(e), { separator: ',', appendNewLineIfNotEmpty: true, skipNewLineAfterLastItem: true})}
+        `;
+        const text = toString(node);
+        expect(text).toBe(s`
+            Data:
+              a,
+              b
         `);
     });
 });


### PR DESCRIPTION
Some improvements inspired by applications in productive projects

* extended definition of 'JoinOptions' used to configure executions of 'joinToNode'
* extended type definitions of `joinToNode` allowing to skip the `toGenerated` argument (conversion function)