### PR TITLE
Remove vscode-uri bundler workaround

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8918,9 +8918,9 @@
       "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg=="
     },
     "node_modules/vscode-uri": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.7.tgz",
-      "integrity": "sha512-eOpPHogvorZRobNqJGhapa0JdwaxpjVvyBp0QIUMRMSf8ZAlqOdEquKuRmw9Qwu0qXtJIWqFtMkmvJjUZmMjVA=="
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.8.tgz",
+      "integrity": "sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw=="
     },
     "node_modules/walk-up-path": {
       "version": "1.0.0",
@@ -9974,7 +9974,7 @@
         "chevrotain-allstar": "~0.3.0",
         "vscode-languageserver": "~9.0.1",
         "vscode-languageserver-textdocument": "~1.0.11",
-        "vscode-uri": "~3.0.7"
+        "vscode-uri": "~3.0.8"
       },
       "devDependencies": {
         "langium-cli": "~2.0.0"

--- a/packages/langium/package.json
+++ b/packages/langium/package.json
@@ -62,7 +62,7 @@
     "chevrotain-allstar": "~0.3.0",
     "vscode-languageserver": "~9.0.1",
     "vscode-languageserver-textdocument": "~1.0.11",
-    "vscode-uri": "~3.0.7"
+    "vscode-uri": "~3.0.8"
   },
   "devDependencies": {
     "langium-cli": "~2.0.0"

--- a/packages/langium/src/utils/uri-util.ts
+++ b/packages/langium/src/utils/uri-util.ts
@@ -4,27 +4,17 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import * as vscodeUri from 'vscode-uri';
-
-// Node.js and some bundlers don't deal well with the type information in `vscode-uri`
-// This is a workaround to support all runtimes and bundlers
-let uri = vscodeUri;
-if ('default' in uri) {
-    uri = uri.default as typeof uri;
-}
-
-type URI = vscodeUri.URI;
-const URI = uri.URI;
+import { URI, Utils } from 'vscode-uri';
 
 export { URI };
 
 export namespace UriUtils {
 
-    export const basename = uri.Utils.basename;
-    export const dirname = uri.Utils.dirname;
-    export const extname = uri.Utils.extname;
-    export const joinPath = uri.Utils.joinPath;
-    export const resolvePath = uri.Utils.resolvePath;
+    export const basename = Utils.basename;
+    export const dirname = Utils.dirname;
+    export const extname = Utils.extname;
+    export const joinPath = Utils.joinPath;
+    export const resolvePath = Utils.resolvePath;
 
     export function equals(a?: URI | string, b?: URI | string): boolean {
         return a?.toString() === b?.toString();


### PR DESCRIPTION
Microsoft has finally released a node (and bundler) compatible ESM version of `vscode-uri` (3.0.8). See also https://github.com/microsoft/vscode-uri/pull/39.

This change removes the workaround that was needed in Langium to use the values exported by `vscode-uri`.