### PR TITLE
Treat lines with only comment symbols as empty in JSDoc comments

### DIFF
--- a/packages/langium/src/documentation/jsdoc.ts
+++ b/packages/langium/src/documentation/jsdoc.ts
@@ -60,11 +60,11 @@ export interface JSDocParseOptions {
     /**
      * The symbol that start a line of your comment format. Defaults to `*`.
      */
-    readonly end?: RegExp | string
+    readonly line?: RegExp | string
     /**
      * The end symbol of your comment format. Defaults to `*\/`.
      */
-    readonly line?: RegExp | string
+    readonly end?: RegExp | string
 }
 
 export interface JSDocRenderOptions {

--- a/packages/langium/src/documentation/jsdoc.ts
+++ b/packages/langium/src/documentation/jsdoc.ts
@@ -194,7 +194,7 @@ function tokenize(context: TokenizationContext): JSDocToken[] {
         }
 
         line = line.substring(0, lastCharacter(line));
-        const whitespaceEnd = skipWhitespace(line, 0);
+        const whitespaceEnd = skipWhitespace(line, index);
 
         if (whitespaceEnd >= line.length) {
             // Only create a break token when we already have previous tokens

--- a/packages/langium/test/documentation/jsdoc.test.ts
+++ b/packages/langium/test/documentation/jsdoc.test.ts
@@ -150,6 +150,16 @@ describe('JSDoc rendering', () => {
         expect(parsed.toMarkdown()).toBe('```\nA\n\n\nB\nC\n\n```');
     });
 
+    test('Renders paragraphs in markdown', () => {
+        const parsed = parseJSDoc('/**\n * A\n * B\n * \n * C\n */');
+        expect(parsed.toMarkdown()).toBe('A\n B\n\n C');
+    });
+
+    test('Renders paragraphs in plain text', () => {
+        const parsed = parseJSDoc('/**\n * A\n * B\n * \n * C\n */');
+        expect(parsed.toString()).toBe('A\n B\n\n C');
+    });
+
     test('Renders single-line tags in markdown', () => {
         const parsed = parseJSDoc('/** @deprecated Since 1.0 */');
         expect(parsed.toMarkdown()).toBe('*@deprecated* — Since 1.0');


### PR DESCRIPTION
Previously, lines that only contained a (line) comment symbol did not trigger a new Markdown paragraph:

![image](https://github.com/eclipse-langium/langium/assets/2501322/2b36a4a0-e853-4938-8505-cb2d7aef7aa8)

This PR adjusts this behavior, so a new paragraph gets created:

![image](https://github.com/eclipse-langium/langium/assets/2501322/49b9d7a5-5d08-4f86-97a6-28a0e8d29b53)
