### PR TITLE
Customize rendering of tags in JSDoc comments

### DIFF
--- a/packages/langium/src/documentation/documentation-provider.ts
+++ b/packages/langium/src/documentation/documentation-provider.ts
@@ -8,8 +8,9 @@ import type { LangiumServices } from '../services.js';
 import type { AstNode, AstNodeDescription } from '../syntax-tree.js';
 import type { IndexManager } from '../workspace/index-manager.js';
 import type { CommentProvider } from './comment-provider.js';
+import type { JSDocTag } from './jsdoc.js';
 import { getDocument } from '../utils/ast-util.js';
-import {isJSDoc, JSDocTag, parseJSDoc} from './jsdoc.js';
+import { isJSDoc, parseJSDoc } from './jsdoc.js';
 
 /**
  * Provides documentation for AST nodes.
@@ -61,7 +62,7 @@ export class JSDocDocumentationProvider implements DocumentationProvider {
         }
     }
 
-    protected documentationTagRenderer(node: AstNode, tag: JSDocTag): string | undefined {
+    protected documentationTagRenderer(_node: AstNode, _tag: JSDocTag): string | undefined {
         // Fall back to the default tag rendering
         return undefined;
     }

--- a/packages/langium/src/documentation/documentation-provider.ts
+++ b/packages/langium/src/documentation/documentation-provider.ts
@@ -9,7 +9,7 @@ import type { AstNode, AstNodeDescription } from '../syntax-tree.js';
 import type { IndexManager } from '../workspace/index-manager.js';
 import type { CommentProvider } from './comment-provider.js';
 import { getDocument } from '../utils/ast-util.js';
-import { isJSDoc, parseJSDoc } from './jsdoc.js';
+import {isJSDoc, JSDocTag, parseJSDoc} from './jsdoc.js';
 
 /**
  * Provides documentation for AST nodes.
@@ -40,6 +40,9 @@ export class JSDocDocumentationProvider implements DocumentationProvider {
             return parsedJSDoc.toMarkdown({
                 renderLink: (link, display) => {
                     return this.documentationLinkRenderer(node, link, display);
+                },
+                renderTag: (tag) => {
+                    return this.documentationTagRenderer(node, tag);
                 }
             });
         }
@@ -56,6 +59,11 @@ export class JSDocDocumentationProvider implements DocumentationProvider {
         } else {
             return undefined;
         }
+    }
+
+    protected documentationTagRenderer(node: AstNode, tag: JSDocTag): string | undefined {
+        // Fall back to the default tag rendering
+        return undefined;
     }
 
     protected findNameInPrecomputedScopes(node: AstNode, name: string): AstNodeDescription | undefined {

--- a/packages/langium/src/documentation/jsdoc.ts
+++ b/packages/langium/src/documentation/jsdoc.ts
@@ -77,6 +77,11 @@ export interface JSDocRenderOptions {
      */
     link?: 'code' | 'plain'
     /**
+     * Custom tag rendering function.
+     * Return a markdown formatted tag or `undefined` if the tag is not valid.
+     */
+    renderTag?(tag: JSDocTag): string | undefined
+    /**
      * Custom link rendering function. Accepts a link target and a display value for the link.
      * Return a markdown formatted link with the format `[$display]($link)` or `undefined` if the link is not a valid target.
      */
@@ -562,6 +567,10 @@ class JSDocTagImpl implements JSDocTag {
     }
 
     toMarkdown(options?: JSDocRenderOptions): string {
+        return options?.renderTag?.(this) ?? this.toMarkdownDefault(options)
+    }
+
+    private toMarkdownDefault(options?: JSDocRenderOptions): string {
         const content = this.content.toMarkdown(options);
         if (this.inline) {
             const rendered = renderInlineTag(this.name, content, options ?? {});

--- a/packages/langium/src/documentation/jsdoc.ts
+++ b/packages/langium/src/documentation/jsdoc.ts
@@ -78,7 +78,7 @@ export interface JSDocRenderOptions {
     link?: 'code' | 'plain'
     /**
      * Custom tag rendering function.
-     * Return a markdown formatted tag or `undefined` if the tag is not valid.
+     * Return a markdown formatted tag or `undefined` to fall back to the default rendering.
      */
     renderTag?(tag: JSDocTag): string | undefined
     /**

--- a/packages/langium/src/documentation/jsdoc.ts
+++ b/packages/langium/src/documentation/jsdoc.ts
@@ -567,7 +567,7 @@ class JSDocTagImpl implements JSDocTag {
     }
 
     toMarkdown(options?: JSDocRenderOptions): string {
-        return options?.renderTag?.(this) ?? this.toMarkdownDefault(options)
+        return options?.renderTag?.(this) ?? this.toMarkdownDefault(options);
     }
 
     private toMarkdownDefault(options?: JSDocRenderOptions): string {

--- a/packages/langium/test/documentation/jsdoc.test.ts
+++ b/packages/langium/test/documentation/jsdoc.test.ts
@@ -171,7 +171,7 @@ describe('JSDoc rendering', () => {
                 renderTag: (tag) => {
                     const contentMd = tag.content.toMarkdown();
                     const [paramName, description] = contentMd.split(/\s(.*)/s);
-                    return `**@${tag.name}** *${paramName}* — ${description.trim()}`
+                    return `**@${tag.name}** *${paramName}* — ${description.trim()}`;
                 }
             })).toBe('**@param** *p* — Lorem ipsum.');
         });

--- a/packages/langium/test/documentation/jsdoc.test.ts
+++ b/packages/langium/test/documentation/jsdoc.test.ts
@@ -164,6 +164,18 @@ describe('JSDoc rendering', () => {
             const parsed = parseJSDoc('/** @deprecated Since\n1.0*/');
             expect(parsed.toString()).toBe('@deprecated\nSince\n1.0');
         });
+
+        test('Uses the supplied rendering function', () => {
+            const parsed = parseJSDoc('/** @param p Lorem ipsum. */');
+            expect(parsed.toMarkdown({
+                renderTag: (tag) => {
+                    const contentMd = tag.content.toMarkdown();
+                    const [paramName, description] = contentMd.split(/\s(.*)/s);
+                    return `**@${tag.name}** *${paramName}* — ${description.trim()}`
+                }
+            })).toBe('**@param** *p* — Lorem ipsum.');
+        });
+
     });
 
     test('Renders empty lines', () => {
@@ -181,4 +193,5 @@ describe('JSDoc rendering', () => {
         const parsed = parseJSDoc('/**\n * A\n * B\n * \n * C\n */');
         expect(parsed.toString()).toBe('A\n B\n\n C');
     });
+
 });

--- a/packages/langium/test/documentation/jsdoc.test.ts
+++ b/packages/langium/test/documentation/jsdoc.test.ts
@@ -144,6 +144,28 @@ describe('JSDoc rendering', () => {
 
     });
 
+    describe('Tag rendering', () => {
+        test('Renders single-line tags in markdown', () => {
+            const parsed = parseJSDoc('/** @deprecated Since 1.0 */');
+            expect(parsed.toMarkdown()).toBe('*@deprecated* — Since 1.0');
+        });
+
+        test('Renders single-line tags in plain text', () => {
+            const parsed = parseJSDoc('/** @deprecated Since 1.0 */');
+            expect(parsed.toString()).toBe('@deprecated Since 1.0');
+        });
+
+        test('Renders multi-line tags in markdown', () => {
+            const parsed = parseJSDoc('/** @deprecated Since\n1.0*/');
+            expect(parsed.toMarkdown()).toBe('*@deprecated*\nSince\n1.0');
+        });
+
+        test('Renders multi-line tags in plain text', () => {
+            const parsed = parseJSDoc('/** @deprecated Since\n1.0*/');
+            expect(parsed.toString()).toBe('@deprecated\nSince\n1.0');
+        });
+    });
+
     test('Renders empty lines', () => {
         // This test ensures that newlines are rendered as they are in the input
         const parsed = parseJSDoc('/** ```\nA\n\n\nB\nC\n\n``` */');
@@ -159,25 +181,4 @@ describe('JSDoc rendering', () => {
         const parsed = parseJSDoc('/**\n * A\n * B\n * \n * C\n */');
         expect(parsed.toString()).toBe('A\n B\n\n C');
     });
-
-    test('Renders single-line tags in markdown', () => {
-        const parsed = parseJSDoc('/** @deprecated Since 1.0 */');
-        expect(parsed.toMarkdown()).toBe('*@deprecated* — Since 1.0');
-    });
-
-    test('Renders single-line tags in plain text', () => {
-        const parsed = parseJSDoc('/** @deprecated Since 1.0 */');
-        expect(parsed.toString()).toBe('@deprecated Since 1.0');
-    });
-
-    test('Renders multi-line tags in markdown', () => {
-        const parsed = parseJSDoc('/** @deprecated Since\n1.0*/');
-        expect(parsed.toMarkdown()).toBe('*@deprecated*\nSince\n1.0');
-    });
-
-    test('Renders multi-line tags in plain text', () => {
-        const parsed = parseJSDoc('/** @deprecated Since\n1.0*/');
-        expect(parsed.toString()).toBe('@deprecated\nSince\n1.0');
-    });
-
 });


### PR DESCRIPTION
Closes #1242

Add two means to customize the rendering of tags in JSDoc comments in the generated Markdown:

1. When calling the `toMarkdown` methods, a `renderTag` function can be passed in the options.
2. Inside the `JSDocDocumentationProvider`, the method `documentationTagRenderer` can be overridden.