### PR TITLE
JsonSerializer: Support references to other documents

### DIFF
--- a/packages/langium-cli/src/generator/grammar-serializer.ts
+++ b/packages/langium-cli/src/generator/grammar-serializer.ts
@@ -4,7 +4,8 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import type { Grammar, LangiumServices } from 'langium';
+import type { URI } from 'vscode-uri';
+import type { Grammar, LangiumServices, Reference } from 'langium';
 import type { LangiumConfig } from '../package.js';
 import { CompositeGeneratorNode, NL, normalizeEOL, toString } from 'langium';
 import { generatedHeader } from './util.js';
@@ -29,9 +30,17 @@ export function serializeGrammar(services: LangiumServices, grammars: Grammar[],
         if (grammar.name) {
             const production = config.mode === 'production';
             const delimiter = production ? "'" : '`';
+            const uriConverter = (uri: URI, ref: Reference) => {
+                // We expect the grammar to be self-contained after the transformations we've done before
+                throw new Error(`Unexpected reference to symbol '${ref.$refText}' in document: ${uri.toString()}`);
+            };
+            const serializedGrammar = services.serializer.JsonSerializer.serialize(grammar, {
+                space: production ? undefined : 2,
+                uriConverter
+            });
             // The json serializer returns strings with \n line delimiter by default
             // We need to translate these line endings to the OS specific line ending
-            const json = normalizeEOL(services.serializer.JsonSerializer.serialize(grammar, production ? undefined : { space: 2 })
+            const json = normalizeEOL(serializedGrammar
                 .replace(/\\/g, '\\\\')
                 .replace(new RegExp(delimiter, 'g'), '\\' + delimiter));
             node.append(

--- a/packages/langium-vscode/src/extension.ts
+++ b/packages/langium-vscode/src/extension.ts
@@ -134,7 +134,7 @@ function decorateText(document: vscode.TextDocument, decorations: vscode.Decorat
     while ((match = regEx.exec(text))) {
         const startIndex = textIndex + match.index;
         const startPos = document.positionAt(startIndex + indentation);
-        const endPos = document.positionAt(startIndex + match[0].trimRight().length);
+        const endPos = document.positionAt(startIndex + match[0].trimEnd().length);
         if (startPos.isBefore(endPos)) {
             const range = new vscode.Range(startPos, endPos);
             decorations.push({ range });
@@ -144,7 +144,7 @@ function decorateText(document: vscode.TextDocument, decorations: vscode.Decorat
 
 // TODO(@@dd): find bug
 function findIndentation(text: string): number {
-    const indents = text.split(/[\r?\n]/g).map(line => line.trimRight()).filter(line => line.length > 0).map(line => line.search(/\S|$/));
+    const indents = text.split(/[\r?\n]/g).map(line => line.trimEnd()).filter(line => line.length > 0).map(line => line.search(/\S|$/));
     const min = indents.length === 0 ? 0 : Math.min(...indents); // min(...[]) = min() = Infinity
     return Math.max(0, min);
 }

--- a/packages/langium/src/generator/template-string.ts
+++ b/packages/langium/src/generator/template-string.ts
@@ -46,7 +46,7 @@ function internalExpandToString(lineSep: string, staticParts: TemplateStringsArr
         .split(NEWLINE_REGEXP)
         .filter(l => l.trim() !== SNLE)
         // whitespace-only lines are empty (preserving leading whitespace)
-        .map(l => l.replace(SNLE, '').trimRight());
+        .map(l => l.replace(SNLE, '').trimEnd());
 
     // in order to nicely handle single line templates with the leading and trailing termintators (``) on separate lines, like
     //   expandToString`foo
@@ -65,7 +65,7 @@ function internalExpandToString(lineSep: string, staticParts: TemplateStringsArr
     lines = containsLeadingLinebreak ? lines.slice(1) : lines;
 
     // .. and drop the last linebreak if it's the last charactor or is followed by white space
-    const containsTrailingLinebreak = lines.length !== 0 && lines[lines.length-1].trimRight().length === 0;
+    const containsTrailingLinebreak = lines.length !== 0 && lines[lines.length-1].trimEnd().length === 0;
     lines = containsTrailingLinebreak ? lines.slice(0, lines.length-1) : lines;
 
     // finds the minimum indentation

--- a/packages/langium/src/workspace/file-system-provider.ts
+++ b/packages/langium/src/workspace/file-system-provider.ts
@@ -38,11 +38,11 @@ export interface FileSystemProvider {
 export class EmptyFileSystemProvider implements FileSystemProvider {
 
     readFile(): Promise<string> {
-        throw new Error('Method not implemented.');
+        throw new Error('No file system is available.');
     }
 
     readFileSync(): string {
-        throw new Error('Method not implemented.');
+        throw new Error('No file system is available.');
     }
 
     async readDirectory(): Promise<FileSystemNode[]> {

--- a/packages/langium/test/serializer/json-serializer.test.ts
+++ b/packages/langium/test/serializer/json-serializer.test.ts
@@ -1,0 +1,199 @@
+/******************************************************************************
+ * Copyright 2023 TypeFox GmbH
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License, which is available in the project root.
+ ******************************************************************************/
+
+import type { AstNode, Reference } from 'langium';
+import { beforeEach, describe, expect, test } from 'vitest';
+import { createServicesForGrammar, expandToString } from 'langium';
+import { clearDocuments, parseHelper } from 'langium/test';
+
+describe('JsonSerializer', async () => {
+
+    const grammar = expandToString`
+        grammar JsonSerializerTest
+
+        entry Entry: elements+=Element*;
+        
+        Element: 'element' name=ID ('refers' other=[Element:ID])?;
+        
+        hidden terminal WS: /\s+/;
+        terminal ID: /[_a-zA-Z][\w]*/;
+    `;
+    const services = await createServicesForGrammar({ grammar });
+    const serializer = services.serializer.JsonSerializer;
+    const parse = parseHelper<Entry>(services);
+
+    beforeEach(() => {
+        clearDocuments(services);
+    });
+
+    test('Serialize reference to same document', async () => {
+        const document1 = await parse(`
+            element a
+            element b refers a
+        `);
+        await services.shared.workspace.DocumentBuilder.build([document1, document1]);
+        const json = serializer.serialize(document1.parseResult.value, { space: 4 });
+        expect(json).toEqual(expandToString`
+            {
+                "$type": "Entry",
+                "elements": [
+                    {
+                        "$type": "Element",
+                        "name": "a"
+                    },
+                    {
+                        "$type": "Element",
+                        "name": "b",
+                        "other": {
+                            "$ref": "#/elements@0"
+                        }
+                    }
+                ]
+            }
+        `);
+    });
+
+    test('Serialize reference to other document', async () => {
+        const document1 = await parse(`
+            element a
+        `, {
+            documentUri: 'file:///test1.langium'
+        });
+        const document2 = await parse(`
+            element b refers a
+        `, {
+            documentUri: 'file:///test2.langium'
+        });
+        await services.shared.workspace.DocumentBuilder.build([document1, document2]);
+        const json = serializer.serialize(document2.parseResult.value, { space: 4 });
+        expect(json).toEqual(expandToString`
+            {
+                "$type": "Entry",
+                "elements": [
+                    {
+                        "$type": "Element",
+                        "name": "b",
+                        "other": {
+                            "$ref": "file:///test1.langium#/elements@0"
+                        }
+                    }
+                ]
+            }
+        `);
+    });
+
+    test('Serialize reference to other document with custom URI converter', async () => {
+        const document1 = await parse(`
+            element a
+        `, {
+            documentUri: 'file:///test1.langium'
+        });
+        const document2 = await parse(`
+            element b refers a
+        `, {
+            documentUri: 'file:///test2.langium'
+        });
+        await services.shared.workspace.DocumentBuilder.build([document1, document2]);
+        const json = serializer.serialize(document2.parseResult.value, {
+            space: 4,
+            uriConverter: (uri) => uri.with({ path: '/foo' + uri.path }).toString()
+        });
+        expect(json).toEqual(expandToString`
+            {
+                "$type": "Entry",
+                "elements": [
+                    {
+                        "$type": "Element",
+                        "name": "b",
+                        "other": {
+                            "$ref": "file:///foo/test1.langium#/elements@0"
+                        }
+                    }
+                ]
+            }
+        `);
+    });
+
+    test('Revive reference to same document', async () => {
+        const json = expandToString`
+            {
+                "$type": "Entry",
+                "elements": [
+                    {
+                        "$type": "Element",
+                        "name": "a"
+                    },
+                    {
+                        "$type": "Element",
+                        "name": "b",
+                        "other": {
+                            "$ref": "#/elements@0"
+                        }
+                    }
+                ]
+            }
+        `;
+        const model = serializer.deserialize<Entry>(json);
+        expect(model.elements).toHaveLength(2);
+        expect(model.elements[1].other?.ref).toStrictEqual(model.elements[0]);
+    });
+
+    test('Revive reference to other document', async () => {
+        const document1 = await parse(`
+            element a
+        `, {
+            documentUri: 'file:///test1.langium'
+        });
+        await services.shared.workspace.DocumentBuilder.build([document1]);
+        const json = expandToString`
+            {
+                "$type": "Entry",
+                "elements": [
+                    {
+                        "$type": "Element",
+                        "name": "b",
+                        "other": {
+                            "$ref": "file:///test1.langium#/elements@0"
+                        }
+                    }
+                ]
+            }
+        `;
+        const model = serializer.deserialize<Entry>(json);
+        expect(model.elements).toHaveLength(1);
+        expect(model.elements[0].other?.ref).toStrictEqual(document1.parseResult.value.elements[0]);
+    });
+
+    test('Reference error with non-existing document', async () => {
+        const json = expandToString`
+            {
+                "$type": "Entry",
+                "elements": [
+                    {
+                        "$type": "Element",
+                        "name": "b",
+                        "other": {
+                            "$ref": "file:///does-not-exist.langium#/elements@0"
+                        }
+                    }
+                ]
+            }
+        `;
+        const model = serializer.deserialize<Entry>(json);
+        expect(model.elements).toHaveLength(1);
+        expect(model.elements[0].other?.error?.message).toEqual('Error: No file system is available.');
+    });
+
+});
+
+interface Entry extends AstNode {
+    elements: Element[]
+}
+
+interface Element extends AstNode {
+    name: string
+    other?: Reference<Element>
+}

--- a/packages/langium/test/serializer/json-serializer.test.ts
+++ b/packages/langium/test/serializer/json-serializer.test.ts
@@ -36,7 +36,7 @@ describe('JsonSerializer', async () => {
         `);
         await services.shared.workspace.DocumentBuilder.build([document1, document1]);
         const json = serializer.serialize(document1.parseResult.value, { space: 4 });
-        expect(json).toEqual(expandToString`
+        expect(json).toEqual(normalize(expandToString`
             {
                 "$type": "Entry",
                 "elements": [
@@ -53,7 +53,7 @@ describe('JsonSerializer', async () => {
                     }
                 ]
             }
-        `);
+        `));
     });
 
     test('Serialize reference to other document', async () => {
@@ -69,7 +69,7 @@ describe('JsonSerializer', async () => {
         });
         await services.shared.workspace.DocumentBuilder.build([document1, document2]);
         const json = serializer.serialize(document2.parseResult.value, { space: 4 });
-        expect(json).toEqual(expandToString`
+        expect(json).toEqual(normalize(expandToString`
             {
                 "$type": "Entry",
                 "elements": [
@@ -82,7 +82,7 @@ describe('JsonSerializer', async () => {
                     }
                 ]
             }
-        `);
+        `));
     });
 
     test('Serialize reference to other document with custom URI converter', async () => {
@@ -101,7 +101,7 @@ describe('JsonSerializer', async () => {
             space: 4,
             uriConverter: (uri) => uri.with({ path: '/foo' + uri.path }).toString()
         });
-        expect(json).toEqual(expandToString`
+        expect(json).toEqual(normalize(expandToString`
             {
                 "$type": "Entry",
                 "elements": [
@@ -114,7 +114,7 @@ describe('JsonSerializer', async () => {
                     }
                 ]
             }
-        `);
+        `));
     });
 
     test('Revive reference to same document', async () => {
@@ -196,4 +196,8 @@ interface Entry extends AstNode {
 interface Element extends AstNode {
     name: string
     other?: Reference<Element>
+}
+
+function normalize(s: string): string {
+    return s.replace(/\r\n/g, '\n');
 }

--- a/packages/langium/test/serializer/json-serializer.test.ts
+++ b/packages/langium/test/serializer/json-serializer.test.ts
@@ -6,12 +6,12 @@
 
 import type { AstNode, Reference } from 'langium';
 import { beforeEach, describe, expect, test } from 'vitest';
-import { createServicesForGrammar, expandToString } from 'langium';
+import { createServicesForGrammar, expandToStringLF } from 'langium';
 import { clearDocuments, parseHelper } from 'langium/test';
 
 describe('JsonSerializer', async () => {
 
-    const grammar = expandToString`
+    const grammar = expandToStringLF`
         grammar JsonSerializerTest
 
         entry Entry: elements+=Element*;
@@ -36,7 +36,7 @@ describe('JsonSerializer', async () => {
         `);
         await services.shared.workspace.DocumentBuilder.build([document1, document1]);
         const json = serializer.serialize(document1.parseResult.value, { space: 4 });
-        expect(json).toEqual(normalize(expandToString`
+        expect(json).toEqual(expandToStringLF`
             {
                 "$type": "Entry",
                 "elements": [
@@ -53,7 +53,7 @@ describe('JsonSerializer', async () => {
                     }
                 ]
             }
-        `));
+        `);
     });
 
     test('Serialize reference to other document', async () => {
@@ -69,7 +69,7 @@ describe('JsonSerializer', async () => {
         });
         await services.shared.workspace.DocumentBuilder.build([document1, document2]);
         const json = serializer.serialize(document2.parseResult.value, { space: 4 });
-        expect(json).toEqual(normalize(expandToString`
+        expect(json).toEqual(expandToStringLF`
             {
                 "$type": "Entry",
                 "elements": [
@@ -82,7 +82,7 @@ describe('JsonSerializer', async () => {
                     }
                 ]
             }
-        `));
+        `);
     });
 
     test('Serialize reference to other document with custom URI converter', async () => {
@@ -101,7 +101,7 @@ describe('JsonSerializer', async () => {
             space: 4,
             uriConverter: (uri) => uri.with({ path: '/foo' + uri.path }).toString()
         });
-        expect(json).toEqual(normalize(expandToString`
+        expect(json).toEqual(expandToStringLF`
             {
                 "$type": "Entry",
                 "elements": [
@@ -114,11 +114,11 @@ describe('JsonSerializer', async () => {
                     }
                 ]
             }
-        `));
+        `);
     });
 
     test('Revive reference to same document', async () => {
-        const json = expandToString`
+        const json = expandToStringLF`
             {
                 "$type": "Entry",
                 "elements": [
@@ -148,7 +148,7 @@ describe('JsonSerializer', async () => {
             documentUri: 'file:///test1.langium'
         });
         await services.shared.workspace.DocumentBuilder.build([document1]);
-        const json = expandToString`
+        const json = expandToStringLF`
             {
                 "$type": "Entry",
                 "elements": [
@@ -168,7 +168,7 @@ describe('JsonSerializer', async () => {
     });
 
     test('Reference error with non-existing document', async () => {
-        const json = expandToString`
+        const json = expandToStringLF`
             {
                 "$type": "Entry",
                 "elements": [
@@ -196,8 +196,4 @@ interface Entry extends AstNode {
 interface Element extends AstNode {
     name: string
     other?: Reference<Element>
-}
-
-function normalize(s: string): string {
-    return s.replace(/\r\n/g, '\n');
 }


### PR DESCRIPTION
The current implementation of the JsonSerializer assumes that all cross-references point to nodes in the same document. This change adds support for references to other documents by including the document URI in the `$ref` string.