### PR TITLE
Add Langium file icon

### DIFF
--- a/packages/langium-vscode/package.json
+++ b/packages/langium-vscode/package.json
@@ -46,7 +46,11 @@
         "aliases": [
           "Langium"
         ],
-        "configuration": "./data/langium.configuration.json"
+        "configuration": "./data/langium.configuration.json",
+        "icon": {
+          "light": "./data/langium-logo.png",
+          "dark": "./data/langium-logo.png"
+        }
       }
     ],
     "grammars": [


### PR DESCRIPTION
Uses the extension icon for all `.langium` files. This way of adding file icons is fairly new. Previously, only file icon themes were able to contribute new icons. 

To test this, just start the extension and take a look at the `.langium` files in the navigator or editor tab. Both should have the langium logo as the file icon.