### PR TITLE
Partly revert change "Fix generator support on Windows (#857)"; introduced 'expandToStringLF' and 'expandToStringLFWithNL'

### DIFF
--- a/examples/statemachine/test/generator.test.ts
+++ b/examples/statemachine/test/generator.test.ts
@@ -7,7 +7,7 @@
 import type { Generated } from 'langium';
 import type { Statemachine } from '../src/language-server/generated/ast.js';
 import { describe, expect, test } from 'vitest';
-import { EmptyFileSystem, normalizeEOL, toString } from 'langium';
+import { EmptyFileSystem, expandToStringWithNL, toString } from 'langium';
 import { parseHelper } from 'langium/test';
 import { generateCppContent } from '../src/cli/generator.js';
 import { createStatemachineServices } from '../src/language-server/statemachine-module.js';
@@ -31,7 +31,7 @@ describe('Tests the code generator', () => {
     });
 });
 
-const input = `
+const input = expandToStringWithNL`
     statemachine TrafficLight
 
     events
@@ -60,8 +60,8 @@ const input = `
     end
 `;
 
-const expectedOutput =
-normalizeEOL(`#include <iostream>
+const expectedOutput = expandToStringWithNL`
+#include <iostream>
 #include <map>
 #include <string>
 
@@ -213,4 +213,4 @@ int main() {
     delete statemachine;
     return 0;
 }
-`);
+`;

--- a/packages/langium/src/generator/index.ts
+++ b/packages/langium/src/generator/index.ts
@@ -8,4 +8,5 @@ export * from './generator-node.js';
 export type { SourceRegion, TextRegion, TraceRegion, TraceSourceSpec } from './generator-tracing.js';
 export * from './node-joiner.js';
 export * from './template-node.js';
-export { expandToString, expandToStringWithNL, normalizeEOL } from './template-string.js';
+export { expandToString, expandToStringLF, expandToStringLFWithNL, expandToStringWithNL, normalizeEOL } from './template-string.js';
+

--- a/packages/langium/src/generator/template-string.ts
+++ b/packages/langium/src/generator/template-string.ts
@@ -10,14 +10,35 @@ export function expandToStringWithNL(staticParts: TemplateStringsArray, ...subst
     return expandToString(staticParts, ...substitutions) + EOL;
 }
 
+export function expandToStringLFWithNL(staticParts: TemplateStringsArray, ...substitutions: unknown[]): string {
+    return expandToStringLF(staticParts, ...substitutions) + '\n';
+}
+
 /**
  * A tag function that automatically aligns embedded multiline strings.
+ * Multiple lines are joined with the platform-specific line separator.
  *
  * @param staticParts the static parts of a tagged template literal
  * @param substitutions the variable parts of a tagged template literal
  * @returns an aligned string that consists of the given parts
  */
 export function expandToString(staticParts: TemplateStringsArray, ...substitutions: unknown[]): string {
+    return internalExpandToString(EOL, staticParts, ...substitutions);
+}
+
+/**
+ * A tag function that automatically aligns embedded multiline strings.
+ * Multiple lines are joined with the LINE_FEED (`\n`) line separator.
+ *
+ * @param staticParts the static parts of a tagged template literal
+ * @param substitutions the variable parts of a tagged template literal
+ * @returns an aligned string that consists of the given parts
+ */
+export function expandToStringLF(staticParts: TemplateStringsArray, ...substitutions: unknown[]): string {
+    return internalExpandToString('\n', staticParts, ...substitutions);
+}
+
+function internalExpandToString(lineSep: string, staticParts: TemplateStringsArray, ...substitutions: unknown[]): string {
     let lines = substitutions
         // align substitutions and fuse them with static parts
         .reduce((acc: string, subst: unknown, i: number) => acc + (subst === undefined ? SNLE : align(toString(subst), acc)) + (staticParts[i + 1] ?? ''), staticParts[0])
@@ -51,9 +72,9 @@ export function expandToString(staticParts: TemplateStringsArray, ...substitutio
     const indent = findIndentation(lines);
     return lines
         // shifts lines to the left
-        .map(line => line.slice(indent).trimRight())
+        .map(line => line.slice(indent).trimEnd())
         // convert lines to string
-        .join(EOL);
+        .join(lineSep);
 }
 
 export const SNLE = Object.freeze('__«SKIP^NEW^LINE^IF^EMPTY»__');

--- a/packages/langium/test/generator/template-string.test.ts
+++ b/packages/langium/test/generator/template-string.test.ts
@@ -5,7 +5,7 @@
  ******************************************************************************/
 
 import { expect, test } from 'vitest';
-import { expandToString as s, normalizeEOL } from 'langium';
+import { expandToStringLF as s } from 'langium';
 
 test('Should not throw when substituting null', () => {
     expect(s`${null}`).toBe('null');
@@ -16,10 +16,10 @@ test('Should not throw when substituting undefined', () => {
 });
 
 test('Should omit lines containing just a subsitution being undefined', () => {
-    const expected = normalizeEOL(`123
+    const expected = `123
 456
 abc
-def`);
+def`;
     expect(s`
         123
         ${456}
@@ -70,8 +70,8 @@ const frayedIndentation = s`
   test2
 `;
 
-const expectedFrayedIndentation = normalizeEOL(`  test1
-test2`);
+const expectedFrayedIndentation = `  test1
+test2`;
 
 const trimmedMultilineString = s`
   ${1}
@@ -86,7 +86,7 @@ const multilineStringWithWhitespace = s`
           ${3}${''}
     `;
 
-const expectedMultilineStringWithWhitespace = normalizeEOL('// we add some right space\n1\n  2\n    3');
+const expectedMultilineStringWithWhitespace = '// we add some right space\n1\n  2\n    3';
 
 const generator = () => {
     const applyMethod = (paramName: string) => s`
@@ -105,12 +105,12 @@ const generator = () => {
     `;
 };
 
-const expectedGeneratorOutput = normalizeEOL(`public interface PartialFunction<T, R> {
+const expectedGeneratorOutput = `public interface PartialFunction<T, R> {
     R apply(T t);
     boolean isDefinedAt(T t);
     @Override
     String toString() { return "T -> R"; }
-}`);
+}`;
 
 const nestedIndentation = s`
 ${1}x
@@ -120,6 +120,6 @@ ${1}x
   `}
 `;
 
-const expectedNestedIndentation = normalizeEOL(`1x
+const expectedNestedIndentation = `1x
       test1
-  test2`);
+  test2`;


### PR DESCRIPTION
@spoenemann this will improve your line sep issue in https://github.com/eclipse-langium/langium/pull/1254/files#diff-166bffa727392669c60e01fc8dd00f12bc664e7eb80dd808dea9976a004a8cfb