### PR TITLE
Flush semantic token builder cache on request

### DIFF
--- a/packages/langium/src/lsp/semantic-token-provider.ts
+++ b/packages/langium/src/lsp/semantic-token-provider.ts
@@ -205,6 +205,7 @@ export abstract class AbstractSemanticTokenProvider implements SemanticTokenProv
         this.currentRange = undefined;
         this.currentDocument = document;
         this.currentTokensBuilder = this.getDocumentTokensBuilder(document);
+        // Flush the current state - we don't want to perform a delta highlighting
         this.currentTokensBuilder.previousResult(this.currentTokensBuilder.id);
         await this.computeHighlighting(document, this.createAcceptor(), cancelToken);
         return this.currentTokensBuilder.build();
@@ -214,6 +215,7 @@ export abstract class AbstractSemanticTokenProvider implements SemanticTokenProv
         this.currentRange = params.range;
         this.currentDocument = document;
         this.currentTokensBuilder = this.getDocumentTokensBuilder(document);
+        // Flush the current state - we don't want to perform a delta highlighting
         this.currentTokensBuilder.previousResult(this.currentTokensBuilder.id);
         await this.computeHighlighting(document, this.createAcceptor(), cancelToken);
         return this.currentTokensBuilder.build();

--- a/packages/langium/src/lsp/semantic-token-provider.ts
+++ b/packages/langium/src/lsp/semantic-token-provider.ts
@@ -205,6 +205,7 @@ export abstract class AbstractSemanticTokenProvider implements SemanticTokenProv
         this.currentRange = undefined;
         this.currentDocument = document;
         this.currentTokensBuilder = this.getDocumentTokensBuilder(document);
+        this.currentTokensBuilder.previousResult(this.currentTokensBuilder.id);
         await this.computeHighlighting(document, this.createAcceptor(), cancelToken);
         return this.currentTokensBuilder.build();
     }
@@ -213,6 +214,7 @@ export abstract class AbstractSemanticTokenProvider implements SemanticTokenProv
         this.currentRange = params.range;
         this.currentDocument = document;
         this.currentTokensBuilder = this.getDocumentTokensBuilder(document);
+        this.currentTokensBuilder.previousResult(this.currentTokensBuilder.id);
         await this.computeHighlighting(document, this.createAcceptor(), cancelToken);
         return this.currentTokensBuilder.build();
     }


### PR DESCRIPTION
Related to https://github.com/eclipse-langium/langium/discussions/1283

I wasn't able to reproduce this - it might only appear in the monaco-vscode-api package, which probably slightly differs in how vscode invokes the semantic token provider.

Anyway, flushing the cache when we perform a non-delta updates seems pretty reasonable on my side. The main issue was that the semantic token builder from the `vscode-languageserver` package is pretty undocumented and gives little help on how to use it.

It also seems to fix the issue that @cdietrich was experiencing with a web based Langium LSP worker.