### PR TITLE
Introduce DocumentUpdateHandler service

### DIFF
--- a/examples/arithmetics/src/extension.ts
+++ b/examples/arithmetics/src/extension.ts
@@ -5,7 +5,7 @@
  ******************************************************************************/
 
 import type { LanguageClientOptions, ServerOptions } from 'vscode-languageclient/node.js';
-import * as vscode from 'vscode';
+import type * as vscode from 'vscode';
 import * as path from 'node:path';
 import { LanguageClient, TransportKind } from 'vscode-languageclient/node.js';
 
@@ -37,16 +37,9 @@ function startLanguageClient(context: vscode.ExtensionContext): LanguageClient {
         debug: { module: serverModule, transport: TransportKind.ipc, options: debugOptions }
     };
 
-    const fileSystemWatcher = vscode.workspace.createFileSystemWatcher('**/*.calc');
-    context.subscriptions.push(fileSystemWatcher);
-
     // Options to control the language client
     const clientOptions: LanguageClientOptions = {
-        documentSelector: [{ scheme: 'file', language: 'arithmetics' }],
-        synchronize: {
-            // Notify the server about file changes to files contained in the workspace
-            fileEvents: fileSystemWatcher
-        }
+        documentSelector: [{ scheme: 'file', language: 'arithmetics' }]
     };
 
     // Create the language client and start the client.

--- a/examples/domainmodel/src/extension.ts
+++ b/examples/domainmodel/src/extension.ts
@@ -5,7 +5,7 @@
  ******************************************************************************/
 
 import type { LanguageClientOptions, ServerOptions } from 'vscode-languageclient/node.js';
-import * as vscode from 'vscode';
+import type * as vscode from 'vscode';
 import * as path from 'node:path';
 import { LanguageClient, TransportKind } from 'vscode-languageclient/node.js';
 
@@ -37,16 +37,9 @@ function startLanguageClient(context: vscode.ExtensionContext): LanguageClient {
         debug: { module: serverModule, transport: TransportKind.ipc, options: debugOptions }
     };
 
-    const fileSystemWatcher = vscode.workspace.createFileSystemWatcher('**/*.dmodel');
-    context.subscriptions.push(fileSystemWatcher);
-
     // Options to control the language client
     const clientOptions: LanguageClientOptions = {
-        documentSelector: [{ scheme: 'file', language: 'domain-model' }],
-        synchronize: {
-            // Notify the server about file changes to files contained in the workspace
-            fileEvents: fileSystemWatcher
-        }
+        documentSelector: [{ scheme: 'file', language: 'domain-model' }]
     };
 
     // Create the language client and start the client.

--- a/examples/requirements/src/extension.ts
+++ b/examples/requirements/src/extension.ts
@@ -6,7 +6,7 @@
 
 import type { LanguageClientOptions, ServerOptions } from 'vscode-languageclient/node.js';
 import { LanguageClient, TransportKind } from 'vscode-languageclient/node.js';
-import * as vscode from 'vscode';
+import type * as vscode from 'vscode';
 import * as path from 'node:path';
 
 let client: LanguageClient;
@@ -38,18 +38,11 @@ function startLanguageClient(context: vscode.ExtensionContext): LanguageClient {
         debug: { module: serverModule, transport: TransportKind.ipc, options: debugOptions }
     };
 
-    const fileSystemWatcher = vscode.workspace.createFileSystemWatcher('**/*.(req|tst)');
-    context.subscriptions.push(fileSystemWatcher);
-
     // Options to control the language client
     const clientOptions: LanguageClientOptions = {
         documentSelector: [
             { scheme: 'file', language: 'tests-lang' },
-            { scheme: 'file', language: 'requirements-lang' }],
-        synchronize: {
-            // Notify the server about file changes to files contained in the workspace
-            fileEvents: fileSystemWatcher
-        }
+            { scheme: 'file', language: 'requirements-lang' }]
     };
 
     // Create the language client and start the client.

--- a/examples/statemachine/src/extension.ts
+++ b/examples/statemachine/src/extension.ts
@@ -5,7 +5,7 @@
  ******************************************************************************/
 
 import type { LanguageClientOptions, ServerOptions } from 'vscode-languageclient/node.js';
-import * as vscode from 'vscode';
+import type * as vscode from 'vscode';
 import * as path from 'node:path';
 import { LanguageClient, TransportKind } from 'vscode-languageclient/node.js';
 
@@ -37,16 +37,9 @@ function startLanguageClient(context: vscode.ExtensionContext): LanguageClient {
         debug: { module: serverModule, transport: TransportKind.ipc, options: debugOptions }
     };
 
-    const fileSystemWatcher = vscode.workspace.createFileSystemWatcher('**/*.statemachine');
-    context.subscriptions.push(fileSystemWatcher);
-
     // Options to control the language client
     const clientOptions: LanguageClientOptions = {
-        documentSelector: [{ scheme: 'file', language: 'statemachine' }],
-        synchronize: {
-            // Notify the server about file changes to files contained in the workspace
-            fileEvents: fileSystemWatcher
-        }
+        documentSelector: [{ scheme: 'file', language: 'statemachine' }]
     };
 
     // Create the language client and start the client.

--- a/packages/generator-langium/templates/vscode/src/extension/main.ts
+++ b/packages/generator-langium/templates/vscode/src/extension/main.ts
@@ -1,5 +1,5 @@
 import type { LanguageClientOptions, ServerOptions} from 'vscode-languageclient/node.js';
-import * as vscode from 'vscode';
+import type * as vscode from 'vscode';
 import * as path from 'node:path';
 import { LanguageClient, TransportKind } from 'vscode-languageclient/node.js';
 
@@ -32,16 +32,9 @@ function startLanguageClient(context: vscode.ExtensionContext): LanguageClient {
         debug: { module: serverModule, transport: TransportKind.ipc, options: debugOptions }
     };
 
-    const fileSystemWatcher = vscode.workspace.createFileSystemWatcher('**/*.<%= file-glob-extension %>');
-    context.subscriptions.push(fileSystemWatcher);
-
     // Options to control the language client
     const clientOptions: LanguageClientOptions = {
-        documentSelector: [{ scheme: 'file', language: '<%= language-id %>' }],
-        synchronize: {
-            // Notify the server about file changes to files contained in the workspace
-            fileEvents: fileSystemWatcher
-        }
+        documentSelector: [{ scheme: 'file', language: '<%= language-id %>' }]
     };
 
     // Create the language client and start the client.

--- a/packages/langium-vscode/src/extension.ts
+++ b/packages/langium-vscode/src/extension.ts
@@ -45,17 +45,10 @@ async function startLanguageClient(context: vscode.ExtensionContext): Promise<La
         }
     };
 
-    const fileSystemWatcher = vscode.workspace.createFileSystemWatcher('**/*.langium');
-    context.subscriptions.push(fileSystemWatcher);
-
     // Options to control the language client
     const clientOptions: LanguageClientOptions = {
         // Register the server for langium documents
-        documentSelector: [{ scheme: 'file', language: 'langium' }],
-        synchronize: {
-            // Notify the server about file changes to langium files contained in the workspace
-            fileEvents: fileSystemWatcher
-        }
+        documentSelector: [{ scheme: 'file', language: 'langium' }]
     };
 
     // Create the language client and start the client.

--- a/packages/langium/src/default-module.ts
+++ b/packages/langium/src/default-module.ts
@@ -15,6 +15,7 @@ import { createCompletionParser } from './parser/completion-parser-builder.js';
 import { DefaultCompletionProvider } from './lsp/completion/completion-provider.js';
 import { DefaultDocumentHighlightProvider } from './lsp/document-highlight-provider.js';
 import { DefaultDocumentSymbolProvider } from './lsp/document-symbol-provider.js';
+import { DefaultDocumentUpdateHandler } from './lsp/document-update-handler.js';
 import { DefaultFoldingRangeProvider } from './lsp/folding-range-provider.js';
 import { DefaultFuzzyMatcher } from './lsp/fuzzy-matcher.js';
 import { DefaultDefinitionProvider } from './lsp/definition-provider.js';
@@ -136,6 +137,7 @@ export function createDefaultSharedModule(context: DefaultSharedModuleContext): 
         lsp: {
             Connection: () => context.connection,
             LanguageServer: (services) => new DefaultLanguageServer(services),
+            DocumentUpdateHandler: (services) => new DefaultDocumentUpdateHandler(services),
             WorkspaceSymbolProvider: (services) => new DefaultWorkspaceSymbolProvider(services),
             NodeKindProvider: () => new DefaultNodeKindProvider(),
             FuzzyMatcher: () => new DefaultFuzzyMatcher()

--- a/packages/langium/src/lsp/document-update-handler.ts
+++ b/packages/langium/src/lsp/document-update-handler.ts
@@ -1,0 +1,135 @@
+/******************************************************************************
+ * Copyright 2023 TypeFox GmbH
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License, which is available in the project root.
+ ******************************************************************************/
+
+import type { CreateFilesParams, DeleteFilesParams, DidChangeWatchedFilesParams, DidChangeWatchedFilesRegistrationOptions, FileOperationOptions, RenameFilesParams, TextDocumentChangeEvent, WorkspaceEdit} from 'vscode-languageserver';
+import type { TextDocument } from 'vscode-languageserver-textdocument';
+import type { LangiumSharedServices } from '../services.js';
+import type { MaybePromise, MutexLock } from '../utils/promise-util.js';
+import type { DocumentBuilder } from '../workspace/document-builder.js';
+import { DidChangeWatchedFilesNotification, FileChangeType } from 'vscode-languageserver';
+import { URI } from 'vscode-uri';
+import { stream } from '../utils/stream.js';
+
+/**
+ * Shared service for handling document changes such as content changes, file creation, file deletion, etc.
+ * The interface methods are optional, so they are only registered if they are implemented.
+ */
+export interface DocumentUpdateHandler {
+
+    /**
+     * These options are reported to the client as part of the ServerCapabilities.
+     */
+    readonly fileOperationOptions?: FileOperationOptions;
+
+    /**
+     * A content change event was triggered by the `TextDocuments` service.
+     */
+    didChangeContent?(change: TextDocumentChangeEvent<TextDocument>): void;
+
+    /**
+     * The client detected changes to files and folders watched by the language client.
+     */
+    didChangeWatchedFiles?(params: DidChangeWatchedFilesParams): void;
+
+    /**
+     * Files were created from within the client.
+     * This notification must be registered with the {@link fileOperationOptions}.
+     */
+    didCreateFiles?(params: CreateFilesParams): void;
+
+    /**
+     * Files were renamed from within the client.
+     * This notification must be registered with the {@link fileOperationOptions}.
+     */
+    didRenameFiles?(params: RenameFilesParams): void;
+
+    /**
+     * Files were deleted from within the client.
+     * This notification must be registered with the {@link fileOperationOptions}.
+     */
+    didDeleteFiles?(params: DeleteFilesParams): void;
+
+    /**
+     * Called before files are actually created as long as the creation is triggered from within
+     * the client either by a user action or by applying a workspace edit.
+     * This request must be registered with the {@link fileOperationOptions}.
+     * @returns a WorkspaceEdit which will be applied to workspace before the files are created.
+     */
+    willCreateFiles?(params: CreateFilesParams): MaybePromise<WorkspaceEdit | null>;
+
+    /**
+     * Called before files are actually renamed as long as the rename is triggered from within
+     * the client either by a user action or by applying a workspace edit.
+     * This request must be registered with the {@link fileOperationOptions}.
+     * @returns a WorkspaceEdit which will be applied to workspace before the files are renamed.
+     */
+    willRenameFiles?(params: RenameFilesParams): MaybePromise<WorkspaceEdit | null>;
+
+    /**
+     * Called before files are actually deleted as long as the deletion is triggered from within
+     * the client either by a user action or by applying a workspace edit.
+     * This request must be registered with the {@link fileOperationOptions}.
+     * @returns a WorkspaceEdit which will be applied to workspace before the files are deleted.
+     */
+    willDeleteFiles?(params: DeleteFilesParams): MaybePromise<WorkspaceEdit | null>;
+
+}
+
+export class DefaultDocumentUpdateHandler implements DocumentUpdateHandler {
+
+    protected readonly documentBuilder: DocumentBuilder;
+    protected readonly mutexLock: MutexLock;
+
+    constructor(services: LangiumSharedServices) {
+        this.documentBuilder = services.workspace.DocumentBuilder;
+        this.mutexLock = services.workspace.MutexLock;
+
+        let canRegisterFileWatcher = false;
+        services.lsp.LanguageServer.onInitialize(params => {
+            canRegisterFileWatcher = Boolean(params.capabilities.workspace?.didChangeWatchedFiles?.dynamicRegistration);
+        });
+
+        services.lsp.LanguageServer.onInitialized(_params => {
+            if (canRegisterFileWatcher) {
+                this.registerFileWatcher(services);
+            }
+        });
+    }
+
+    protected registerFileWatcher(services: LangiumSharedServices): void {
+        const fileExtensions = stream(services.ServiceRegistry.all)
+            .flatMap(language => language.LanguageMetaData.fileExtensions)
+            .map(ext => ext.startsWith('.') ? ext.substring(1) : ext)
+            .distinct()
+            .toArray();
+        if (fileExtensions.length > 0) {
+            const connection = services.lsp.Connection;
+            const options: DidChangeWatchedFilesRegistrationOptions = {
+                watchers: [{
+                    globPattern: fileExtensions.length === 1
+                        ? `**/*.${fileExtensions[0]}`
+                        : `**/*.{${fileExtensions.join(',')}}`
+                }]
+            };
+            connection?.client.register(DidChangeWatchedFilesNotification.type, options);
+        }
+    }
+
+    protected fireDocumentUpdate(changed: URI[], deleted: URI[]): void {
+        this.mutexLock.lock(token => this.documentBuilder.update(changed, deleted, token));
+    }
+
+    didChangeContent(change: TextDocumentChangeEvent<TextDocument>): void {
+        this.fireDocumentUpdate([URI.parse(change.document.uri)], []);
+    }
+
+    didChangeWatchedFiles(params: DidChangeWatchedFilesParams): void {
+        const changedUris = params.changes.filter(c => c.type !== FileChangeType.Deleted).map(c => URI.parse(c.uri));
+        const deletedUris = params.changes.filter(c => c.type === FileChangeType.Deleted).map(c => URI.parse(c.uri));
+        this.fireDocumentUpdate(changedUris, deletedUris);
+    }
+
+}

--- a/packages/langium/src/lsp/document-update-handler.ts
+++ b/packages/langium/src/lsp/document-update-handler.ts
@@ -79,8 +79,16 @@ export class DefaultDocumentUpdateHandler implements DocumentUpdateHandler {
     }
 
     didChangeWatchedFiles(params: DidChangeWatchedFilesParams): void {
-        const changedUris = params.changes.filter(c => c.type !== FileChangeType.Deleted).map(c => URI.parse(c.uri));
-        const deletedUris = params.changes.filter(c => c.type === FileChangeType.Deleted).map(c => URI.parse(c.uri));
+        const changedUris = stream(params.changes)
+            .filter(c => c.type !== FileChangeType.Deleted)
+            .distinct(c => c.uri)
+            .map(c => URI.parse(c.uri))
+            .toArray();
+        const deletedUris = stream(params.changes)
+            .filter(c => c.type === FileChangeType.Deleted)
+            .distinct(c => c.uri)
+            .map(c => URI.parse(c.uri))
+            .toArray();
         this.fireDocumentUpdate(changedUris, deletedUris);
     }
 

--- a/packages/langium/src/lsp/document-update-handler.ts
+++ b/packages/langium/src/lsp/document-update-handler.ts
@@ -4,77 +4,29 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import type { CreateFilesParams, DeleteFilesParams, DidChangeWatchedFilesParams, DidChangeWatchedFilesRegistrationOptions, FileOperationOptions, RenameFilesParams, TextDocumentChangeEvent, WorkspaceEdit} from 'vscode-languageserver';
+import type { DidChangeWatchedFilesParams, DidChangeWatchedFilesRegistrationOptions, TextDocumentChangeEvent } from 'vscode-languageserver';
 import type { TextDocument } from 'vscode-languageserver-textdocument';
 import type { LangiumSharedServices } from '../services.js';
-import type { MaybePromise, MutexLock } from '../utils/promise-util.js';
+import type { MutexLock } from '../utils/promise-util.js';
 import type { DocumentBuilder } from '../workspace/document-builder.js';
 import { DidChangeWatchedFilesNotification, FileChangeType } from 'vscode-languageserver';
 import { URI } from 'vscode-uri';
 import { stream } from '../utils/stream.js';
 
 /**
- * Shared service for handling document changes such as content changes, file creation, file deletion, etc.
- * The interface methods are optional, so they are only registered if they are implemented.
+ * Shared service for handling text document changes and watching relevant files.
  */
 export interface DocumentUpdateHandler {
 
     /**
-     * These options are reported to the client as part of the ServerCapabilities.
-     */
-    readonly fileOperationOptions?: FileOperationOptions;
-
-    /**
      * A content change event was triggered by the `TextDocuments` service.
      */
-    didChangeContent?(change: TextDocumentChangeEvent<TextDocument>): void;
+    didChangeContent(change: TextDocumentChangeEvent<TextDocument>): void;
 
     /**
      * The client detected changes to files and folders watched by the language client.
      */
-    didChangeWatchedFiles?(params: DidChangeWatchedFilesParams): void;
-
-    /**
-     * Files were created from within the client.
-     * This notification must be registered with the {@link fileOperationOptions}.
-     */
-    didCreateFiles?(params: CreateFilesParams): void;
-
-    /**
-     * Files were renamed from within the client.
-     * This notification must be registered with the {@link fileOperationOptions}.
-     */
-    didRenameFiles?(params: RenameFilesParams): void;
-
-    /**
-     * Files were deleted from within the client.
-     * This notification must be registered with the {@link fileOperationOptions}.
-     */
-    didDeleteFiles?(params: DeleteFilesParams): void;
-
-    /**
-     * Called before files are actually created as long as the creation is triggered from within
-     * the client either by a user action or by applying a workspace edit.
-     * This request must be registered with the {@link fileOperationOptions}.
-     * @returns a WorkspaceEdit which will be applied to workspace before the files are created.
-     */
-    willCreateFiles?(params: CreateFilesParams): MaybePromise<WorkspaceEdit | null>;
-
-    /**
-     * Called before files are actually renamed as long as the rename is triggered from within
-     * the client either by a user action or by applying a workspace edit.
-     * This request must be registered with the {@link fileOperationOptions}.
-     * @returns a WorkspaceEdit which will be applied to workspace before the files are renamed.
-     */
-    willRenameFiles?(params: RenameFilesParams): MaybePromise<WorkspaceEdit | null>;
-
-    /**
-     * Called before files are actually deleted as long as the deletion is triggered from within
-     * the client either by a user action or by applying a workspace edit.
-     * This request must be registered with the {@link fileOperationOptions}.
-     * @returns a WorkspaceEdit which will be applied to workspace before the files are deleted.
-     */
-    willDeleteFiles?(params: DeleteFilesParams): MaybePromise<WorkspaceEdit | null>;
+    didChangeWatchedFiles(params: DidChangeWatchedFilesParams): void;
 
 }
 

--- a/packages/langium/src/lsp/file-operation-handler.ts
+++ b/packages/langium/src/lsp/file-operation-handler.ts
@@ -1,0 +1,63 @@
+/******************************************************************************
+ * Copyright 2023 TypeFox GmbH
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License, which is available in the project root.
+ ******************************************************************************/
+
+import type { CreateFilesParams, DeleteFilesParams, FileOperationOptions, RenameFilesParams, WorkspaceEdit } from 'vscode-languageserver';
+import type { MaybePromise } from '../utils/promise-util.js';
+
+/**
+ * Shared service for handling file changes such as file creation, deletion and renaming.
+ * The interface methods are optional, so they are only registered if they are implemented.
+ */
+export interface FileOperationHandler {
+
+    /**
+     * These options are reported to the client as part of the ServerCapabilities.
+     */
+    readonly fileOperationOptions: FileOperationOptions;
+
+    /**
+     * Files were created from within the client.
+     * This notification must be registered with the {@link fileOperationOptions}.
+     */
+    didCreateFiles?(params: CreateFilesParams): void;
+
+    /**
+     * Files were renamed from within the client.
+     * This notification must be registered with the {@link fileOperationOptions}.
+     */
+    didRenameFiles?(params: RenameFilesParams): void;
+
+    /**
+     * Files were deleted from within the client.
+     * This notification must be registered with the {@link fileOperationOptions}.
+     */
+    didDeleteFiles?(params: DeleteFilesParams): void;
+
+    /**
+     * Called before files are actually created as long as the creation is triggered from within
+     * the client either by a user action or by applying a workspace edit.
+     * This request must be registered with the {@link fileOperationOptions}.
+     * @returns a WorkspaceEdit which will be applied to workspace before the files are created.
+     */
+    willCreateFiles?(params: CreateFilesParams): MaybePromise<WorkspaceEdit | null>;
+
+    /**
+     * Called before files are actually renamed as long as the rename is triggered from within
+     * the client either by a user action or by applying a workspace edit.
+     * This request must be registered with the {@link fileOperationOptions}.
+     * @returns a WorkspaceEdit which will be applied to workspace before the files are renamed.
+     */
+    willRenameFiles?(params: RenameFilesParams): MaybePromise<WorkspaceEdit | null>;
+
+    /**
+     * Called before files are actually deleted as long as the deletion is triggered from within
+     * the client either by a user action or by applying a workspace edit.
+     * This request must be registered with the {@link fileOperationOptions}.
+     * @returns a WorkspaceEdit which will be applied to workspace before the files are deleted.
+     */
+    willDeleteFiles?(params: DeleteFilesParams): MaybePromise<WorkspaceEdit | null>;
+
+}

--- a/packages/langium/src/lsp/language-server.ts
+++ b/packages/langium/src/lsp/language-server.ts
@@ -87,7 +87,7 @@ export class DefaultLanguageServer implements LanguageServer {
 
     protected buildInitializeResult(_params: InitializeParams): InitializeResult {
         const languages = this.services.ServiceRegistry.all;
-        const fileOperationOptions = this.services.lsp.DocumentUpdateHandler.fileOperationOptions;
+        const fileOperationOptions = this.services.lsp.FileOperationHandler?.fileOperationOptions;
         const hasFormattingService = this.hasService(e => e.lsp.Formatter);
         const formattingOnTypeOptions = languages.map(e => e.lsp.Formatter?.formatOnTypeOptions).find(e => Boolean(e));
         const hasCodeActionProvider = this.hasService(e => e.lsp.CodeActionProvider);
@@ -183,6 +183,7 @@ export function startLanguageServer(services: LangiumSharedServices): void {
     }
 
     addDocumentsHandler(connection, services);
+    addFileOperationHandler(connection, services);
     addDiagnosticsHandler(connection, services);
     addCompletionHandler(connection, services);
     addFindReferencesHandler(connection, services);
@@ -231,6 +232,13 @@ export function addDocumentsHandler(connection: Connection, services: LangiumSha
     }
     if (handler.didChangeWatchedFiles) {
         connection.onDidChangeWatchedFiles(params => handler.didChangeWatchedFiles!(params));
+    }
+}
+
+export function addFileOperationHandler(connection: Connection, services: LangiumSharedServices): void {
+    const handler = services.lsp.FileOperationHandler;
+    if (!handler) {
+        return;
     }
     if (handler.didCreateFiles) {
         connection.workspace.onDidCreateFiles(params => handler.didCreateFiles!(params));

--- a/packages/langium/src/lsp/language-server.ts
+++ b/packages/langium/src/lsp/language-server.ts
@@ -182,7 +182,7 @@ export function startLanguageServer(services: LangiumSharedServices): void {
         throw new Error('Starting a language server requires the languageServer.Connection service to be set.');
     }
 
-    addDocumentsHandler(connection, services);
+    addDocumentUpdateHandler(connection, services);
     addFileOperationHandler(connection, services);
     addDiagnosticsHandler(connection, services);
     addCompletionHandler(connection, services);
@@ -224,15 +224,11 @@ export function startLanguageServer(services: LangiumSharedServices): void {
     connection.listen();
 }
 
-export function addDocumentsHandler(connection: Connection, services: LangiumSharedServices): void {
+export function addDocumentUpdateHandler(connection: Connection, services: LangiumSharedServices): void {
     const handler = services.lsp.DocumentUpdateHandler;
     const documents = services.workspace.TextDocuments;
-    if (handler.didChangeContent) {
-        documents.onDidChangeContent(change => handler.didChangeContent!(change));
-    }
-    if (handler.didChangeWatchedFiles) {
-        connection.onDidChangeWatchedFiles(params => handler.didChangeWatchedFiles!(params));
-    }
+    documents.onDidChangeContent(change => handler.didChangeContent(change));
+    connection.onDidChangeWatchedFiles(params => handler.didChangeWatchedFiles(params));
 }
 
 export function addFileOperationHandler(connection: Connection, services: LangiumSharedServices): void {

--- a/packages/langium/src/services.ts
+++ b/packages/langium/src/services.ts
@@ -51,9 +51,10 @@ import type { SignatureHelpProvider } from './lsp/signature-help-provider.js';
 import type { TypeDefinitionProvider } from './lsp/type-provider.js';
 import type { ImplementationProvider } from './lsp/implementation-provider.js';
 import type { CallHierarchyProvider } from './lsp/call-hierarchy-provider.js';
-import type { DocumentLinkProvider } from './lsp/document-link-provider.js';
 import type { CodeLensProvider } from './lsp/code-lens-provider.js';
 import type { DeclarationProvider } from './lsp/declaration-provider.js';
+import type { DocumentLinkProvider } from './lsp/document-link-provider.js';
+import type { DocumentUpdateHandler } from './lsp/document-update-handler.js';
 import type { DocumentationProvider } from './documentation/documentation-provider.js';
 import type { InlayHintProvider } from './lsp/inlay-hint-provider.js';
 import type { CommentProvider } from './documentation/comment-provider.js';
@@ -162,11 +163,12 @@ export type LangiumDefaultSharedServices = {
     ServiceRegistry: ServiceRegistry
     lsp: {
         Connection?: Connection
+        LanguageServer: LanguageServer
+        DocumentUpdateHandler: DocumentUpdateHandler
         ExecuteCommandHandler?: ExecuteCommandHandler
         WorkspaceSymbolProvider?: WorkspaceSymbolProvider
         NodeKindProvider: NodeKindProvider
         FuzzyMatcher: FuzzyMatcher
-        LanguageServer: LanguageServer
     }
     workspace: {
         DocumentBuilder: DocumentBuilder

--- a/packages/langium/src/services.ts
+++ b/packages/langium/src/services.ts
@@ -56,6 +56,7 @@ import type { DeclarationProvider } from './lsp/declaration-provider.js';
 import type { DocumentLinkProvider } from './lsp/document-link-provider.js';
 import type { DocumentUpdateHandler } from './lsp/document-update-handler.js';
 import type { DocumentationProvider } from './documentation/documentation-provider.js';
+import type { FileOperationHandler } from './lsp/file-operation-handler.js';
 import type { InlayHintProvider } from './lsp/inlay-hint-provider.js';
 import type { CommentProvider } from './documentation/comment-provider.js';
 import type { WorkspaceSymbolProvider } from './lsp/workspace-symbol-provider.js';
@@ -166,6 +167,7 @@ export type LangiumDefaultSharedServices = {
         LanguageServer: LanguageServer
         DocumentUpdateHandler: DocumentUpdateHandler
         ExecuteCommandHandler?: ExecuteCommandHandler
+        FileOperationHandler?: FileOperationHandler
         WorkspaceSymbolProvider?: WorkspaceSymbolProvider
         NodeKindProvider: NodeKindProvider
         FuzzyMatcher: FuzzyMatcher

--- a/packages/langium/src/services.ts
+++ b/packages/langium/src/services.ts
@@ -81,26 +81,26 @@ export type LangiumGeneratedServices = {
  * Services related to the Language Server Protocol (LSP).
  */
 export type LangiumLspServices = {
-    CompletionProvider?: CompletionProvider
-    DocumentHighlightProvider?: DocumentHighlightProvider
-    DocumentSymbolProvider?: DocumentSymbolProvider
-    HoverProvider?: HoverProvider
-    FoldingRangeProvider?: FoldingRangeProvider
-    DefinitionProvider?: DefinitionProvider
-    TypeProvider?: TypeDefinitionProvider
-    ImplementationProvider?: ImplementationProvider
-    ReferencesProvider?: ReferencesProvider
-    CodeActionProvider?: CodeActionProvider
-    SemanticTokenProvider?: SemanticTokenProvider
-    RenameProvider?: RenameProvider
-    Formatter?: Formatter
-    SignatureHelp?: SignatureHelpProvider
     CallHierarchyProvider?: CallHierarchyProvider
-    TypeHierarchyProvider?: TypeHierarchyProvider;
-    DeclarationProvider?: DeclarationProvider
-    InlayHintProvider?: InlayHintProvider
+    CodeActionProvider?: CodeActionProvider
     CodeLensProvider?: CodeLensProvider
+    CompletionProvider?: CompletionProvider
+    DeclarationProvider?: DeclarationProvider
+    DefinitionProvider?: DefinitionProvider
+    DocumentHighlightProvider?: DocumentHighlightProvider
     DocumentLinkProvider?: DocumentLinkProvider
+    DocumentSymbolProvider?: DocumentSymbolProvider
+    FoldingRangeProvider?: FoldingRangeProvider
+    Formatter?: Formatter
+    HoverProvider?: HoverProvider
+    ImplementationProvider?: ImplementationProvider
+    InlayHintProvider?: InlayHintProvider
+    ReferencesProvider?: ReferencesProvider
+    RenameProvider?: RenameProvider
+    SemanticTokenProvider?: SemanticTokenProvider
+    SignatureHelp?: SignatureHelpProvider
+    TypeHierarchyProvider?: TypeHierarchyProvider;
+    TypeProvider?: TypeDefinitionProvider
 }
 
 /**
@@ -164,24 +164,24 @@ export type LangiumDefaultSharedServices = {
     ServiceRegistry: ServiceRegistry
     lsp: {
         Connection?: Connection
-        LanguageServer: LanguageServer
         DocumentUpdateHandler: DocumentUpdateHandler
         ExecuteCommandHandler?: ExecuteCommandHandler
         FileOperationHandler?: FileOperationHandler
-        WorkspaceSymbolProvider?: WorkspaceSymbolProvider
-        NodeKindProvider: NodeKindProvider
         FuzzyMatcher: FuzzyMatcher
+        LanguageServer: LanguageServer
+        NodeKindProvider: NodeKindProvider
+        WorkspaceSymbolProvider?: WorkspaceSymbolProvider
     }
     workspace: {
+        ConfigurationProvider: ConfigurationProvider
         DocumentBuilder: DocumentBuilder
+        FileSystemProvider: FileSystemProvider
         IndexManager: IndexManager
         LangiumDocuments: LangiumDocuments
         LangiumDocumentFactory: LangiumDocumentFactory
+        MutexLock: MutexLock
         TextDocuments: TextDocuments<TextDocument>
         WorkspaceManager: WorkspaceManager
-        FileSystemProvider: FileSystemProvider
-        MutexLock: MutexLock
-        ConfigurationProvider: ConfigurationProvider
     }
 }
 


### PR DESCRIPTION
Fixes #1272.

In addition, I stumbled over this statement from the LSP specification, [didChangeWatchedFiles notification](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_didChangeWatchedFiles):

> It is recommended that servers register for these file system events using the registration mechanism. In former implementations clients pushed file events without the server actively asking for it.

The default implementation of the new DocumentUpdateHandler service, which listens and reacts to `didChangeWatchedFiles` notifications, takes care of registering a file watcher so this doesn't have to be done by the client. This solves the problem I described in https://github.com/eclipse-langium/langium/issues/1230#issuecomment-1785356096:

> ...what I don't like about it is that we have a distribution of responsibilities between language client and language server code. It would be better to find a solution where watched file system events are specified fully on the client or server side.

We should test this thoroughly, and also check what happens if the client still creates a FileSystemWatcher – does the language server receive the notifications twice? In that case, this is a breaking change that should be well documented in the CHANGELOG.