### PR TITLE
Add validation against function call recursion #1019

### DIFF
--- a/examples/arithmetics/README.md
+++ b/examples/arithmetics/README.md
@@ -10,6 +10,7 @@ The Arithmetics Example features an interpreter that you can run via cli.
 The interpreter calculates each Evaluation in the source file and prints the result.
 
 You also can use `arithmetics-cli` as a replacement for `node ./bin/cli`, if you install the cli globally.
+
 * Run `npm install -g ./` from the arithmetics directory.
 * Use `arithmetics-cli` or `arithmetics-cli eval <full-path-to-calc-file>`.
 

--- a/examples/arithmetics/example/recursions.calc
+++ b/examples/arithmetics/example/recursions.calc
@@ -1,7 +1,7 @@
 Module recursions
 
 def fun1(x):
-    fun2(x) + fun2(x) + fun3(x);
+    fun1(x) + fun2(x) + fun2(x) + fun3(x);
 
 def fun2(x):
     fun3(x) + fun4(x);

--- a/examples/arithmetics/example/recursions.calc
+++ b/examples/arithmetics/example/recursions.calc
@@ -1,0 +1,19 @@
+Module recursions
+
+def fun1(x):
+    fun2(x) + fun2(x) + fun3(x);
+
+def fun2(x):
+    fun3(x) + fun4(x);
+
+def fun3(x):
+    3*x;
+
+def fun4(x):
+    fun3(x) + fun1(x);
+
+def fun5(x):
+    fun6(x);
+
+def fun6(x):
+    fun5(x);

--- a/examples/arithmetics/src/language-server/arithmetics-util.ts
+++ b/examples/arithmetics/src/language-server/arithmetics-util.ts
@@ -4,7 +4,8 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import type { BinaryExpression } from './generated/ast.js';
+import type { ResolvedReference } from 'langium';
+import { isDefinition, type BinaryExpression, type Definition, type FunctionCall } from './generated/ast.js';
 
 export function applyOp(op: BinaryExpression['operator']): (x: number, y: number) => number {
     switch (op) {
@@ -21,4 +22,12 @@ export function applyOp(op: BinaryExpression['operator']): (x: number, y: number
         };
         default: throw new Error('Unknown operator: ' + op);
     }
+}
+
+export type ResolvedFunctionCall = FunctionCall & {
+    func: ResolvedReference<Definition>
+}
+
+export function isResolvedFunctionCall(functionCall: FunctionCall): functionCall is ResolvedFunctionCall {
+    return isDefinition(functionCall.func.ref);
 }

--- a/examples/arithmetics/src/language-server/arithmetics-validator.ts
+++ b/examples/arithmetics/src/language-server/arithmetics-validator.ts
@@ -132,9 +132,11 @@ export class ArithmeticsValidator {
     }
 
     checkMatchingParameters(functionCall: FunctionCall, accept: ValidationAcceptor): void {
-        if (!functionCall.func.ref || !(functionCall.func.ref as Definition).args) return;
-        if (functionCall.args.length !== (functionCall.func.ref as Definition).args.length) {
-            accept('error', `Function ${functionCall.func.ref?.name} expects ${functionCall.args.length} parameters, but ${(functionCall.func.ref as Definition).args.length} were given.`, { node: functionCall, property: 'args' });
+        if (!isResolvedFunctionCall(functionCall) || !functionCall.func.ref.args) {
+            return;
+        }
+        if (functionCall.args.length !== functionCall.func.ref.args.length) {
+            accept('error', `Function ${functionCall.func.ref.name} expects ${functionCall.func.ref.args.length} parameters, but ${functionCall.args.length} were given.`, { node: functionCall, property: 'args' });
         }
     }
 }

--- a/examples/arithmetics/src/language-server/arithmetics-validator.ts
+++ b/examples/arithmetics/src/language-server/arithmetics-validator.ts
@@ -17,7 +17,7 @@ export function registerValidationChecks(services: ArithmeticsServices): void {
     const validator = services.validation.ArithmeticsValidator;
     const checks: ValidationChecks<ArithmeticsAstType> = {
         BinaryExpression: validator.checkDivByZero,
-        Definition: validator.checkNormalisable,
+        Definition: [validator.checkUniqueParmeters, validator.checkNormalisable],
         Module: validator.checkUniqueDefinitions,
         FunctionCall: validator.checkMatchingParameters,
     };
@@ -55,8 +55,6 @@ export class ArithmeticsValidator {
                 accept('warning', 'Expression could be normalized to constant ' + result, { node: expr });
             }
         }
-
-        this.checkUniqueParmeters(def, accept);
     }
 
     checkUniqueDefinitions(module: Module, accept: ValidationAcceptor): void {

--- a/examples/arithmetics/src/language-server/arithmetics-validator.ts
+++ b/examples/arithmetics/src/language-server/arithmetics-validator.ts
@@ -100,8 +100,11 @@ export class ArithmeticsValidator {
             return undefined;
         };
 
-        const callCycles: Array<[NestedFunctionCall, NestedFunctionCall]> = [];
-        const printCycle = ([start, end]: [NestedFunctionCall, NestedFunctionCall]): string => {
+        const callCycles: NestedFunctionCall[][] = [];
+        const printCycle = (cycle: NestedFunctionCall[]): string => {
+            const start = cycle[0];
+            const end = cycle[cycle.length - 1];
+            if (start === end) return printNestedFunctionCall(start);
             let printedCycle = printNestedFunctionCall(end);
             let parent = callsTree.get(end.call);
             while (parent) {
@@ -113,8 +116,10 @@ export class ArithmeticsValidator {
         };
 
         const bfsStep = (parent: NestedFunctionCall): NestedFunctionCall[] => {
+            const referencedFunc = parent.call.func.ref;
             const uncycledChildren: NestedFunctionCall[] = [];
-            for (const child of getNestedCallsIfUnprocessed(parent.call.func.ref)) {
+            if (parent.host === referencedFunc) callCycles.push([parent]);
+            else for (const child of getNestedCallsIfUnprocessed(referencedFunc)) {
                 callsTree.set(child.call, parent);
                 const callCycle = getCycle(child);
                 if (callCycle) {

--- a/examples/arithmetics/src/language-server/arithmetics-validator.ts
+++ b/examples/arithmetics/src/language-server/arithmetics-validator.ts
@@ -208,7 +208,7 @@ namespace NestedFunctionCall {
         }
     }
 
-    export function toString({ host, call }: NestedFunctionCall): string {
-        return `${host.name}::${call.func.ref.name}()`;
+    export function toString({ call }: NestedFunctionCall): string {
+        return `${call.func.ref.name}()`;
     }
 }

--- a/examples/arithmetics/src/language-server/arithmetics-validator.ts
+++ b/examples/arithmetics/src/language-server/arithmetics-validator.ts
@@ -18,7 +18,7 @@ export function registerValidationChecks(services: ArithmeticsServices): void {
     const validator = services.validation.ArithmeticsValidator;
     const checks: ValidationChecks<ArithmeticsAstType> = {
         BinaryExpression: validator.checkDivByZero,
-        Definition: [validator.checkUniqueParmeters, validator.checkNormalisable],
+        Definition: [validator.checkUniqueParameters, validator.checkNormalisable],
         Module: [validator.checkUniqueDefinitions, validator.checkFunctionRecursion],
         FunctionCall: validator.checkMatchingParameters,
     };
@@ -122,7 +122,7 @@ export class ArithmeticsValidator {
         }
     }
 
-    checkUniqueParmeters(definition: Definition, accept: ValidationAcceptor): void {
+    checkUniqueParameters(definition: Definition, accept: ValidationAcceptor): void {
         const names = new MultiMap<string, DeclaredParameter>();
         for (const def of definition.args) {
             if (def.name) {

--- a/examples/arithmetics/src/language-server/arithmetics-validator.ts
+++ b/examples/arithmetics/src/language-server/arithmetics-validator.ts
@@ -77,7 +77,9 @@ export class ArithmeticsValidator {
             if (isFunctionCall(expression)) {
                 if (isResolvedFunctionCall(expression)) yield { call: expression, host };
             } else if (isBinaryExpression(expression)) {
-                for (const expr of [expression.left, expression.right]) yield* getNestedCalls(host, expr);
+                for (const expr of [expression.left, expression.right]) {
+                    if (expr) yield* getNestedCalls(host, expr);
+                }
             }
         }
 

--- a/packages/langium/src/syntax-tree.ts
+++ b/packages/langium/src/syntax-tree.ts
@@ -67,6 +67,10 @@ export function isReference(obj: unknown): obj is Reference {
     return typeof obj === 'object' && obj !== null && typeof (obj as Reference).$refText === 'string';
 }
 
+export type ResolvedReference<T extends AstNode = AstNode> = Reference<T> & {
+    readonly ref: T;
+}
+
 /**
  * A description of an AST node is used when constructing scopes and looking up cross-reference targets.
  */


### PR DESCRIPTION
Resolves #1019.
Recursion validation implemented using BFS algorithm for nested function calls as graph nodes.

Implemented scenarios:

1. Function calls itself `def fun1(x): fun1(x);`
2. Several functions calls each other in a cycle, e.g.:

```arithmetics
def fun1(x):
    fun2(x) + fun2(x) + fun3(x);

def fun2(x):
    fun3(x) + fun4(x);

def fun3(x):
    3*x;

def fun4(x):
    fun3(x) + fun1(x);
```
Here every affected call in the cycle gets a validation error (fun1::fun2, fun2::fun4, and fun4::fun1). In case a function B is called several times from a function A, only first call instance is marked with error (e.g., only first fun1::fun2).

3. If a Module has multiple recursion cycles, all of them are identified. See example scenarios in `example/recursions.calc`.