### PR TITLE
Enable array of validations for AstNodes

### DIFF
--- a/packages/langium/src/validation/validation-registry.ts
+++ b/packages/langium/src/validation/validation-registry.ts
@@ -73,7 +73,7 @@ export type ValidationCheck<T extends AstNode = AstNode> = (node: T, accept: Val
 export type ValidationChecks<T> = {
     [K in keyof T]?: T[K] extends AstNode ? ValidationCheck<T[K]> | Array<ValidationCheck<T[K]>> : never
 } & {
-    AstNode?: ValidationCheck<AstNode>;
+    AstNode?: ValidationCheck<AstNode> | Array<ValidationCheck<AstNode>>;
 }
 
 /**

--- a/packages/langium/test/validation/document-validator.test.ts
+++ b/packages/langium/test/validation/document-validator.test.ts
@@ -84,9 +84,15 @@ describe('Generic `AstNode` validation applies to all nodes', () => {
             grammar
         });
         const validationChecks: ValidationChecks<object> = {
-            AstNode: (node, accept) => {
-                accept('error', 'TEST', { node });
-            }
+            // register two different validations for each AstNode
+            AstNode: [
+                (node, accept) => {
+                    accept('error', 'TEST', { node });
+                },
+                (node, accept) => {
+                    accept('warning', 'Second generic validation', { node });
+                }
+            ]
         };
         services.validation.ValidationRegistry.register(validationChecks);
         validate = validationHelper(services);
@@ -95,8 +101,12 @@ describe('Generic `AstNode` validation applies to all nodes', () => {
     test('Diagnostics are shown on all elements', async () => {
         const validationResult = await validate('a 42');
         const diagnostics = validationResult.diagnostics;
-        // One for each `element`, once on the root model
-        expect(diagnostics).toHaveLength(3);
+        // two validations for each AstNode: One for each `element`, once on the root model
+        expect(diagnostics).toHaveLength(6);
+        expect(diagnostics.filter(d => d.severity === 1)).toHaveLength(3); // 3 errors
+        expect(diagnostics.filter(d => d.severity === 2)).toHaveLength(3); // 3 warnings
+        expect(diagnostics.filter(d => d.severity === 3)).toHaveLength(0);
+        expect(diagnostics.filter(d => d.severity === 4)).toHaveLength(0);
     });
 
 });


### PR DESCRIPTION
At the moment, it is possible to register a single function for checking `AstNode` like this:

```ts
const checks: ValidationChecks<MyAstType> = {
  // ... checks for language-dependent types ...
  AstNode: checkAstNode
};
```
 
But it is not possible to register an array of functions for checking `AstNode`. This PR enables this feature:

```ts
const checks: ValidationChecks<MyAstType> = {
  // ... checks for language-dependent types ...
  AstNode: [ checkAstNodeOne, checkAstNodeTwo ]
};
```

This behaviour is already supported for language-dependent types, but not for `AstNode` yet.