### PR TITLE
Reparse documents only when content changed

### DIFF
--- a/examples/domainmodel/test/refs-index.test.ts
+++ b/examples/domainmodel/test/refs-index.test.ts
@@ -8,7 +8,7 @@ import type { AstNode, LangiumDocument, ReferenceDescription, URI } from 'langiu
 import type { Domainmodel } from '../src/language-server/generated/ast.js';
 import { describe, expect, test } from 'vitest';
 import { EmptyFileSystem, getDocument } from 'langium';
-import { parseDocument } from 'langium/test';
+import { parseDocument, setTextDocument } from 'langium/test';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { createDomainModelServices } from '../src/language-server/domain-model-module.js';
 
@@ -21,10 +21,15 @@ describe('Cross references indexed after affected process', () => {
         let allRefs = await getReferences((superDoc.parseResult.value as Domainmodel).elements[0]);
         expect(allRefs.length).toEqual(0); // linking error
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const textDocs: any = services.shared.workspace.TextDocuments;
-        textDocs._syncedDocuments.set(superDoc.textDocument.uri.toString(),
-            TextDocument.create(superDoc.textDocument.uri.toString(), superDoc.textDocument.languageId, 0, 'entity SuperEntity {}'));
+        setTextDocument(
+            services,
+            TextDocument.create(
+                superDoc.textDocument.uri.toString(),
+                superDoc.textDocument.languageId,
+                0,
+                'entity SuperEntity {}'
+            )
+        );
         await services.shared.workspace.DocumentBuilder.update([superDoc.uri], []);
 
         const updatedSuperDoc = await services.shared.workspace.LangiumDocuments.getOrCreateDocument(superDoc.uri);

--- a/packages/langium/src/parser/cst-node-builder.ts
+++ b/packages/langium/src/parser/cst-node-builder.ts
@@ -23,6 +23,7 @@ export class CstNodeBuilder {
 
     buildRootNode(input: string): RootCstNode {
         this.rootNode = new RootCstNodeImpl(input);
+        this.rootNode.root = this.rootNode;
         this.nodeStack = [this.rootNode];
         return this.rootNode;
     }

--- a/packages/langium/src/test/langium-test.ts
+++ b/packages/langium/src/test/langium-test.ts
@@ -694,6 +694,19 @@ export function expectWarning<T extends AstNode = AstNode, N extends AstNode = A
     });
 }
 
+/**
+ * Add the given document to the `TextDocuments` service, simulating it being opened in an editor.
+ */
+export function setTextDocument(services: LangiumServices | LangiumSharedServices, document: TextDocument): Disposable {
+    const shared = 'shared' in services ? services.shared : services;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const textDocuments = shared.workspace.TextDocuments as any;
+    textDocuments._syncedDocuments.set(document.uri, document);
+    return Disposable.create(() => {
+        textDocuments._syncedDocuments.delete(document.uri);
+    });
+}
+
 export function clearDocuments(services: LangiumServices | LangiumSharedServices, documents?: LangiumDocument[]): Promise<void> {
     const shared = 'shared' in services ? services.shared : services;
     const allDocs = (documents ? stream(documents) : shared.workspace.LangiumDocuments.all).map(x => x.uri).toArray();

--- a/packages/langium/test/utils/caching.test.ts
+++ b/packages/langium/test/utils/caching.test.ts
@@ -10,15 +10,14 @@ import { beforeEach, describe, expect, test } from 'vitest';
 import type { DefaultDocumentBuilder} from 'langium';
 import { DocumentCache, EmptyFileSystem, URI, WorkspaceCache } from 'langium';
 import { createLangiumGrammarServices } from 'langium/grammar';
+import { setTextDocument } from 'langium/test';
 
 const services = createLangiumGrammarServices(EmptyFileSystem);
 const workspace = services.shared.workspace;
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const textDocuments = services.shared.workspace.TextDocuments as any;
 const document1 = workspace.LangiumDocumentFactory.fromString('', URI.file('/document1.langium'));
-textDocuments._syncedDocuments.set(document1.uri.toString(), document1.textDocument);
+setTextDocument(services.shared, document1.textDocument);
 const document2 = workspace.LangiumDocumentFactory.fromString('', URI.file('/document2.langium'));
-textDocuments._syncedDocuments.set(document2.uri.toString(), document2.textDocument);
+setTextDocument(services.shared, document2.textDocument);
 workspace.LangiumDocuments.addDocument(document1);
 workspace.LangiumDocuments.addDocument(document2);
 

--- a/packages/langium/test/workspace/document-factory.test.ts
+++ b/packages/langium/test/workspace/document-factory.test.ts
@@ -1,0 +1,54 @@
+/******************************************************************************
+ * Copyright 2023 TypeFox GmbH
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License, which is available in the project root.
+ ******************************************************************************/
+
+import type { Grammar, LangiumServices } from 'langium';
+import { describe, expect, test } from 'vitest';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { DocumentState, EmptyFileSystem } from 'langium';
+import { createLangiumGrammarServices } from 'langium/grammar';
+import { setTextDocument } from 'langium/test';
+
+describe('DefaultLangiumDocumentFactory', () => {
+
+    test('updates document when receiving a new text', async () => {
+        const services = createLangiumGrammarServices(EmptyFileSystem).grammar;
+        const documentFactory = services.shared.workspace.LangiumDocumentFactory;
+        const uri = 'file:///test.langium';
+        const document = documentFactory.fromTextDocument<Grammar>(createTextDocument(uri, 'grammar X', services));
+        expect(document.state).toBe(DocumentState.Parsed);
+        expect(document.parseResult.value.name).toBe('X');
+        document.state = DocumentState.Changed;
+        // Update the document with a different text.
+        createTextDocument(uri, 'grammar Y', services);
+        const updated = documentFactory.update(document);
+        expect(updated.state).toBe(DocumentState.Parsed);
+        // Assert that the parse result was updated.
+        expect(updated.parseResult.value.name).toBe('Y');
+    });
+
+    test('does not update document when receiving the same text', async () => {
+        const services = createLangiumGrammarServices(EmptyFileSystem).grammar;
+        const documentFactory = services.shared.workspace.LangiumDocumentFactory;
+        const uri = 'file:///test.langium';
+        const document = documentFactory.fromTextDocument<Grammar>(createTextDocument(uri, 'grammar X', services));
+        expect(document.parseResult.value.name).toBe('X');
+        // We set a new name value here. When the document is updated, this value should be preserved.
+        document.parseResult.value.name = 'HELLO';
+        expect(document.parseResult.value.name).toBe('HELLO');
+        document.state = DocumentState.Changed;
+        // Update the document with the same text.
+        createTextDocument(uri, 'grammar X', services);
+        const updated = documentFactory.update(document);
+        // Confirm that the parse result wasn't updated.
+        expect(updated.parseResult.value.name).toBe('HELLO');
+    });
+});
+
+function createTextDocument(uri: string, text: string, services: LangiumServices): TextDocument {
+    const document = TextDocument.create(uri, 'langium', 0, text);
+    setTextDocument(services, document);
+    return document;
+}


### PR DESCRIPTION
When opening a workspace, we currently parse documents twice, even if their content hasn't changed.

1. Documents are parsed the first time when the `initializeWorkspace` method of the `WorkspaceManager` is called.
2. When a document has been opened in the editor, a `textDocument/onDidChange` notification is sent to the language server. This leads to a `LangiumDocumentFactory#update` call that tries to reparse the document.

This reparsing step can be quite expensive in case our documents are very large, as the parsing step cannot be interrupted, unlike every other builder step.

This change addresses point 2 by skipping the reparse in case the text document hasn't changed since the last parse. See tests on the effect (and potential side effects) of this change.