### PR TITLE
Refactor document factory to support async parsing

### DIFF
--- a/examples/arithmetics/src/cli/cli-util.ts
+++ b/examples/arithmetics/src/cli/cli-util.ts
@@ -21,7 +21,7 @@ export async function extractDocument<T extends AstNode>(fileName: string, exten
         process.exit(1);
     }
 
-    const document = services.shared.workspace.LangiumDocuments.getOrCreateDocument(URI.file(path.resolve(fileName)));
+    const document = await services.shared.workspace.LangiumDocuments.getOrCreateDocument(URI.file(path.resolve(fileName)));
     await services.shared.workspace.DocumentBuilder.build([document], { validation: true });
 
     const validationErrors = (document.diagnostics ?? []).filter(e => e.severity === 1);

--- a/examples/domainmodel/src/cli/cli-util.ts
+++ b/examples/domainmodel/src/cli/cli-util.ts
@@ -22,7 +22,7 @@ export async function extractDocument<T extends AstNode>(fileName: string, exten
         process.exit(1);
     }
 
-    const document = services.shared.workspace.LangiumDocuments.getOrCreateDocument(URI.file(path.resolve(fileName)));
+    const document = await services.shared.workspace.LangiumDocuments.getOrCreateDocument(URI.file(path.resolve(fileName)));
     await services.shared.workspace.DocumentBuilder.build([document], { validation: true });
 
     const validationErrors = (document.diagnostics ?? []).filter(e => e.severity === 1);

--- a/examples/domainmodel/src/language-server/domain-model-rename-refactoring.ts
+++ b/examples/domainmodel/src/language-server/domain-model-rename-refactoring.ts
@@ -69,8 +69,11 @@ export class DomainModelRenameProvider extends DefaultRenameProvider {
         return { changes };
     }
 
-    protected hasQualifiedNameText(uri: URI, range: Range) {
-        const langiumDoc = this.langiumDocuments.getOrCreateDocument(uri);
+    protected hasQualifiedNameText(uri: URI, range: Range): boolean {
+        const langiumDoc = this.langiumDocuments.getDocument(uri);
+        if (!langiumDoc) {
+            return false;
+        }
         const rangeText = langiumDoc.textDocument.getText(range);
         return rangeText.includes('.', 0);
     }

--- a/examples/requirements/src/cli/cli-util.ts
+++ b/examples/requirements/src/cli/cli-util.ts
@@ -54,7 +54,7 @@ export async function extractDocuments(fileName: string, services: LangiumServic
             process.exit(1);
         }
     });
-    const mainDocument = services.shared.workspace.LangiumDocuments.getOrCreateDocument(URI.file(path.resolve(fileName)));
+    const mainDocument = await services.shared.workspace.LangiumDocuments.getOrCreateDocument(URI.file(path.resolve(fileName)));
 
     return [mainDocument, documents];
 }

--- a/examples/statemachine/src/cli/cli-util.ts
+++ b/examples/statemachine/src/cli/cli-util.ts
@@ -21,7 +21,7 @@ export async function extractDocument(fileName: string, extensions: readonly str
         process.exit(1);
     }
 
-    const document = services.shared.workspace.LangiumDocuments.getOrCreateDocument(URI.file(path.resolve(fileName)));
+    const document = await services.shared.workspace.LangiumDocuments.getOrCreateDocument(URI.file(path.resolve(fileName)));
     await services.shared.workspace.DocumentBuilder.build([document], { validation: true });
 
     const validationErrors = (document.diagnostics ?? []).filter(e => e.severity === 1);

--- a/packages/generator-langium/templates/cli/src/cli/cli-util.ts
+++ b/packages/generator-langium/templates/cli/src/cli/cli-util.ts
@@ -16,7 +16,7 @@ export async function extractDocument(fileName: string, services: LangiumService
         process.exit(1);
     }
 
-    const document = services.shared.workspace.LangiumDocuments.getOrCreateDocument(URI.file(path.resolve(fileName)));
+    const document = await services.shared.workspace.LangiumDocuments.getOrCreateDocument(URI.file(path.resolve(fileName)));
     await services.shared.workspace.DocumentBuilder.build([document], { validation: true });
 
     const validationErrors = (document.diagnostics ?? []).filter(e => e.severity === 1);

--- a/packages/langium-sprotty/src/diagram-generator.ts
+++ b/packages/langium-sprotty/src/diagram-generator.ts
@@ -49,13 +49,13 @@ export abstract class LangiumDiagramGenerator implements IDiagramGenerator {
     /**
      * Builds a `GeneratorContext` and calls `generateRoot` with it.
      */
-    generate(args: LangiumDiagramGeneratorArguments): SModelRoot | Promise<SModelRoot> {
+    async generate(args: LangiumDiagramGeneratorArguments): Promise<SModelRoot> {
         if (!args.document) {
             const sourceUri = args.options.sourceUri as string;
             if (!sourceUri) {
                 return Promise.reject("Missing 'sourceUri' option in request.");
             }
-            args.document = this.langiumDocuments.getOrCreateDocument(URI.parse(sourceUri));
+            args.document = await this.langiumDocuments.getOrCreateDocument(URI.parse(sourceUri));
         }
         if (!args.cancelToken) {
             args.cancelToken = CancellationToken.None;

--- a/packages/langium-sprotty/src/trace-provider.ts
+++ b/packages/langium-sprotty/src/trace-provider.ts
@@ -72,7 +72,10 @@ export class DefaultTraceProvider implements TraceProvider {
         }
         try {
             const traceUri = URI.parse(target.trace);
-            const document = this.langiumDocuments.getOrCreateDocument(traceUri.with({ fragment: null, query: null }));
+            const document = this.langiumDocuments.getDocument(traceUri.with({ fragment: null, query: null }));
+            if (!document) {
+                return undefined;
+            }
             return this.astNodeLocator.getAstNode(document.parseResult.value, traceUri.fragment);
         } catch (err) {
             console.warn(`Could not retrieve source of trace: ${target.trace}`, err);

--- a/packages/langium-vscode/src/language-server/railroad-handler.ts
+++ b/packages/langium-vscode/src/language-server/railroad-handler.ts
@@ -22,10 +22,10 @@ export function registerRailroadConnectionHandler(connection: Connection, servic
     });
     // After receiving the `DOCUMENTS_VALIDATED_NOTIFICATION`
     // the vscode extension will perform the following request
-    connection.onRequest(RAILROAD_DIAGRAM_REQUEST, (uri: string) => {
+    connection.onRequest(RAILROAD_DIAGRAM_REQUEST, async (uri: string) => {
         try {
             const parsedUri = URI.parse(uri);
-            const document = documents.getOrCreateDocument(parsedUri);
+            const document = await documents.getOrCreateDocument(parsedUri);
             if (document.diagnostics?.some(e => e.severity === DiagnosticSeverity.Error)) {
                 return undefined;
             }

--- a/packages/langium/src/default-module.ts
+++ b/packages/langium/src/default-module.ts
@@ -48,6 +48,7 @@ import { DefaultLexer } from './parser/lexer.js';
 import { JSDocDocumentationProvider } from './documentation/documentation-provider.js';
 import { DefaultCommentProvider } from './documentation/comment-provider.js';
 import { LangiumParserErrorMessageProvider } from './parser/langium-parser.js';
+import { DefaultAsyncParser } from './parser/async-parser.js';
 import { DefaultWorkspaceLock } from './workspace/workspace-lock.js';
 
 /**
@@ -68,6 +69,7 @@ export function createDefaultModule(context: DefaultModuleContext): Module<Langi
             DocumentationProvider: (services) => new JSDocDocumentationProvider(services)
         },
         parser: {
+            AsyncParser: (services) => new DefaultAsyncParser(services),
             GrammarConfig: (services) => createGrammarConfig(services),
             LangiumParser: (services) => createLangiumParser(services),
             CompletionParser: (services) => createCompletionParser(services),

--- a/packages/langium/src/grammar/internal-grammar-util.ts
+++ b/packages/langium/src/grammar/internal-grammar-util.ts
@@ -89,16 +89,16 @@ export function resolveImportUri(imp: ast.GrammarImport): URI | undefined {
 
 export function resolveImport(documents: LangiumDocuments, imp: ast.GrammarImport): ast.Grammar | undefined {
     const resolvedUri = resolveImportUri(imp);
-    try {
-        if (resolvedUri) {
-            const resolvedDocument = documents.getOrCreateDocument(resolvedUri);
-            const node = resolvedDocument.parseResult.value;
-            if (ast.isGrammar(node)) {
-                return node;
-            }
-        }
-    } catch {
-        // NOOP
+    if (!resolvedUri) {
+        return undefined;
+    }
+    const resolvedDocument = documents.getDocument(resolvedUri);
+    if (!resolvedDocument) {
+        return undefined;
+    }
+    const node = resolvedDocument.parseResult.value;
+    if (ast.isGrammar(node)) {
+        return node;
     }
     return undefined;
 }

--- a/packages/langium/src/grammar/lsp/grammar-call-hierarchy.ts
+++ b/packages/langium/src/grammar/lsp/grammar-call-hierarchy.ts
@@ -15,6 +15,7 @@ import { findLeafNodeAtOffset } from '../../utils/cst-util.js';
 import { isParserRule, isRuleCall } from '../../languages/generated/ast.js';
 
 export class LangiumGrammarCallHierarchyProvider extends AbstractCallHierarchyProvider {
+
     protected getIncomingCalls(node: AstNode, references: Stream<ReferenceDescription>): CallHierarchyIncomingCall[] | undefined {
         if (!isParserRule(node)) {
             return undefined;
@@ -22,7 +23,10 @@ export class LangiumGrammarCallHierarchyProvider extends AbstractCallHierarchyPr
         // This map is used to group incoming calls to avoid duplicates.
         const uniqueRules = new Map<string, { parserRule: CstNode, nameNode: CstNode, targetNodes: CstNode[], docUri: string }>();
         references.forEach(ref => {
-            const doc = this.documents.getOrCreateDocument(ref.sourceUri);
+            const doc = this.documents.getDocument(ref.sourceUri);
+            if (!doc) {
+                return;
+            }
             const rootNode = doc.parseResult.value;
             if (!rootNode.$cstNode) {
                 return;

--- a/packages/langium/src/grammar/lsp/grammar-type-hierarchy.ts
+++ b/packages/langium/src/grammar/lsp/grammar-type-hierarchy.ts
@@ -37,7 +37,11 @@ export class LangiumGrammarTypeHierarchyProvider extends AbstractTypeHierarchyPr
         const items = this.references
             .findReferences(node, {includeDeclaration: false})
             .flatMap(ref => {
-                const document = this.documents.getOrCreateDocument(ref.sourceUri);
+                const document = this.documents.getDocument(ref.sourceUri);
+                if (!document) {
+                    return [];
+                }
+
                 const rootNode = document.parseResult.value;
                 if (!rootNode.$cstNode) {
                     return [];

--- a/packages/langium/src/grammar/references/grammar-references.ts
+++ b/packages/langium/src/grammar/references/grammar-references.ts
@@ -154,13 +154,15 @@ export class LangiumGrammarReferences extends DefaultReferences {
     protected findRulesWithReturnType(interf: Interface | Type): Array<ParserRule | Action> {
         const rules: Array<ParserRule | Action> = [];
         const refs = this.index.findAllReferences(interf, this.nodeLocator.getAstNodePath(interf));
-        refs.forEach(ref => {
-            const doc = this.documents.getOrCreateDocument(ref.sourceUri);
-            const astNode = this.nodeLocator.getAstNode(doc.parseResult.value, ref.sourcePath);
-            if (isParserRule(astNode) || isAction(astNode)) {
-                rules.push(astNode);
+        for (const ref of refs) {
+            const doc = this.documents.getDocument(ref.sourceUri);
+            if (doc) {
+                const astNode = this.nodeLocator.getAstNode(doc.parseResult.value, ref.sourcePath);
+                if (isParserRule(astNode) || isAction(astNode)) {
+                    rules.push(astNode);
+                }
             }
-        });
+        }
         return rules;
     }
 }

--- a/packages/langium/src/grammar/references/grammar-scope.ts
+++ b/packages/langium/src/grammar/references/grammar-scope.ts
@@ -77,8 +77,8 @@ export class LangiumGrammarScopeProvider extends DefaultScopeProvider {
             const uri = resolveImportUri(imp0rt);
             if (uri && !importedUris.has(uri.toString())) {
                 importedUris.add(uri.toString());
-                if (this.langiumDocuments.hasDocument(uri)) {
-                    const importedDocument = this.langiumDocuments.getOrCreateDocument(uri);
+                const importedDocument = this.langiumDocuments.getDocument(uri);
+                if (importedDocument) {
                     const rootNode = importedDocument.parseResult.value;
                     if (isGrammar(rootNode)) {
                         this.gatherImports(rootNode, importedUris);

--- a/packages/langium/src/grammar/type-system/types-util.ts
+++ b/packages/langium/src/grammar/type-system/types-util.ts
@@ -42,8 +42,11 @@ export function collectChildrenTypes(interfaceNode: Interface, references: Refer
     const childrenTypes = new Set<Interface | Type>();
     childrenTypes.add(interfaceNode);
     const refs = references.findReferences(interfaceNode, {});
-    refs.forEach(ref => {
-        const doc = langiumDocuments.getOrCreateDocument(ref.sourceUri);
+    for (const ref of refs) {
+        const doc = langiumDocuments.getDocument(ref.sourceUri);
+        if (!doc) {
+            continue;
+        }
         const astNode = nodeLocator.getAstNode(doc.parseResult.value, ref.sourcePath);
         if (isInterface(astNode)) {
             childrenTypes.add(astNode);
@@ -52,7 +55,7 @@ export function collectChildrenTypes(interfaceNode: Interface, references: Refer
         } else if (astNode && isType(astNode.$container)) {
             childrenTypes.add(astNode.$container);
         }
-    });
+    }
     return childrenTypes;
 }
 

--- a/packages/langium/src/lsp/call-hierarchy-provider.ts
+++ b/packages/langium/src/lsp/call-hierarchy-provider.ts
@@ -82,7 +82,10 @@ export abstract class AbstractCallHierarchyProvider implements CallHierarchyProv
     }
 
     incomingCalls(params: CallHierarchyIncomingCallsParams): CallHierarchyIncomingCall[] | undefined {
-        const document = this.documents.getOrCreateDocument(URI.parse(params.item.uri));
+        const document = this.documents.getDocument(URI.parse(params.item.uri));
+        if (!document) {
+            return undefined;
+        }
         const rootNode = document.parseResult.value;
         const targetNode = findDeclarationNodeAtOffset(
             rootNode.$cstNode,
@@ -108,7 +111,10 @@ export abstract class AbstractCallHierarchyProvider implements CallHierarchyProv
     protected abstract getIncomingCalls(node: AstNode, references: Stream<ReferenceDescription>): CallHierarchyIncomingCall[] | undefined;
 
     outgoingCalls(params: CallHierarchyOutgoingCallsParams): CallHierarchyOutgoingCall[] | undefined {
-        const document = this.documents.getOrCreateDocument(URI.parse(params.item.uri));
+        const document = this.documents.getDocument(URI.parse(params.item.uri));
+        if (!document) {
+            return undefined;
+        }
         const rootNode = document.parseResult.value;
         const targetNode = findDeclarationNodeAtOffset(
             rootNode.$cstNode,

--- a/packages/langium/src/lsp/language-server.ts
+++ b/packages/langium/src/lsp/language-server.ts
@@ -590,12 +590,13 @@ export function createServerRequestHandler<P extends { textDocument: TextDocumen
         const uri = URI.parse(params.textDocument.uri);
         const language = serviceRegistry.getServices(uri);
         if (!language) {
-            console.error(`Could not find service instance for uri: '${uri.toString()}'`);
-            throw new Error();
+            const errorText = `Could not find service instance for uri: '${uri}'`;
+            console.error(errorText);
+            throw new Error(errorText);
         }
-        const document = documents.getOrCreateDocument(uri);
+        const document = documents.getDocument(uri);
         if (!document) {
-            throw new Error();
+            throw new Error(`Could not find document for uri: '${uri}'`);
         }
         try {
             return await serviceCall(language, document, params, cancelToken);
@@ -618,7 +619,7 @@ export function createRequestHandler<P extends { textDocument: TextDocumentIdent
             console.error(`Could not find service instance for uri: '${uri.toString()}'`);
             return null;
         }
-        const document = documents.getOrCreateDocument(uri);
+        const document = documents.getDocument(uri);
         if (!document) {
             return null;
         }

--- a/packages/langium/src/lsp/type-hierarchy-provider.ts
+++ b/packages/langium/src/lsp/type-hierarchy-provider.ts
@@ -99,7 +99,10 @@ export abstract class AbstractTypeHierarchyProvider implements TypeHierarchyProv
     }
 
     supertypes(params: TypeHierarchySupertypesParams, _cancelToken?: CancellationToken): TypeHierarchyItem[] | undefined {
-        const document = this.documents.getOrCreateDocument(URI.parse(params.item.uri));
+        const document = this.documents.getDocument(URI.parse(params.item.uri));
+        if (!document) {
+            return undefined;
+        }
         const rootNode = document.parseResult.value;
         const targetNode = findDeclarationNodeAtOffset(
             rootNode.$cstNode,
@@ -118,7 +121,10 @@ export abstract class AbstractTypeHierarchyProvider implements TypeHierarchyProv
     protected abstract getSupertypes(node: AstNode): TypeHierarchyItem[] | undefined;
 
     subtypes(params: TypeHierarchySubtypesParams, _cancelToken?: CancellationToken): TypeHierarchyItem[] | undefined {
-        const document = this.documents.getOrCreateDocument(URI.parse(params.item.uri));
+        const document = this.documents.getDocument(URI.parse(params.item.uri));
+        if (!document) {
+            return undefined;
+        }
         const rootNode = document.parseResult.value;
         const targetNode = findDeclarationNodeAtOffset(
             rootNode.$cstNode,

--- a/packages/langium/src/node/node-file-system-provider.ts
+++ b/packages/langium/src/node/node-file-system-provider.ts
@@ -19,10 +19,6 @@ export class NodeFileSystemProvider implements FileSystemProvider {
         return fs.promises.readFile(uri.fsPath, this.encoding);
     }
 
-    readFileSync(uri: URI): string {
-        return fs.readFileSync(uri.fsPath, this.encoding);
-    }
-
     async readDirectory(folderPath: URI): Promise<FileSystemNode[]> {
         const dirents = await fs.promises.readdir(folderPath.fsPath, { withFileTypes: true });
         return dirents.map(dirent => ({

--- a/packages/langium/src/parser/async-parser.ts
+++ b/packages/langium/src/parser/async-parser.ts
@@ -1,0 +1,39 @@
+/******************************************************************************
+ * Copyright 2023 TypeFox GmbH
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License, which is available in the project root.
+ ******************************************************************************/
+
+import type { CancellationToken } from 'vscode-languageserver';
+import type { LangiumParser, ParseResult } from './langium-parser.js';
+import type { LangiumServices } from '../services.js';
+import type { AstNode } from '../syntax-tree.js';
+
+/**
+ * Async parser that allows to cancel the current parsing process.
+ * The sync parser implementation is blocking the event loop, which can become quite problematic for large files.
+ *
+ * Note that the default implementation is not actually async. It just wraps the sync parser in a promise.
+ * A real implementation would create worker threads or web workers to offload the parsing work.
+ */
+export interface AsyncParser {
+    parse<T extends AstNode>(text: string, cancelToken: CancellationToken): Promise<ParseResult<T>>;
+}
+
+/**
+ * Default implementation of the async parser. This implementation only wraps the sync parser in a promise.
+ *
+ * A real implementation would create worker threads or web workers to offload the parsing work.
+ */
+export class DefaultAsyncParser implements AsyncParser {
+
+    protected readonly syncParser: LangiumParser;
+
+    constructor(services: LangiumServices) {
+        this.syncParser = services.parser.LangiumParser;
+    }
+
+    parse<T extends AstNode>(text: string): Promise<ParseResult<T>> {
+        return Promise.resolve(this.syncParser.parse<T>(text));
+    }
+}

--- a/packages/langium/src/parser/index.ts
+++ b/packages/langium/src/parser/index.ts
@@ -4,6 +4,7 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
+export * from './async-parser.js';
 export * from './completion-parser-builder.js';
 export * from './cst-node-builder.js';
 export * from './langium-parser-builder.js';

--- a/packages/langium/src/references/linker.ts
+++ b/packages/langium/src/references/linker.ts
@@ -203,7 +203,10 @@ export class DefaultLinker implements Linker {
         if (nodeDescription.node) {
             return nodeDescription.node;
         }
-        const doc = this.langiumDocuments().getOrCreateDocument(nodeDescription.documentUri);
+        const doc = this.langiumDocuments().getDocument(nodeDescription.documentUri);
+        if (!doc) {
+            return undefined;
+        }
         return this.astNodeLocator.getAstNode(doc.parseResult.value, nodeDescription.path);
     }
 

--- a/packages/langium/src/serializer/json-serializer.ts
+++ b/packages/langium/src/serializer/json-serializer.ts
@@ -288,11 +288,17 @@ export class DefaultJsonSerializer implements JsonSerializer {
             }
             if (fragmentIndex < 0) {
                 const documentUri = uriConverter ? uriConverter(uri) : URI.parse(uri);
-                const document = this.langiumDocuments.getOrCreateDocument(documentUri);
+                const document = this.langiumDocuments.getDocument(documentUri);
+                if (!document) {
+                    return 'Could not find document for URI: ' + uri;
+                }
                 return document.parseResult.value;
             }
             const documentUri = uriConverter ? uriConverter(uri.substring(0, fragmentIndex)) : URI.parse(uri.substring(0, fragmentIndex));
-            const document = this.langiumDocuments.getOrCreateDocument(documentUri);
+            const document = this.langiumDocuments.getDocument(documentUri);
+            if (!document) {
+                return 'Could not find document for URI: ' + uri;
+            }
             if (fragmentIndex === uri.length - 1) {
                 return document.parseResult.value;
             }

--- a/packages/langium/src/services.ts
+++ b/packages/langium/src/services.ts
@@ -63,6 +63,7 @@ import type { NodeKindProvider } from './lsp/node-kind-provider.js';
 import type { FuzzyMatcher } from './lsp/fuzzy-matcher.js';
 import type { IParserErrorMessageProvider } from 'chevrotain';
 import type { TypeHierarchyProvider } from './lsp/type-hierarchy-provider.js';
+import type { AsyncParser } from './parser/async-parser.js';
 import type { WorkspaceLock } from './workspace/workspace-lock.js';
 
 /**
@@ -109,6 +110,7 @@ export type LangiumLspServices = {
 export type LangiumDefaultServices = {
     lsp: LangiumLspServices
     parser: {
+        AsyncParser: AsyncParser
         GrammarConfig: GrammarConfig
         ValueConverter: ValueConverter
         LangiumParser: LangiumParser

--- a/packages/langium/src/workspace/document-builder.ts
+++ b/packages/langium/src/workspace/document-builder.ts
@@ -157,10 +157,7 @@ export class DefaultDocumentBuilder implements DocumentBuilder {
         this.indexManager.remove(deleted);
         // Set the state of all changed documents to `Changed` so they are completely rebuilt
         for (const changedUri of changed) {
-            const invalidated = this.langiumDocuments.invalidateDocument(changedUri);
-            if (!invalidated) {
-                this.langiumDocuments.getOrCreateDocument(changedUri);
-            }
+            this.langiumDocuments.invalidateDocument(changedUri);
             this.buildState.delete(changedUri.toString());
         }
         // Set the state of all documents that should be relinked to `ComputedScopes` (if not already lower)
@@ -224,7 +221,7 @@ export class DefaultDocumentBuilder implements DocumentBuilder {
         this.prepareBuild(documents, options);
         // 0. Parse content
         await this.runCancelable(documents, DocumentState.Parsed, cancelToken, doc => {
-            this.langiumDocumentFactory.update(doc);
+            this.langiumDocumentFactory.update(doc, cancelToken);
         });
         // 1. Index content
         await this.runCancelable(documents, DocumentState.IndexedContent, cancelToken, doc =>

--- a/packages/langium/src/workspace/document-builder.ts
+++ b/packages/langium/src/workspace/document-builder.ts
@@ -160,9 +160,12 @@ export class DefaultDocumentBuilder implements DocumentBuilder {
         for (const changedUri of changed) {
             const invalidated = this.langiumDocuments.invalidateDocument(changedUri);
             if (!invalidated) {
-                // A "changed" document might also be one we haven't seen before (e.g. when creating a new file).
-                // In this case, we create a new document and parse it from scratch.
-                newDocuments.push(this.langiumDocuments.getOrCreateDocument(changedUri));
+                // We create an unparsed, invalid document.
+                // This will be parsed as soon as we reach the first document builder phase.
+                // This allows to cancel the parsing process later in case we need it.
+                const newDocument = this.langiumDocumentFactory.fromModel({ $type: 'INVALID' }, changedUri);
+                newDocument.state = DocumentState.Changed;
+                this.langiumDocuments.addDocument(newDocument);
             }
             this.buildState.delete(changedUri.toString());
         }

--- a/packages/langium/src/workspace/document-builder.ts
+++ b/packages/langium/src/workspace/document-builder.ts
@@ -155,7 +155,6 @@ export class DefaultDocumentBuilder implements DocumentBuilder {
             this.buildState.delete(deletedUri.toString());
         }
         this.indexManager.remove(deleted);
-        const newDocuments: Array<Promise<unknown>> = [];
         // Set the state of all changed documents to `Changed` so they are completely rebuilt
         for (const changedUri of changed) {
             const invalidated = this.langiumDocuments.invalidateDocument(changedUri);
@@ -169,8 +168,6 @@ export class DefaultDocumentBuilder implements DocumentBuilder {
             }
             this.buildState.delete(changedUri.toString());
         }
-        // Parse documents in parallel (if possible)
-        await Promise.all(newDocuments);
         // Set the state of all documents that should be relinked to `ComputedScopes` (if not already lower)
         const allChangedUris = stream(changed).concat(deleted).map(uri => uri.toString()).toSet();
         this.langiumDocuments.all

--- a/packages/langium/src/workspace/file-system-provider.ts
+++ b/packages/langium/src/workspace/file-system-provider.ts
@@ -24,11 +24,6 @@ export interface FileSystemProvider {
      */
     readFile(uri: URI): Promise<string>;
     /**
-     * Reads a document synchronously from a given URI.
-     * @returns The string content of the file with the specified URI.
-     */
-    readFileSync(uri: URI): string;
-    /**
      * Reads the directory information for the given URI.
      * @returns The list of file system entries that are contained within the specified directory.
      */
@@ -38,10 +33,6 @@ export interface FileSystemProvider {
 export class EmptyFileSystemProvider implements FileSystemProvider {
 
     readFile(): Promise<string> {
-        throw new Error('No file system is available.');
-    }
-
-    readFileSync(): string {
         throw new Error('No file system is available.');
     }
 

--- a/packages/langium/src/workspace/workspace-manager.ts
+++ b/packages/langium/src/workspace/workspace-manager.ts
@@ -116,7 +116,8 @@ export class DefaultWorkspaceManager implements WorkspaceManager {
                 if (entry.isDirectory) {
                     await this.traverseFolder(workspaceFolder, entry.uri, fileExtensions, collector);
                 } else if (entry.isFile) {
-                    const document = this.langiumDocuments.getOrCreateDocument(entry.uri);
+                    const content = await this.fileSystemProvider.readFile(entry.uri);
+                    const document = await this.langiumDocuments.createDocument(entry.uri, content, CancellationToken.None);
                     collector(document);
                 }
             }

--- a/packages/langium/src/workspace/workspace-manager.ts
+++ b/packages/langium/src/workspace/workspace-manager.ts
@@ -116,8 +116,7 @@ export class DefaultWorkspaceManager implements WorkspaceManager {
                 if (entry.isDirectory) {
                     await this.traverseFolder(workspaceFolder, entry.uri, fileExtensions, collector);
                 } else if (entry.isFile) {
-                    const content = await this.fileSystemProvider.readFile(entry.uri);
-                    const document = await this.langiumDocuments.createDocument(entry.uri, content, CancellationToken.None);
+                    const document = await this.langiumDocuments.getOrCreateDocument(entry.uri);
                     collector(document);
                 }
             }

--- a/packages/langium/test/grammar/lsp/grammar-type-hierarchy.test.ts
+++ b/packages/langium/test/grammar/lsp/grammar-type-hierarchy.test.ts
@@ -100,23 +100,17 @@ describe('LangiumGrammarTypeHierarchyProvider', async () => {
 });
 
 const getActualSimpleSupertypes = async (code: string): Promise<SimpleTypeHierarchyItem[] | undefined> => {
-    return typeHierarchyProvider
-        .supertypes({
-            item: await getUniqueTypeHierarchyItem(code),
-        })
-        ?.map((type) => ({
-            name: type.name,
-        }));
+    const supertypes = await typeHierarchyProvider.supertypes({ item: await getUniqueTypeHierarchyItem(code) });
+    return supertypes?.map((type) => ({
+        name: type.name,
+    }));
 };
 
 const getActualSimpleSubtypes = async (code: string): Promise<SimpleTypeHierarchyItem[] | undefined> => {
-    return typeHierarchyProvider
-        .subtypes({
-            item: await getUniqueTypeHierarchyItem(code),
-        })
-        ?.map((type) => ({
-            name: type.name,
-        }));
+    const supertypes = await typeHierarchyProvider.subtypes({ item: await getUniqueTypeHierarchyItem(code) });
+    return supertypes?.map((type) => ({
+        name: type.name,
+    }));
 };
 
 const getUniqueTypeHierarchyItem = async (code: string): Promise<TypeHierarchyItem> => {
@@ -132,7 +126,7 @@ const getUniqueTypeHierarchyItem = async (code: string): Promise<TypeHierarchyIt
     const position = document.textDocument.positionAt(indices[0]);
 
     const items =
-        typeHierarchyProvider.prepareTypeHierarchy(document, {
+        await typeHierarchyProvider.prepareTypeHierarchy(document, {
             textDocument: {
                 uri: document.textDocument.uri,
             },

--- a/packages/langium/test/serializer/json-serializer.test.ts
+++ b/packages/langium/test/serializer/json-serializer.test.ts
@@ -217,7 +217,7 @@ describe('JsonSerializer', async () => {
         `;
         const model = serializer.deserialize<Entry>(json);
         expect(model.elements).toHaveLength(1);
-        expect(model.elements[0].other?.error?.message).toEqual('Error: No file system is available.');
+        expect(model.elements[0].other?.error?.message).toEqual('Could not find document for URI: file:///does-not-exist.langium#/elements@0');
     });
 
 });

--- a/packages/langium/test/workspace/document-factory.test.ts
+++ b/packages/langium/test/workspace/document-factory.test.ts
@@ -10,6 +10,7 @@ import { TextDocument } from 'vscode-languageserver-textdocument';
 import { DocumentState, EmptyFileSystem } from 'langium';
 import { createLangiumGrammarServices } from 'langium/grammar';
 import { setTextDocument } from 'langium/test';
+import { CancellationToken } from 'vscode-languageserver';
 
 describe('DefaultLangiumDocumentFactory', () => {
 
@@ -23,7 +24,7 @@ describe('DefaultLangiumDocumentFactory', () => {
         document.state = DocumentState.Changed;
         // Update the document with a different text.
         createTextDocument(uri, 'grammar Y', services);
-        const updated = documentFactory.update(document);
+        const updated = await documentFactory.update(document, CancellationToken.None);
         expect(updated.state).toBe(DocumentState.Parsed);
         // Assert that the parse result was updated.
         expect(updated.parseResult.value.name).toBe('Y');
@@ -41,7 +42,7 @@ describe('DefaultLangiumDocumentFactory', () => {
         document.state = DocumentState.Changed;
         // Update the document with the same text.
         createTextDocument(uri, 'grammar X', services);
-        const updated = documentFactory.update(document);
+        const updated = await documentFactory.update(document, CancellationToken.None);
         // Confirm that the parse result wasn't updated.
         expect(updated.parseResult.value.name).toBe('HELLO');
     });


### PR DESCRIPTION
Closes #273

This change allows adopters to create asynchronous parsers to prevent blocking the event loop when parsing large files. Note that the default implementation is still synchronous. Adopters have to supply the necessary worker threads/webworkers themselves.

Most things in this change are pretty backwards compatible. The only really breaking change is that `getOrCreateDocument` is now async and returns a promise. In addition to that method, the `LangiumDocuments` now expose `getDocument(URI): LangiumDocument | undefined` and `createDocument` (both sync and async).

