### PR TITLE
Update monaco-editor wrapper to latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,8 +6,16 @@
     "": {
       "name": "langium-workspaces",
       "workspaces": [
-        "packages/*",
-        "examples/*"
+        "packages/langium",
+        "packages/langium-railrod",
+        "packages/langium-cli",
+        "packages/langium-sprotty",
+        "packages/langium-vscode",
+        "packages/generator-langium",
+        "examples/arithmetics",
+        "examples/domainmodel",
+        "examples/requirements",
+        "examples/statemachine"
       ],
       "devDependencies": {
         "@types/node": "~16.18.41",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,15 @@
     "npm": "9.6.7"
   },
   "workspaces": [
-    "packages/*",
-    "examples/*"
+    "packages/langium",
+    "packages/langium-railrod",
+    "packages/langium-cli",
+    "packages/langium-sprotty",
+    "packages/langium-vscode",
+    "packages/generator-langium",
+    "examples/arithmetics",
+    "examples/domainmodel",
+    "examples/requirements",
+    "examples/statemachine"
   ]
 }

--- a/packages/generator-langium/templates/web/.package.json
+++ b/packages/generator-langium/templates/web/.package.json
@@ -10,14 +10,23 @@
         "serve": "npm run dev"
     },
     "dependencies": {
-        "@codingame/monaco-vscode-editor-service-override": "~1.83.2",
-        "@codingame/monaco-vscode-keybindings-service-override": "~1.83.2",
+        "@codingame/monaco-vscode-editor-service-override": "1.83.16",
+        "@codingame/monaco-vscode-keybindings-service-override": "1.83.16",
+        "monaco-editor": "npm:@codingame/monaco-editor-treemended@1.83.16",
         "monaco-editor-workers": "~0.44.0",
-        "monaco-editor-wrapper": "~3.3.0",
-        "monaco-languageclient": "~6.6.0",
-        "vscode": "npm:@codingame/monaco-vscode-api@>=1.83.2 <1.84.0"
+        "monaco-editor-wrapper": "~3.5.0",
+        "monaco-languageclient": "~7.2.0",
+        "vscode": "npm:@codingame/monaco-vscode-api@1.83.16"
     },
     "devDependencies": {
         "vite": "~4.4.11"
+    },
+    "overrides": {
+        "monaco-editor": "$monaco-editor",
+        "vscode": "$vscode"
+    },
+    "resolutions": {
+        "monaco-editor": "npm:@codingame/monaco-editor-treemended@1.83.16",
+        "vscode": "npm:@codingame/monaco-vscode-api@1.83.16"
     }
 }

--- a/packages/generator-langium/templates/web/static/setupClassic.js
+++ b/packages/generator-langium/templates/web/static/setupClassic.js
@@ -28,5 +28,5 @@ export const setupConfigClassic = () => {
 export const executeClassic = async (htmlElement) => {
     const userConfig = setupConfigClassic();
     const wrapper = new MonacoEditorLanguageClientWrapper();
-    await wrapper.start(userConfig, htmlElement);
+    await wrapper.initAndStart(userConfig, htmlElement);
 };

--- a/packages/generator-langium/templates/web/static/setupExtended.js
+++ b/packages/generator-langium/templates/web/static/setupExtended.js
@@ -58,5 +58,5 @@ export const setupConfigExtended = () => {
 export const executeExtended = async (htmlElement) => {
     const userConfig = setupConfigExtended();
     const wrapper = new MonacoEditorLanguageClientWrapper();
-    await wrapper.start(userConfig, htmlElement);
+    await wrapper.initAndStart(userConfig, htmlElement);
 };


### PR DESCRIPTION
This update `monaco-editor wrapper` to `3.5.0` and fixes the version of `@codingame/monaco-vscode-api` to `1.83.16` to prevent any minor version changes to break the compilation https://github.com/CodinGame/monaco-vscode-api/issues/291