### PR TITLE
`AbstractType`s need to include `InferredType`s

### DIFF
--- a/packages/langium/src/grammar/generated/grammar.ts
+++ b/packages/langium/src/grammar/generated/grammar.ts
@@ -3907,12 +3907,6 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "SimpleType",
             "typeRef": {
-              "$ref": "#/rules@27/definition/elements@0"
-            }
-          },
-          {
-            "$type": "SimpleType",
-            "typeRef": {
               "$ref": "#/rules@17"
             }
           },

--- a/packages/langium/src/grammar/generated/grammar.ts
+++ b/packages/langium/src/grammar/generated/grammar.ts
@@ -3915,6 +3915,12 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "typeRef": {
               "$ref": "#/rules@17"
             }
+          },
+          {
+            "$type": "SimpleType",
+            "typeRef": {
+              "$ref": "#/rules@18"
+            }
           }
         ]
       }

--- a/packages/langium/src/grammar/internal-grammar-util.ts
+++ b/packages/langium/src/grammar/internal-grammar-util.ts
@@ -64,7 +64,7 @@ function isStringTypeInternal(type: ast.AbstractType | ast.TypeDefinition, visit
     return false;
 }
 
-export function getTypeNameWithoutError(type?: ast.AbstractType | ast.InferredType): string | undefined {
+export function getTypeNameWithoutError(type?: ast.AbstractType): string | undefined {
     if (!type) {
         return undefined;
     }

--- a/packages/langium/src/grammar/internal-grammar-util.ts
+++ b/packages/langium/src/grammar/internal-grammar-util.ts
@@ -64,7 +64,7 @@ function isStringTypeInternal(type: ast.AbstractType | ast.TypeDefinition, visit
     return false;
 }
 
-export function getTypeNameWithoutError(type?: ast.AbstractType): string | undefined {
+export function getTypeNameWithoutError(type?: ast.AbstractType | ast.Action): string | undefined {
     if (!type) {
         return undefined;
     }

--- a/packages/langium/src/grammar/langium-grammar.langium
+++ b/packages/langium/src/grammar/langium-grammar.langium
@@ -55,7 +55,7 @@ SimpleType infers TypeDefinition:
 PrimitiveType returns string:
     'string' | 'number' | 'boolean' | 'Date' | 'bigint';
 
-type AbstractType = Interface | Type | Action | ParserRule;
+type AbstractType = Interface | Type | Action | ParserRule | InferredType;
 
 Type:
     'type' name=ID '=' type=TypeDefinition ';'?;

--- a/packages/langium/src/grammar/langium-grammar.langium
+++ b/packages/langium/src/grammar/langium-grammar.langium
@@ -55,7 +55,7 @@ SimpleType infers TypeDefinition:
 PrimitiveType returns string:
     'string' | 'number' | 'boolean' | 'Date' | 'bigint';
 
-type AbstractType = Interface | Type | Action | ParserRule | InferredType;
+type AbstractType = Interface | Type | ParserRule | InferredType;
 
 Type:
     'type' name=ID '=' type=TypeDefinition ';'?;

--- a/packages/langium/src/grammar/references/grammar-scope.ts
+++ b/packages/langium/src/grammar/references/grammar-scope.ts
@@ -17,7 +17,7 @@ import { DefaultScopeProvider } from '../../references/scope-provider.js';
 import { findRootNode, getContainerOfType, getDocument, streamAllContents } from '../../utils/ast-utils.js';
 import { toDocumentSegment } from '../../utils/cst-utils.js';
 import { stream } from '../../utils/stream.js';
-import { AbstractType, Interface, isAction, isGrammar, isParserRule, isReturnType, Type } from '../../languages/generated/ast.js';
+import { AbstractType, InferredType, Interface, isAction, isGrammar, isParserRule, isReturnType, Type } from '../../languages/generated/ast.js';
 import { resolveImportUri } from '../internal-grammar-util.js';
 import { getActionType } from '../../utils/grammar-utils.js';
 
@@ -46,7 +46,7 @@ export class LangiumGrammarScopeProvider extends DefaultScopeProvider {
         if (precomputed && rootNode) {
             const allDescriptions = precomputed.get(rootNode);
             if (allDescriptions.length > 0) {
-                localScope = stream(allDescriptions).filter(des => des.type === Interface || des.type === Type);
+                localScope = stream(allDescriptions).filter(des => des.type === Interface || des.type === Type || des.type === InferredType);
             }
         }
 
@@ -67,7 +67,7 @@ export class LangiumGrammarScopeProvider extends DefaultScopeProvider {
         this.gatherImports(grammar, importedUris);
         let importedElements = this.indexManager.allElements(referenceType, importedUris);
         if (referenceType === AbstractType) {
-            importedElements = importedElements.filter(des => des.type === Interface || des.type === Type);
+            importedElements = importedElements.filter(des => des.type === Interface || des.type === Type || des.type === InferredType);
         }
         return new MapScope(importedElements);
     }
@@ -99,19 +99,36 @@ export class LangiumGrammarScopeComputation extends DefaultScopeComputation {
     }
 
     protected override exportNode(node: AstNode, exports: AstNodeDescription[], document: LangiumDocument): void {
+        // this function is called in order to export nodes to the GLOBAL scope
+
+        /* Among others, TYPES need to be exported.
+         * There are three ways to define types:
+         * - explicit "type" declarations
+         * - explicit "interface" declarations
+         * - "inferred types", which can be distinguished into ...
+         *     - inferred types with explicitly declared names, i.e. parser rules with "infers", actions with "infer"
+         *       Note, that multiple explicitly inferred types might have the same name! Cross-references to such types are resolved to the first declaration.
+         *     - implicitly inferred types, i.e. parser rules without "infers" and without "returns",
+         *       which implicitly declare a type with the same name as the parser rule
+         *       Note, that implicitly inferred types are unique, since names of parser rules must be unique.
+         */
+
+        // export the top-level elements: parser rules, terminal rules, types, interfaces
         super.exportNode(node, exports, document);
+
+        // additionally, export inferred types:
         if (isParserRule(node)) {
             if (!node.returnType && !node.dataType) {
-                // Export inferred rule type as interface
+                // Export inferred rule type
                 const typeNode = node.inferredType ?? node;
-                exports.push(this.createInterfaceDescription(typeNode, typeNode.name, document));
+                exports.push(this.createInferredTypeDescription(typeNode, typeNode.name, document));
             }
             streamAllContents(node).forEach(childNode => {
                 if (isAction(childNode) && childNode.inferredType) {
                     const typeName = getActionType(childNode);
                     if (typeName) {
                         // Export inferred action type as interface
-                        exports.push(this.createInterfaceDescription(childNode, typeName, document));
+                        exports.push(this.createInferredTypeDescription(childNode, typeName, document));
                     }
                 }
             });
@@ -119,26 +136,29 @@ export class LangiumGrammarScopeComputation extends DefaultScopeComputation {
     }
 
     protected override processNode(node: AstNode, document: LangiumDocument, scopes: PrecomputedScopes): void {
-        if (isReturnType(node)) return;
+        // for the precompution of the local scope
+        if (isReturnType(node)) {
+            return;
+        }
         this.processTypeNode(node, document, scopes);
         this.processActionNode(node, document, scopes);
         super.processNode(node, document, scopes);
     }
 
     /**
-     * Add synthetic Interface in case of explicitly or implicitly inferred type:<br>
+     * Add synthetic type into the scope in case of explicitly or implicitly inferred type:<br>
      * cases: `ParserRule: ...;` or `ParserRule infers Type: ...;`
      */
     protected processTypeNode(node: AstNode, document: LangiumDocument, scopes: PrecomputedScopes): void {
         const container = node.$container;
         if (container && isParserRule(node) && !node.returnType && !node.dataType) {
             const typeNode = node.inferredType ?? node;
-            scopes.add(container, this.createInterfaceDescription(typeNode, typeNode.name, document));
+            scopes.add(container, this.createInferredTypeDescription(typeNode, typeNode.name, document));
         }
     }
 
     /**
-     * Add synthetic Interface in case of explicitly inferred type:
+     * Add synthetic type into the scope in case of explicitly inferred type:
      *
      * case: `{infer Action}`
      */
@@ -147,12 +167,12 @@ export class LangiumGrammarScopeComputation extends DefaultScopeComputation {
         if (container && isAction(node) && node.inferredType) {
             const typeName = getActionType(node);
             if (typeName) {
-                scopes.add(container, this.createInterfaceDescription(node, typeName, document));
+                scopes.add(container, this.createInferredTypeDescription(node, typeName, document));
             }
         }
     }
 
-    protected createInterfaceDescription(node: AstNode, name: string, document: LangiumDocument = getDocument(node)): AstNodeDescription {
+    protected createInferredTypeDescription(node: AstNode, name: string, document: LangiumDocument = getDocument(node)): AstNodeDescription {
         let nameNodeSegment: DocumentSegment | undefined;
         const nameSegmentGetter = () => nameNodeSegment ??= toDocumentSegment(this.nameProvider.getNameNode(node) ?? node.$cstNode);
         return {
@@ -162,7 +182,7 @@ export class LangiumGrammarScopeComputation extends DefaultScopeComputation {
                 return nameSegmentGetter();
             },
             selectionSegment: toDocumentSegment(node.$cstNode),
-            type: 'Interface',
+            type: InferredType,
             documentUri: document.uri,
             path: this.astNodeLocator.getAstNodePath(node)
         };

--- a/packages/langium/src/grammar/validation/validator.ts
+++ b/packages/langium/src/grammar/validation/validator.ts
@@ -372,7 +372,7 @@ export class LangiumGrammarValidator {
         }
     }
 
-    private getActionType(rule: ast.Action): ast.AbstractType | ast.InferredType | undefined {
+    private getActionType(rule: ast.Action): ast.AbstractType | undefined {
         if (rule.type) {
             return rule.type?.ref;
         } else if (rule.inferredType) {

--- a/packages/langium/src/languages/generated/ast.ts
+++ b/packages/langium/src/languages/generated/ast.ts
@@ -25,7 +25,7 @@ export function isAbstractRule(item: unknown): item is AbstractRule {
     return reflection.isInstance(item, AbstractRule);
 }
 
-export type AbstractType = Action | Interface | ParserRule | Type;
+export type AbstractType = Action | InferredType | Interface | ParserRule | Type;
 
 export const AbstractType = 'AbstractType';
 
@@ -684,6 +684,7 @@ export class LangiumGrammarAstReflection extends AbstractAstReflection {
             case ParameterReference: {
                 return this.isSubtype(Condition, supertype);
             }
+            case InferredType:
             case Interface:
             case Type: {
                 return this.isSubtype(AbstractType, supertype);

--- a/packages/langium/src/languages/generated/ast.ts
+++ b/packages/langium/src/languages/generated/ast.ts
@@ -25,7 +25,7 @@ export function isAbstractRule(item: unknown): item is AbstractRule {
     return reflection.isInstance(item, AbstractRule);
 }
 
-export type AbstractType = Action | InferredType | Interface | ParserRule | Type;
+export type AbstractType = InferredType | Interface | ParserRule | Type;
 
 export const AbstractType = 'AbstractType';
 
@@ -643,9 +643,7 @@ export class LangiumGrammarAstReflection extends AbstractAstReflection {
 
     protected override computeIsSubtype(subtype: string, supertype: string): boolean {
         switch (subtype) {
-            case Action: {
-                return this.isSubtype(AbstractElement, supertype) || this.isSubtype(AbstractType, supertype);
-            }
+            case Action:
             case Alternatives:
             case Assignment:
             case CharacterRange:

--- a/packages/langium/src/utils/grammar-utils.ts
+++ b/packages/langium/src/utils/grammar-utils.ts
@@ -237,6 +237,10 @@ export function findAssignment(cstNode: CstNode): ast.Assignment | undefined {
 export function findNameAssignment(type: ast.AbstractType): ast.Assignment | undefined {
     if (ast.isInferredType(type)) {
         // inferred type is unexpected, extract AbstractType first
+        if (ast.isAction(type.$container)) {
+            // a type which is explicitly inferred by an action
+            return undefined;
+        }
         type = type.$container;
     }
     return findNameAssignmentInternal(type, new Map());
@@ -254,7 +258,9 @@ function findNameAssignmentInternal(type: ast.AbstractType, cache: Map<ast.Abstr
         return childAssignment;
     }
 
-    if (cache.has(type)) return cache.get(type);
+    if (cache.has(type)) {
+        return cache.get(type);
+    }
     cache.set(type, undefined);
     for (const node of streamAllContents(type)) {
         if (ast.isAssignment(node) && node.feature.toLowerCase() === 'name') {
@@ -395,7 +401,7 @@ export function getExplicitRuleType(rule: ast.ParserRule): string | undefined {
     return undefined;
 }
 
-export function getTypeName(type: ast.AbstractType): string {
+export function getTypeName(type: ast.AbstractType | ast.Action): string {
     if (ast.isParserRule(type)) {
         return isDataTypeRule(type) ? type.name : getExplicitRuleType(type) ?? type.name;
     } else if (ast.isInterface(type) || ast.isType(type) || ast.isReturnType(type)) {

--- a/packages/langium/src/utils/grammar-utils.ts
+++ b/packages/langium/src/utils/grammar-utils.ts
@@ -234,7 +234,7 @@ export function findAssignment(cstNode: CstNode): ast.Assignment | undefined {
  * from a parser rule, and that rule must contain an assignment to the `name` property. In all other cases,
  * this function returns `undefined`.
  */
-export function findNameAssignment(type: ast.AbstractType | ast.InferredType): ast.Assignment | undefined {
+export function findNameAssignment(type: ast.AbstractType): ast.Assignment | undefined {
     if (ast.isInferredType(type)) {
         // inferred type is unexpected, extract AbstractType first
         type = type.$container;
@@ -395,7 +395,7 @@ export function getExplicitRuleType(rule: ast.ParserRule): string | undefined {
     return undefined;
 }
 
-export function getTypeName(type: ast.AbstractType | ast.InferredType): string {
+export function getTypeName(type: ast.AbstractType): string {
     if (ast.isParserRule(type)) {
         return isDataTypeRule(type) ? type.name : getExplicitRuleType(type) ?? type.name;
     } else if (ast.isInterface(type) || ast.isType(type) || ast.isReturnType(type)) {
@@ -412,7 +412,7 @@ export function getTypeName(type: ast.AbstractType | ast.InferredType): string {
 }
 
 export function getActionType(action: ast.Action): string | undefined {
-    if(action.inferredType) {
+    if (action.inferredType) {
         return action.inferredType.name;
     } else if (action.type?.ref) {
         return getTypeName(action.type.ref);

--- a/packages/langium/src/utils/grammar-utils.ts
+++ b/packages/langium/src/utils/grammar-utils.ts
@@ -4,8 +4,9 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import type { AstNode, CstNode } from '../syntax-tree.js';
+import { assertUnreachable } from '../utils/errors.js';
 import * as ast from '../languages/generated/ast.js';
+import type { AstNode, CstNode } from '../syntax-tree.js';
 import { isCompositeCstNode } from '../syntax-tree.js';
 import { getContainerOfType, streamAllContents } from './ast-utils.js';
 import { streamCst } from './cst-utils.js';
@@ -245,7 +246,7 @@ export function findNameAssignment(type: ast.AbstractType): ast.Assignment | und
             // investigate the parser rule with the explicitly inferred type
             startNode = startNode.$container;
         } else {
-            throw new Error('impossible');
+            assertUnreachable(startNode.$container);
         }
     }
     return findNameAssignmentInternal(type, startNode, new Map());

--- a/packages/langium/test/grammar/grammar-validator.test.ts
+++ b/packages/langium/test/grammar/grammar-validator.test.ts
@@ -252,6 +252,42 @@ describe('Check Rule Fragment Validation', () => {
     });
 });
 
+describe('Check cross-references to inferred types', () => {
+    test.only('infer after the parser rules names', async () => {
+        const validationResult = await validate(`
+        grammar HelloWorld
+
+        entry Model: a+=A*;
+
+        A infers B: 'a' name=ID (otherA=[B])?; // works
+
+        hidden terminal WS: /\s+/;
+        terminal ID: /[a-zA-Z_][a-zA-Z0-9_]*/;
+        `.trim());
+        expectNoIssues(validationResult);
+        // expect(validationResult.diagnostics).toHaveLength(1);
+        // expect(validationResult.diagnostics[0].message).toBe('Cannot infer terminal or data type rule for cross-reference.');
+        // expectError(validationResult, 'Cannot use rule fragments in types.');
+    });
+
+    test.only('infer in the parser rules body', async () => {
+        const validationResult = await validate(`
+        grammar HelloWorld
+
+        entry Model: a+=A*;
+
+        A: {infer B} 'a' name=ID (otherA=[B])?;
+
+        hidden terminal WS: /\s+/;
+        terminal ID: /[a-zA-Z_][a-zA-Z0-9_]*/;
+        `.trim());
+        expectNoIssues(validationResult);
+        // expect(validationResult.diagnostics).toHaveLength(1);
+        // expect(validationResult.diagnostics[0].message).toBe('Cannot infer terminal or data type rule for cross-reference.');
+        // expectError(validationResult, 'Cannot use rule fragments in types.');
+    });
+});
+
 describe('Checked Named CrossRefs', () => {
     const input = `
     grammar g

--- a/packages/langium/test/grammar/grammar-validator.test.ts
+++ b/packages/langium/test/grammar/grammar-validator.test.ts
@@ -253,7 +253,7 @@ describe('Check Rule Fragment Validation', () => {
 });
 
 describe('Check cross-references to inferred types', () => {
-    test.only('infer after the parser rules names', async () => {
+    test('infer after the parser rules names', async () => {
         const validationResult = await validate(`
         grammar HelloWorld
 
@@ -261,7 +261,7 @@ describe('Check cross-references to inferred types', () => {
 
         A infers B: 'a' name=ID (otherA=[B])?; // works
 
-        hidden terminal WS: /\s+/;
+        hidden terminal WS: /\\s+/;
         terminal ID: /[a-zA-Z_][a-zA-Z0-9_]*/;
         `.trim());
         expectNoIssues(validationResult);
@@ -270,7 +270,7 @@ describe('Check cross-references to inferred types', () => {
         // expectError(validationResult, 'Cannot use rule fragments in types.');
     });
 
-    test.only('infer in the parser rules body', async () => {
+    test('infer in the parser rules body', async () => {
         const validationResult = await validate(`
         grammar HelloWorld
 
@@ -278,7 +278,7 @@ describe('Check cross-references to inferred types', () => {
 
         A: {infer B} 'a' name=ID (otherA=[B])?;
 
-        hidden terminal WS: /\s+/;
+        hidden terminal WS: /\\s+/;
         terminal ID: /[a-zA-Z_][a-zA-Z0-9_]*/;
         `.trim());
         expectNoIssues(validationResult);

--- a/packages/langium/test/grammar/type-system/type-validator.test.ts
+++ b/packages/langium/test/grammar/type-system/type-validator.test.ts
@@ -10,6 +10,7 @@ import { DiagnosticSeverity } from 'vscode-languageserver';
 import { AstUtils, EmptyFileSystem, GrammarAST } from 'langium';
 import { createLangiumGrammarServices } from 'langium/grammar';
 import { expectError, expectNoIssues, parseDocument, validationHelper } from 'langium/test';
+import { Assignment, CrossReference, Group, ParserRule, isCrossReference, isInferredType, isParserRule } from '../../../src/languages/generated/ast.js';
 
 const grammarServices = createLangiumGrammarServices(EmptyFileSystem).grammar;
 const validate = validationHelper<GrammarAST.Grammar>(grammarServices);
@@ -86,18 +87,36 @@ describe('validate params in types', () => {
 });
 
 describe('validate inferred types', () => {
+    const prog = `
+    A infers B: 'a' name=ID (otherA=[B])?;
+    hidden terminal WS: /\\s+/;
+    terminal ID: /[a-zA-Z_][a-zA-Z0-9_]*/;
+    `.trim();
 
     test('inferred type in cross-reference should not produce an error', async () => {
-        const prog = `
-        A infers B: 'a' name=ID (otherA=[B])?;
-        hidden terminal WS: /\\s+/;
-        terminal ID: /[a-zA-Z_][a-zA-Z0-9_]*/;
-        `.trim();
-
         const validation = await validate(prog);
         expectNoIssues(validation, {
             severity: DiagnosticSeverity.Error
         });
+    });
+
+    test('AbstractType for cross-reference includes InferredType', async () => {
+        const validation = await validate(prog);
+        // parser rule with explicitly inferred type
+        const rule: ParserRule = validation.document.parseResult.value.rules.filter(r => isParserRule(r))[0] as ParserRule;
+        expect(rule.inferredType).toBeTruthy();
+        expect(rule.inferredType!.name).toBe('B');
+        // determine the cross-reference
+        const assignment: Assignment = (rule.definition as Group).elements[2] as Assignment;
+        expect(isCrossReference(assignment.terminal)).toBeTruthy();
+        const crossRef: CrossReference = assignment.terminal as CrossReference;
+        const refType = crossRef.type.ref!;
+        // the type of the cross-reference is the inferred type of the parser rule
+        expect(isInferredType(refType)).toBeTruthy();
+        expect(refType.$type).toBe('InferredType');
+        if (isInferredType(refType)) {
+            expect(isParserRule(refType.$container)).toBeTruthy();
+        }
     });
 });
 

--- a/packages/langium/test/grammar/type-system/type-validator.test.ts
+++ b/packages/langium/test/grammar/type-system/type-validator.test.ts
@@ -10,7 +10,8 @@ import { DiagnosticSeverity } from 'vscode-languageserver';
 import { AstUtils, EmptyFileSystem, GrammarAST } from 'langium';
 import { createLangiumGrammarServices } from 'langium/grammar';
 import { expectError, expectNoIssues, parseDocument, validationHelper } from 'langium/test';
-import { Assignment, CrossReference, Group, ParserRule, isCrossReference, isInferredType, isParserRule } from '../../../src/languages/generated/ast.js';
+import { isCrossReference, isInferredType, isParserRule } from '../../../src/languages/generated/ast.js';
+import type { Assignment, CrossReference, Group, ParserRule } from '../../../src/languages/generated/ast.js';
 
 const grammarServices = createLangiumGrammarServices(EmptyFileSystem).grammar;
 const validate = validationHelper<GrammarAST.Grammar>(grammarServices);


### PR DESCRIPTION
... since cross-references might use `InferredType`s as their types.

This seems to be an edge-case in the Langium grammar:
The type of a cross-reference does not point to the parser rule itself, if this parser rule has an explicitly declared inferred type.
Instead, the cross-reference points to the corresponding `InferredType`.

But `InferredType` is not supported by `AbstractType`, which is used as type for cross-references in the Langium grammar:
```
type AbstractType = Interface | Type | Action | ParserRule;

CrossReference infers AbstractElement:
    {infer CrossReference} '[' type=[AbstractType] ((deprecatedSyntax?='|' | ':') terminal=CrossReferenceableTerminal )? ']';
```

The example from the created test case is available [here in the playground](https://langium.org/playground?grammar=OYJwhgthYgBAEgUwDbIPYHU0mQEwFD6IB2ALiAJ6wCyauKAXLGANQC8AggFQDchHsAJbEAZohABnWACEmAcjBzYxSIjYBJACKwAFGlIALcRzYBtaQF0AlAH4%2BBwbnrFYpcRGFhksDAGUmAPQAOhIsAXxuIB4q3lqBpmAAtABeHIkAWgD6FgkpaekADIkAnNlc4fhAA&content=IYAgsgngcsC2CmBGAUKSMECZzTk5QA).

At the moment, the TS compiler complains about this issue:
<img width="880" alt="Screenshot 2024-01-02 at 11 55 50" src="https://github.com/eclipse-langium/langium/assets/23192240/475b8ac7-6e89-4909-b9a4-ab9c3724d279">

Resolving this cross-reference to the InferredType works at runtime, since it is explicitly exported: https://github.com/eclipse-langium/langium/blob/2ca2b3adb452ad5048135af85e1510f84a71fd7b/packages/langium/src/grammar/references/grammar-scope.ts#L106


I am proposing to mark InferredTypes as AbstractTypes ...
```
type AbstractType = Interface | Type | Action | ParserRule | InferredType;
```
... but there might be a better solution.


Update 2024-01-05:
- I decided to export implicitly and explicitly inferred types (i.e. the `InferredType` nodes) with the type `InferredType` into the scopes, since that fits to the $type of the exported AST node and that clearly distinguishes explicit types and interfaces from inferred types. @spoenemann In my eyes, that is more consistent than the current implementation.
- Since InferredTypes are AbstractTypes now, it is not required for `Action`s to be `AbstractType`s anymore: Actions either reuse already declared types or contribute a new type with an `InferredType` and InferredTypes are AbstractTypes now. Additionally, `Action`s are not exported into scopes in `grammar-scope.ts` and therefore cannot be resolved for cross-references to `AbstractType`.

@pluralia Since we discussed about these topics, I am looking forward to your review as well!

Update 2024-01-12:
- I fixed a bug, since I missed that Actions with explicitly inferred types are still exported into scopes and not their InferredType.
- Additionally, I fixed a related bug, since the identification for the name-assignment for a type used in cross-references which is explicitly inferred from an Action didn't work as expected. The example for the new test cases can be found in the [playground as well](https://langium.org/playground?grammar=OYJwhgthYgBAEgUwDbIPYHU0mQEwFD6IB2ALiAJ6wCyauKAXLGANQC8AggFQDchA9Pw6wAlsQBmiEAGdYAISYByMItjFIiNgEkAIrAAUaUgAspHNgG05AXQCUAfh6xBsAO7YA1tPwcmAbzFJODkAX1hlVXUITV0DI1MQcys7R2d%2BN09ZYiNCYxFcemJYUikIMTBkWAwAZSZ%2BAB1pFn4%2BEpAy9UrdOoswAFoALw4%2BgC0AfWteweGRgAY%2BgE4Jrhb8IA&content=IYAgsgngcsC2CmBGAUKSMECZzTk5QA).