### PR TITLE
Ensure expected document state in LSP responses

### DIFF
--- a/packages/langium/src/lsp/language-server.ts
+++ b/packages/langium/src/lsp/language-server.ts
@@ -622,11 +622,11 @@ export function createHierarchyRequestHandler<P extends TypeHierarchySupertypesP
 ): ServerRequestHandler<P, R, PR, E> {
     const serviceRegistry = sharedServices.ServiceRegistry;
     return async (params: P, cancelToken: CancellationToken) => {
-        const cancellationError = await waitUntilPhase<E>(sharedServices, cancelToken, DocumentState.IndexedReferences);
+        const uri = URI.parse(params.item.uri);
+        const cancellationError = await waitUntilPhase<E>(sharedServices, cancelToken, uri, DocumentState.IndexedReferences);
         if (cancellationError) {
             return cancellationError;
         }
-        const uri = URI.parse(params.item.uri);
         const language = serviceRegistry.getServices(uri);
         if (!language) {
             const message = `Could not find service instance for uri: '${uri.toString()}'`;
@@ -649,11 +649,11 @@ export function createServerRequestHandler<P extends { textDocument: TextDocumen
     const documents = sharedServices.workspace.LangiumDocuments;
     const serviceRegistry = sharedServices.ServiceRegistry;
     return async (params: P, cancelToken: CancellationToken) => {
-        const cancellationError = await waitUntilPhase<E>(sharedServices, cancelToken, targetState);
+        const uri = URI.parse(params.textDocument.uri);
+        const cancellationError = await waitUntilPhase<E>(sharedServices, cancelToken, uri, targetState);
         if (cancellationError) {
             return cancellationError;
         }
-        const uri = URI.parse(params.textDocument.uri);
         const language = serviceRegistry.getServices(uri);
         if (!language) {
             const errorText = `Could not find service instance for uri: '${uri}'`;
@@ -677,11 +677,11 @@ export function createRequestHandler<P extends { textDocument: TextDocumentIdent
     const documents = sharedServices.workspace.LangiumDocuments;
     const serviceRegistry = sharedServices.ServiceRegistry;
     return async (params: P, cancelToken: CancellationToken) => {
-        const cancellationError = await waitUntilPhase<E>(sharedServices, cancelToken, targetState);
+        const uri = URI.parse(params.textDocument.uri);
+        const cancellationError = await waitUntilPhase<E>(sharedServices, cancelToken, uri, targetState);
         if (cancellationError) {
             return cancellationError;
         }
-        const uri = URI.parse(params.textDocument.uri);
         const language = serviceRegistry.getServices(uri);
         if (!language) {
             console.error(`Could not find service instance for uri: '${uri.toString()}'`);
@@ -699,11 +699,11 @@ export function createRequestHandler<P extends { textDocument: TextDocumentIdent
     };
 }
 
-async function waitUntilPhase<E>(services: LangiumSharedServices, cancelToken: CancellationToken, targetState?: DocumentState): Promise<ResponseError<E> | undefined> {
+async function waitUntilPhase<E>(services: LangiumSharedServices, cancelToken: CancellationToken, uri?: URI, targetState?: DocumentState): Promise<ResponseError<E> | undefined> {
     if (targetState !== undefined) {
         const documentBuilder = services.workspace.DocumentBuilder;
         try {
-            await documentBuilder.waitUntil(targetState, cancelToken);
+            await documentBuilder.waitUntil(targetState, uri, cancelToken);
         } catch (err) {
             return responseError(err);
         }

--- a/packages/langium/src/lsp/language-server.ts
+++ b/packages/langium/src/lsp/language-server.ts
@@ -313,110 +313,127 @@ export function addCompletionHandler(connection: Connection, services: LangiumSh
         (services, document, params, cancelToken) => {
             return services.lsp?.CompletionProvider?.getCompletion(document, params, cancelToken);
         },
-        services
+        services,
+        DocumentState.IndexedReferences
     ));
 }
 
 export function addFindReferencesHandler(connection: Connection, services: LangiumSharedServices): void {
     connection.onReferences(createRequestHandler(
         (services, document, params, cancelToken) => services.lsp?.ReferencesProvider?.findReferences(document, params, cancelToken),
-        services
+        services,
+        DocumentState.IndexedReferences
     ));
 }
 
 export function addCodeActionHandler(connection: Connection, services: LangiumSharedServices): void {
     connection.onCodeAction(createRequestHandler(
         (services, document, params, cancelToken) => services.lsp?.CodeActionProvider?.getCodeActions(document, params, cancelToken),
-        services
+        services,
+        DocumentState.Validated
     ));
 }
 
 export function addDocumentSymbolHandler(connection: Connection, services: LangiumSharedServices): void {
     connection.onDocumentSymbol(createRequestHandler(
         (services, document, params, cancelToken) => services.lsp?.DocumentSymbolProvider?.getSymbols(document, params, cancelToken),
-        services
+        services,
+        DocumentState.Parsed
     ));
 }
 
 export function addGotoDefinitionHandler(connection: Connection, services: LangiumSharedServices): void {
     connection.onDefinition(createRequestHandler(
         (services, document, params, cancelToken) => services.lsp?.DefinitionProvider?.getDefinition(document, params, cancelToken),
-        services
+        services,
+        DocumentState.IndexedReferences
     ));
 }
 
 export function addGoToTypeDefinitionHandler(connection: Connection, services: LangiumSharedServices): void {
     connection.onTypeDefinition(createRequestHandler(
         (services, document, params, cancelToken) => services.lsp?.TypeProvider?.getTypeDefinition(document, params, cancelToken),
-        services
+        services,
+        DocumentState.IndexedReferences
     ));
 }
 
 export function addGoToImplementationHandler(connection: Connection, services: LangiumSharedServices) {
     connection.onImplementation(createRequestHandler(
         (services, document, params, cancelToken) => services.lsp?.ImplementationProvider?.getImplementation(document, params, cancelToken),
-        services
+        services,
+        DocumentState.IndexedReferences
     ));
 }
 
 export function addGoToDeclarationHandler(connection: Connection, services: LangiumSharedServices) {
     connection.onDeclaration(createRequestHandler(
         (services, document, params, cancelToken) => services.lsp?.DeclarationProvider?.getDeclaration(document, params, cancelToken),
-        services
+        services,
+        DocumentState.IndexedReferences
     ));
 }
 
 export function addDocumentHighlightsHandler(connection: Connection, services: LangiumSharedServices): void {
     connection.onDocumentHighlight(createRequestHandler(
         (services, document, params, cancelToken) => services.lsp?.DocumentHighlightProvider?.getDocumentHighlight(document, params, cancelToken),
-        services
+        services,
+        DocumentState.IndexedReferences
     ));
 }
 
 export function addHoverHandler(connection: Connection, services: LangiumSharedServices): void {
     connection.onHover(createRequestHandler(
         (services, document, params, cancelToken) => services.lsp?.HoverProvider?.getHoverContent(document, params, cancelToken),
-        services
+        services,
+        DocumentState.IndexedReferences
     ));
 }
 
 export function addFoldingRangeHandler(connection: Connection, services: LangiumSharedServices): void {
     connection.onFoldingRanges(createRequestHandler(
         (services, document, params, cancelToken) => services.lsp?.FoldingRangeProvider?.getFoldingRanges(document, params, cancelToken),
-        services
+        services,
+        DocumentState.Parsed
     ));
 }
 
 export function addFormattingHandler(connection: Connection, services: LangiumSharedServices): void {
     connection.onDocumentFormatting(createRequestHandler(
         (services, document, params, cancelToken) => services.lsp?.Formatter?.formatDocument(document, params, cancelToken),
-        services
+        services,
+        DocumentState.Parsed
     ));
     connection.onDocumentRangeFormatting(createRequestHandler(
         (services, document, params, cancelToken) => services.lsp?.Formatter?.formatDocumentRange(document, params, cancelToken),
-        services
+        services,
+        DocumentState.Parsed
     ));
     connection.onDocumentOnTypeFormatting(createRequestHandler(
         (services, document, params, cancelToken) => services.lsp?.Formatter?.formatDocumentOnType(document, params, cancelToken),
-        services
+        services,
+        DocumentState.Parsed
     ));
 }
 
 export function addRenameHandler(connection: Connection, services: LangiumSharedServices): void {
     connection.onRenameRequest(createRequestHandler(
         (services, document, params, cancelToken) => services.lsp?.RenameProvider?.rename(document, params, cancelToken),
-        services
+        services,
+        DocumentState.IndexedReferences
     ));
     connection.onPrepareRename(createRequestHandler(
         (services, document, params, cancelToken) => services.lsp?.RenameProvider?.prepareRename(document, params, cancelToken),
-        services
+        services,
+        DocumentState.IndexedReferences
     ));
 }
 
 export function addInlayHintHandler(connection: Connection, services: LangiumSharedServices): void {
     connection.languages.inlayHint.on(createServerRequestHandler(
         (services, document, params, cancelToken) => services.lsp?.InlayHintProvider?.getInlayHints(document, params, cancelToken),
-        services
+        services,
+        DocumentState.IndexedReferences
     ));
 }
 
@@ -430,7 +447,8 @@ export function addSemanticTokenHandler(connection: Connection, services: Langiu
             }
             return emptyResult;
         },
-        services
+        services,
+        DocumentState.IndexedReferences
     ));
     connection.languages.semanticTokens.onDelta(createServerRequestHandler<SemanticTokensDeltaParams, SemanticTokens | SemanticTokensDelta, SemanticTokensDeltaPartialResult, void>(
         (services, document, params, cancelToken) => {
@@ -439,7 +457,8 @@ export function addSemanticTokenHandler(connection: Connection, services: Langiu
             }
             return emptyResult;
         },
-        services
+        services,
+        DocumentState.IndexedReferences
     ));
     connection.languages.semanticTokens.onRange(createServerRequestHandler<SemanticTokensRangeParams, SemanticTokens, SemanticTokensPartialResult, void>(
         (services, document, params, cancelToken) => {
@@ -448,7 +467,8 @@ export function addSemanticTokenHandler(connection: Connection, services: Langiu
             }
             return emptyResult;
         },
-        services
+        services,
+        DocumentState.IndexedReferences
     ));
 }
 export function addConfigurationChangeHandler(connection: Connection, services: LangiumSharedServices): void {
@@ -475,29 +495,34 @@ export function addExecuteCommandHandler(connection: Connection, services: Langi
 export function addDocumentLinkHandler(connection: Connection, services: LangiumSharedServices): void {
     connection.onDocumentLinks(createServerRequestHandler(
         (services, document, params, cancelToken) => services.lsp?.DocumentLinkProvider?.getDocumentLinks(document, params, cancelToken),
-        services
+        services,
+        DocumentState.Parsed
     ));
 }
 
 export function addSignatureHelpHandler(connection: Connection, services: LangiumSharedServices): void {
     connection.onSignatureHelp(createServerRequestHandler(
         (services, document, params, cancelToken) => services.lsp?.SignatureHelp?.provideSignatureHelp(document, params, cancelToken),
-        services
+        services,
+        DocumentState.IndexedReferences
     ));
 }
 
 export function addCodeLensHandler(connection: Connection, services: LangiumSharedServices): void {
     connection.onCodeLens(createServerRequestHandler(
         (services, document, params, cancelToken) => services.lsp?.CodeLensProvider?.provideCodeLens(document, params, cancelToken),
-        services
+        services,
+        DocumentState.IndexedReferences
     ));
 }
 
 export function addWorkspaceSymbolHandler(connection: Connection, services: LangiumSharedServices): void {
     const workspaceSymbolProvider = services.lsp.WorkspaceSymbolProvider;
     if (workspaceSymbolProvider) {
+        const documentBuilder = services.workspace.DocumentBuilder;
         connection.onWorkspaceSymbol(async (params, token) => {
             try {
+                await documentBuilder.waitUntil(DocumentState.IndexedContent);
                 return await workspaceSymbolProvider.getSymbols(params, token);
             } catch (err) {
                 return responseError(err);
@@ -507,6 +532,7 @@ export function addWorkspaceSymbolHandler(connection: Connection, services: Lang
         if (resolveWorkspaceSymbol) {
             connection.onWorkspaceSymbolResolve(async (workspaceSymbol, token) => {
                 try {
+                    await documentBuilder.waitUntil(DocumentState.IndexedContent);
                     return await resolveWorkspaceSymbol(workspaceSymbol, token);
                 } catch (err) {
                     return responseError(err);
@@ -525,7 +551,8 @@ export function addCallHierarchyHandler(connection: Connection, services: Langiu
             }
             return null;
         },
-        services
+        services,
+        DocumentState.IndexedReferences
     ));
 
     connection.languages.callHierarchy.onIncomingCalls(createHierarchyRequestHandler(
@@ -558,24 +585,34 @@ export function addTypeHierarchyHandler(connection: Connection, sharedServices: 
     }
 
     connection.languages.typeHierarchy.onPrepare(
-        createServerRequestHandler(async (services, document, params, cancelToken) => {
-            const result = await services.lsp?.TypeHierarchyProvider?.prepareTypeHierarchy(document, params, cancelToken);
-            return result ?? null;
-        }, sharedServices),
+        createServerRequestHandler(
+            async (services, document, params, cancelToken) => {
+                const result = await services.lsp.TypeHierarchyProvider?.prepareTypeHierarchy(document, params, cancelToken);
+                return result ?? null;
+            },
+            sharedServices,
+            DocumentState.IndexedReferences
+        ),
     );
 
     connection.languages.typeHierarchy.onSupertypes(
-        createHierarchyRequestHandler(async (services, params, cancelToken) => {
-            const result = await services.lsp?.TypeHierarchyProvider?.supertypes(params, cancelToken);
-            return result ?? null;
-        }, sharedServices),
+        createHierarchyRequestHandler(
+            async (services, params, cancelToken) => {
+                const result = await services.lsp.TypeHierarchyProvider?.supertypes(params, cancelToken);
+                return result ?? null;
+            },
+            sharedServices
+        ),
     );
 
     connection.languages.typeHierarchy.onSubtypes(
-        createHierarchyRequestHandler(async (services, params, cancelToken) => {
-            const result = await services.lsp?.TypeHierarchyProvider?.subtypes(params, cancelToken);
-            return result ?? null;
-        }, sharedServices),
+        createHierarchyRequestHandler(
+            async (services, params, cancelToken) => {
+                const result = await services.lsp.TypeHierarchyProvider?.subtypes(params, cancelToken);
+                return result ?? null;
+            },
+            sharedServices
+        ),
     );
 }
 
@@ -584,7 +621,9 @@ export function createHierarchyRequestHandler<P extends TypeHierarchySupertypesP
     sharedServices: LangiumSharedServices,
 ): ServerRequestHandler<P, R, PR, E> {
     const serviceRegistry = sharedServices.ServiceRegistry;
+    const documentBuilder = sharedServices.workspace.DocumentBuilder;
     return async (params: P, cancelToken: CancellationToken) => {
+        await documentBuilder.waitUntil(DocumentState.IndexedReferences);
         const uri = URI.parse(params.item.uri);
         const language = serviceRegistry.getServices(uri);
         if (!language) {
@@ -601,12 +640,17 @@ export function createHierarchyRequestHandler<P extends TypeHierarchySupertypesP
 }
 
 export function createServerRequestHandler<P extends { textDocument: TextDocumentIdentifier }, R, PR, E = void>(
-    serviceCall: (services: LangiumCoreAndPartialLSPServices, document: LangiumDocument, params: P, cancelToken: CancellationToken) => HandlerResult<R, E>,
-    sharedServices: LangiumSharedServices
+    serviceCall: (services: LangiumServices, document: LangiumDocument, params: P, cancelToken: CancellationToken) => HandlerResult<R, E>,
+    sharedServices: LangiumSharedServices,
+    targetState?: DocumentState
 ): ServerRequestHandler<P, R, PR, E> {
     const documents = sharedServices.workspace.LangiumDocuments;
+    const documentBuilder = sharedServices.workspace.DocumentBuilder;
     const serviceRegistry = sharedServices.ServiceRegistry;
     return async (params: P, cancelToken: CancellationToken) => {
+        if (targetState !== undefined) {
+            await documentBuilder.waitUntil(targetState);
+        }
         const uri = URI.parse(params.textDocument.uri);
         const language = serviceRegistry.getServices(uri);
         if (!language) {
@@ -624,12 +668,17 @@ export function createServerRequestHandler<P extends { textDocument: TextDocumen
 }
 
 export function createRequestHandler<P extends { textDocument: TextDocumentIdentifier }, R, E = void>(
-    serviceCall: (services: LangiumCoreAndPartialLSPServices, document: LangiumDocument, params: P, cancelToken: CancellationToken) => HandlerResult<R, E>,
-    sharedServices: LangiumSharedServices
+    serviceCall: (services: LangiumServices, document: LangiumDocument, params: P, cancelToken: CancellationToken) => HandlerResult<R, E>,
+    sharedServices: LangiumSharedServices,
+    targetState?: DocumentState
 ): RequestHandler<P, R | null, E> {
     const documents = sharedServices.workspace.LangiumDocuments;
+    const documentBuilder = sharedServices.workspace.DocumentBuilder;
     const serviceRegistry = sharedServices.ServiceRegistry;
     return async (params: P, cancelToken: CancellationToken) => {
+        if (targetState !== undefined) {
+            await documentBuilder.waitUntil(targetState);
+        }
         const uri = URI.parse(params.textDocument.uri);
         const language = serviceRegistry.getServices(uri);
         if (!language) {

--- a/packages/langium/src/lsp/language-server.ts
+++ b/packages/langium/src/lsp/language-server.ts
@@ -587,7 +587,7 @@ export function addTypeHierarchyHandler(connection: Connection, sharedServices: 
     connection.languages.typeHierarchy.onPrepare(
         createServerRequestHandler(
             async (services, document, params, cancelToken) => {
-                const result = await services.lsp.TypeHierarchyProvider?.prepareTypeHierarchy(document, params, cancelToken);
+                const result = await services.lsp?.TypeHierarchyProvider?.prepareTypeHierarchy(document, params, cancelToken);
                 return result ?? null;
             },
             sharedServices,
@@ -598,7 +598,7 @@ export function addTypeHierarchyHandler(connection: Connection, sharedServices: 
     connection.languages.typeHierarchy.onSupertypes(
         createHierarchyRequestHandler(
             async (services, params, cancelToken) => {
-                const result = await services.lsp.TypeHierarchyProvider?.supertypes(params, cancelToken);
+                const result = await services.lsp?.TypeHierarchyProvider?.supertypes(params, cancelToken);
                 return result ?? null;
             },
             sharedServices
@@ -608,7 +608,7 @@ export function addTypeHierarchyHandler(connection: Connection, sharedServices: 
     connection.languages.typeHierarchy.onSubtypes(
         createHierarchyRequestHandler(
             async (services, params, cancelToken) => {
-                const result = await services.lsp.TypeHierarchyProvider?.subtypes(params, cancelToken);
+                const result = await services.lsp?.TypeHierarchyProvider?.subtypes(params, cancelToken);
                 return result ?? null;
             },
             sharedServices
@@ -642,7 +642,7 @@ export function createHierarchyRequestHandler<P extends TypeHierarchySupertypesP
 }
 
 export function createServerRequestHandler<P extends { textDocument: TextDocumentIdentifier }, R, PR, E = void>(
-    serviceCall: (services: LangiumServices, document: LangiumDocument, params: P, cancelToken: CancellationToken) => HandlerResult<R, E>,
+    serviceCall: (services: LangiumCoreAndPartialLSPServices, document: LangiumDocument, params: P, cancelToken: CancellationToken) => HandlerResult<R, E>,
     sharedServices: LangiumSharedServices,
     targetState?: DocumentState
 ): ServerRequestHandler<P, R, PR, E> {
@@ -670,7 +670,7 @@ export function createServerRequestHandler<P extends { textDocument: TextDocumen
 }
 
 export function createRequestHandler<P extends { textDocument: TextDocumentIdentifier }, R, E = void>(
-    serviceCall: (services: LangiumServices, document: LangiumDocument, params: P, cancelToken: CancellationToken) => HandlerResult<R, E>,
+    serviceCall: (services: LangiumCoreAndPartialLSPServices, document: LangiumDocument, params: P, cancelToken: CancellationToken) => HandlerResult<R, E>,
     sharedServices: LangiumSharedServices,
     targetState?: DocumentState
 ): RequestHandler<P, R | null, E> {

--- a/packages/langium/test/workspace/document-builder.test.ts
+++ b/packages/langium/test/workspace/document-builder.test.ts
@@ -10,6 +10,11 @@ import { createServicesForGrammar } from 'langium/grammar';
 import { setTextDocument } from 'langium/test';
 import { describe, expect, test } from 'vitest';
 import { CancellationTokenSource } from 'vscode-languageserver';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { isOperationCancelled, DocumentState, EmptyFileSystem, URI, delayNextTick } from 'langium';
+import { createLangiumGrammarServices, createServicesForGrammar } from 'langium/grammar';
+import { setTextDocument } from 'langium/test';
+import { fail } from 'assert';
 
 describe('DefaultDocumentBuilder', () => {
     async function createServices() {
@@ -234,6 +239,88 @@ describe('DefaultDocumentBuilder', () => {
             'Value is too large: 11',
             'Bar is too long: AnotherStrangeBar'
         ]);
+    });
+
+    test('waits until a specific workspace stage has been reached', async () => {
+        const services = await createServices();
+        const documentFactory = services.shared.workspace.LangiumDocumentFactory;
+        const documents = services.shared.workspace.LangiumDocuments;
+        const builder = services.shared.workspace.DocumentBuilder;
+        const document = documentFactory.fromString('', URI.parse('file:///test1.txt'));
+        documents.addDocument(document);
+
+        const actual: string[] = [];
+        const expected: string[] = [];
+        function wait(state: DocumentState): void {
+            expected.push('B' + state);
+            expected.push('W' + state);
+            builder.onBuildPhase(state, async () => {
+                actual.push('B' + state);
+                await delayNextTick();
+            });
+            builder.waitUntil(state).then(() => actual.push('W' + state));
+        }
+        for (let i = 2; i <= 6; i++) {
+            wait(i);
+        }
+        await builder.build([document], { validation: true });
+        expect(actual).toEqual(expected);
+    });
+
+    test('`waitUntil` will correctly wait even though the build process has been cancelled', async () => {
+        const services = await createServices();
+        const documentFactory = services.shared.workspace.LangiumDocumentFactory;
+        const documents = services.shared.workspace.LangiumDocuments;
+        const builder = services.shared.workspace.DocumentBuilder;
+        const document = documentFactory.fromString('', URI.parse('file:///test1.txt'));
+        documents.addDocument(document);
+
+        const actual: string[] = [];
+        const cancelTokenSource = new CancellationTokenSource();
+        function wait(state: DocumentState): void {
+            builder.onBuildPhase(state, async () => {
+                actual.push('B' + state);
+                await delayNextTick();
+            });
+        }
+        for (let i = 2; i <= 6; i++) {
+            wait(i);
+        }
+        builder.waitUntil(DocumentState.ComputedScopes).then(() => cancelTokenSource.cancel());
+        builder.waitUntil(DocumentState.IndexedReferences).then(() => {
+            actual.push('W' + DocumentState.IndexedReferences);
+        });
+        // Build twice but interrupt the first build after the computing scope phase
+        try {
+            await builder.build([document], { validation: true }, cancelTokenSource.token);
+        } catch {
+            // build has been cancelled, ignore
+        }
+        document.state = DocumentState.Parsed;
+        await builder.build([document], { validation: true });
+        // The B2 and B3 phases are duplicated because the first build has been cancelled
+        // W5 still appears as expected after B5
+        expect(actual).toEqual(['B2', 'B3', 'B2', 'B3', 'B4', 'B5', 'W5', 'B6']);
+    });
+
+    test('`waitUntil` can be cancelled before it gets triggered', async () => {
+        const services = await createServices();
+        const documentFactory = services.shared.workspace.LangiumDocumentFactory;
+        const documents = services.shared.workspace.LangiumDocuments;
+        const builder = services.shared.workspace.DocumentBuilder;
+        const document = documentFactory.fromString('', URI.parse('file:///test1.txt'));
+        documents.addDocument(document);
+
+        const cancelTokenSource = new CancellationTokenSource();
+        builder.waitUntil(DocumentState.IndexedReferences, cancelTokenSource.token).then(() => {
+            fail('This should have been cancelled');
+        }).catch(err => {
+            expect(isOperationCancelled(err)).toBeTruthy();
+        });
+        builder.onBuildPhase(DocumentState.ComputedScopes, () => {
+            cancelTokenSource.cancel();
+        });
+        await builder.build([document], { validation: true });
     });
 
 });

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -18,7 +18,7 @@ export default defineConfig({
             interopDefault: true
         },
         include: ['**/test/**/*.test.ts'],
-        exclude: ['**/node_modules/**', '**/dist/**', '**/generated/**', '**/templates/**'],
+        exclude: ['**/node_modules/**', '**/dist/**', '**/generated/**', '**/templates/**', '**/examples/hello*/**'],
         watchExclude: [ '**/examples/hello*/**' /* populated by the yeoman generator test */],
     }
 });


### PR DESCRIPTION
Related to https://github.com/eclipse-langium/langium/discussions/1290

In the discussion in particular, the console warning appears due to the GLSP handler not awaiting the linking phase. However, all of our own LSP handlers haven't been awaiting that phase, instead opting to respond as quickly as possible. This sometimes leads to unexpected behavior in the response or tries to resolve a cross reference before it is ready.

This change attempts to mitigate the risk of this issue appearing by adding a `waitUntil` method to the `DocumentBuilder`. We use that method in the language server to wait until the required data is available for the respective service to do their work. This is usually either `IndexedReferences` (for any service that requires to resolve cross references) and `Parsed` (for services that operate on the AST/CST directly).

The new `waitUntil` method can also be interrupted in case it is no longer required. It will then `reject` (see tests). 