### PR TITLE
Add trailing semicolon in generated ast interfaces

### DIFF
--- a/examples/arithmetics/src/language-server/generated/ast.ts
+++ b/examples/arithmetics/src/language-server/generated/ast.ts
@@ -42,9 +42,9 @@ export function isStatement(item: unknown): item is Statement {
 export interface BinaryExpression extends AstNode {
     readonly $container: BinaryExpression | Definition | Evaluation | FunctionCall;
     readonly $type: 'BinaryExpression';
-    left: Expression
-    operator: '%' | '*' | '+' | '-' | '/' | '^'
-    right: Expression
+    left: Expression;
+    operator: '%' | '*' | '+' | '-' | '/' | '^';
+    right: Expression;
 }
 
 export const BinaryExpression = 'BinaryExpression';
@@ -56,7 +56,7 @@ export function isBinaryExpression(item: unknown): item is BinaryExpression {
 export interface DeclaredParameter extends AstNode {
     readonly $container: Definition;
     readonly $type: 'DeclaredParameter';
-    name: string
+    name: string;
 }
 
 export const DeclaredParameter = 'DeclaredParameter';
@@ -68,9 +68,9 @@ export function isDeclaredParameter(item: unknown): item is DeclaredParameter {
 export interface Definition extends AstNode {
     readonly $container: Module;
     readonly $type: 'Definition';
-    args: Array<DeclaredParameter>
-    expr: Expression
-    name: string
+    args: Array<DeclaredParameter>;
+    expr: Expression;
+    name: string;
 }
 
 export const Definition = 'Definition';
@@ -82,7 +82,7 @@ export function isDefinition(item: unknown): item is Definition {
 export interface Evaluation extends AstNode {
     readonly $container: Module;
     readonly $type: 'Evaluation';
-    expression: Expression
+    expression: Expression;
 }
 
 export const Evaluation = 'Evaluation';
@@ -94,8 +94,8 @@ export function isEvaluation(item: unknown): item is Evaluation {
 export interface FunctionCall extends AstNode {
     readonly $container: BinaryExpression | Definition | Evaluation | FunctionCall;
     readonly $type: 'FunctionCall';
-    args: Array<Expression>
-    func: Reference<AbstractDefinition>
+    args: Array<Expression>;
+    func: Reference<AbstractDefinition>;
 }
 
 export const FunctionCall = 'FunctionCall';
@@ -106,8 +106,8 @@ export function isFunctionCall(item: unknown): item is FunctionCall {
 
 export interface Module extends AstNode {
     readonly $type: 'Module';
-    name: string
-    statements: Array<Statement>
+    name: string;
+    statements: Array<Statement>;
 }
 
 export const Module = 'Module';
@@ -119,7 +119,7 @@ export function isModule(item: unknown): item is Module {
 export interface NumberLiteral extends AstNode {
     readonly $container: BinaryExpression | Definition | Evaluation | FunctionCall;
     readonly $type: 'NumberLiteral';
-    value: number
+    value: number;
 }
 
 export const NumberLiteral = 'NumberLiteral';

--- a/examples/domainmodel/src/language-server/generated/ast.ts
+++ b/examples/domainmodel/src/language-server/generated/ast.ts
@@ -39,7 +39,7 @@ export function isType(item: unknown): item is Type {
 export interface DataType extends AstNode {
     readonly $container: Domainmodel | PackageDeclaration;
     readonly $type: 'DataType';
-    name: string
+    name: string;
 }
 
 export const DataType = 'DataType';
@@ -50,7 +50,7 @@ export function isDataType(item: unknown): item is DataType {
 
 export interface Domainmodel extends AstNode {
     readonly $type: 'Domainmodel';
-    elements: Array<AbstractElement>
+    elements: Array<AbstractElement>;
 }
 
 export const Domainmodel = 'Domainmodel';
@@ -62,9 +62,9 @@ export function isDomainmodel(item: unknown): item is Domainmodel {
 export interface Entity extends AstNode {
     readonly $container: Domainmodel | PackageDeclaration;
     readonly $type: 'Entity';
-    features: Array<Feature>
-    name: string
-    superType?: Reference<Entity>
+    features: Array<Feature>;
+    name: string;
+    superType?: Reference<Entity>;
 }
 
 export const Entity = 'Entity';
@@ -76,9 +76,9 @@ export function isEntity(item: unknown): item is Entity {
 export interface Feature extends AstNode {
     readonly $container: Entity;
     readonly $type: 'Feature';
-    many: boolean
-    name: string
-    type: Reference<Type>
+    many: boolean;
+    name: string;
+    type: Reference<Type>;
 }
 
 export const Feature = 'Feature';
@@ -90,8 +90,8 @@ export function isFeature(item: unknown): item is Feature {
 export interface PackageDeclaration extends AstNode {
     readonly $container: Domainmodel | PackageDeclaration;
     readonly $type: 'PackageDeclaration';
-    elements: Array<AbstractElement>
-    name: QualifiedName
+    elements: Array<AbstractElement>;
+    name: QualifiedName;
 }
 
 export const PackageDeclaration = 'PackageDeclaration';

--- a/examples/requirements/src/language-server/generated/ast.ts
+++ b/examples/requirements/src/language-server/generated/ast.ts
@@ -18,7 +18,7 @@ export const RequirementsAndTestsTerminals = {
 export interface Contact extends AstNode {
     readonly $container: RequirementModel | TestModel;
     readonly $type: 'Contact';
-    user_name: string
+    user_name: string;
 }
 
 export const Contact = 'Contact';
@@ -30,8 +30,8 @@ export function isContact(item: unknown): item is Contact {
 export interface Environment extends AstNode {
     readonly $container: RequirementModel;
     readonly $type: 'Environment';
-    description: string
-    name: string
+    description: string;
+    name: string;
 }
 
 export const Environment = 'Environment';
@@ -43,9 +43,9 @@ export function isEnvironment(item: unknown): item is Environment {
 export interface Requirement extends AstNode {
     readonly $container: RequirementModel;
     readonly $type: 'Requirement';
-    environments: Array<Reference<Environment>>
-    name: string
-    text: string
+    environments: Array<Reference<Environment>>;
+    name: string;
+    text: string;
 }
 
 export const Requirement = 'Requirement';
@@ -56,9 +56,9 @@ export function isRequirement(item: unknown): item is Requirement {
 
 export interface RequirementModel extends AstNode {
     readonly $type: 'RequirementModel';
-    contact?: Contact
-    environments: Array<Environment>
-    requirements: Array<Requirement>
+    contact?: Contact;
+    environments: Array<Environment>;
+    requirements: Array<Requirement>;
 }
 
 export const RequirementModel = 'RequirementModel';
@@ -70,10 +70,10 @@ export function isRequirementModel(item: unknown): item is RequirementModel {
 export interface Test extends AstNode {
     readonly $container: TestModel;
     readonly $type: 'Test';
-    environments: Array<Reference<Environment>>
-    name: string
-    requirements: Array<Reference<Requirement>>
-    testFile?: string
+    environments: Array<Reference<Environment>>;
+    name: string;
+    requirements: Array<Reference<Requirement>>;
+    testFile?: string;
 }
 
 export const Test = 'Test';
@@ -84,8 +84,8 @@ export function isTest(item: unknown): item is Test {
 
 export interface TestModel extends AstNode {
     readonly $type: 'TestModel';
-    contact?: Contact
-    tests: Array<Test>
+    contact?: Contact;
+    tests: Array<Test>;
 }
 
 export const TestModel = 'TestModel';

--- a/examples/statemachine/src/language-server/generated/ast.ts
+++ b/examples/statemachine/src/language-server/generated/ast.ts
@@ -17,7 +17,7 @@ export const StatemachineTerminals = {
 export interface Command extends AstNode {
     readonly $container: Statemachine;
     readonly $type: 'Command';
-    name: string
+    name: string;
 }
 
 export const Command = 'Command';
@@ -29,7 +29,7 @@ export function isCommand(item: unknown): item is Command {
 export interface Event extends AstNode {
     readonly $container: Statemachine;
     readonly $type: 'Event';
-    name: string
+    name: string;
 }
 
 export const Event = 'Event';
@@ -41,9 +41,9 @@ export function isEvent(item: unknown): item is Event {
 export interface State extends AstNode {
     readonly $container: Statemachine;
     readonly $type: 'State';
-    actions: Array<Reference<Command>>
-    name: string
-    transitions: Array<Transition>
+    actions: Array<Reference<Command>>;
+    name: string;
+    transitions: Array<Transition>;
 }
 
 export const State = 'State';
@@ -54,11 +54,11 @@ export function isState(item: unknown): item is State {
 
 export interface Statemachine extends AstNode {
     readonly $type: 'Statemachine';
-    commands: Array<Command>
-    events: Array<Event>
-    init: Reference<State>
-    name: string
-    states: Array<State>
+    commands: Array<Command>;
+    events: Array<Event>;
+    init: Reference<State>;
+    name: string;
+    states: Array<State>;
 }
 
 export const Statemachine = 'Statemachine';
@@ -70,8 +70,8 @@ export function isStatemachine(item: unknown): item is Statemachine {
 export interface Transition extends AstNode {
     readonly $container: State;
     readonly $type: 'Transition';
-    event: Reference<Event>
-    state: Reference<State>
+    event: Reference<Event>;
+    state: Reference<State>;
 }
 
 export const Transition = 'Transition';

--- a/packages/langium-cli/test/generator/types-generator.test.ts
+++ b/packages/langium-cli/test/generator/types-generator.test.ts
@@ -34,37 +34,37 @@ const EXPECTED_TYPES = expandToStringWithNL`
     type Statement = Definition | Evaluation;
 
     interface BinaryExpression {
-        left: Expression
-        operator: "*" | "+" | "-" | "/"
-        right: Expression
+        left: Expression;
+        operator: "*" | "+" | "-" | "/";
+        right: Expression;
     }
 
     interface DeclaredParameter {
-        name: string
+        name: string;
     }
 
     interface Definition {
-        args: DeclaredParameter[]
-        expr: Expression
-        name: string
+        args: DeclaredParameter[];
+        expr: Expression;
+        name: string;
     }
 
     interface Evaluation {
-        expression: Expression
+        expression: Expression;
     }
 
     interface FunctionCall {
-        args: Expression[]
-        func: @AbstractDefinition
+        args: Expression[];
+        func: @AbstractDefinition;
     }
 
     interface Module {
-        name: string
-        statements: Statement[]
+        name: string;
+        statements: Statement[];
     }
 
     interface NumberLiteral {
-        value: number
+        value: number;
     }
 
 `;

--- a/packages/langium/src/grammar/type-system/type-collector/types.ts
+++ b/packages/langium/src/grammar/type-system/type-collector/types.ts
@@ -404,7 +404,7 @@ function pushProperties(
         const name = mode === 'AstType' ? property.name : escapeReservedWords(property.name, reserved);
         const optional = property.optional && !isMandatoryPropertyType(property.type);
         const propType = propertyTypeToString(property.type, mode);
-        return `${name}${optional ? '?' : ''}: ${propType}`;
+        return `${name}${optional ? '?' : ''}: ${propType};`;
     }
 
     return joinToNode(

--- a/packages/langium/src/languages/generated/ast.ts
+++ b/packages/langium/src/languages/generated/ast.ts
@@ -71,8 +71,8 @@ export function isValueLiteral(item: unknown): item is ValueLiteral {
 
 export interface AbstractElement extends AstNode {
     readonly $type: 'AbstractElement' | 'Action' | 'Alternatives' | 'Assignment' | 'CharacterRange' | 'CrossReference' | 'EndOfFile' | 'Group' | 'Keyword' | 'NegatedToken' | 'RegexToken' | 'RuleCall' | 'TerminalAlternatives' | 'TerminalGroup' | 'TerminalRuleCall' | 'UnorderedGroup' | 'UntilToken' | 'Wildcard';
-    cardinality?: '*' | '+' | '?'
-    lookahead?: '?!' | '?='
+    cardinality?: '*' | '+' | '?';
+    lookahead?: '?!' | '?=';
 }
 
 export const AbstractElement = 'AbstractElement';
@@ -84,7 +84,7 @@ export function isAbstractElement(item: unknown): item is AbstractElement {
 export interface ArrayLiteral extends AstNode {
     readonly $container: ArrayLiteral | TypeAttribute;
     readonly $type: 'ArrayLiteral';
-    elements: Array<ValueLiteral>
+    elements: Array<ValueLiteral>;
 }
 
 export const ArrayLiteral = 'ArrayLiteral';
@@ -96,7 +96,7 @@ export function isArrayLiteral(item: unknown): item is ArrayLiteral {
 export interface ArrayType extends AstNode {
     readonly $container: ArrayType | ReferenceType | Type | TypeAttribute | UnionType;
     readonly $type: 'ArrayType';
-    elementType: TypeDefinition
+    elementType: TypeDefinition;
 }
 
 export const ArrayType = 'ArrayType';
@@ -108,7 +108,7 @@ export function isArrayType(item: unknown): item is ArrayType {
 export interface BooleanLiteral extends AstNode {
     readonly $container: ArrayLiteral | Conjunction | Disjunction | Group | NamedArgument | Negation | TypeAttribute;
     readonly $type: 'BooleanLiteral';
-    true: boolean
+    true: boolean;
 }
 
 export const BooleanLiteral = 'BooleanLiteral';
@@ -120,8 +120,8 @@ export function isBooleanLiteral(item: unknown): item is BooleanLiteral {
 export interface Conjunction extends AstNode {
     readonly $container: Conjunction | Disjunction | Group | NamedArgument | Negation;
     readonly $type: 'Conjunction';
-    left: Condition
-    right: Condition
+    left: Condition;
+    right: Condition;
 }
 
 export const Conjunction = 'Conjunction';
@@ -133,8 +133,8 @@ export function isConjunction(item: unknown): item is Conjunction {
 export interface Disjunction extends AstNode {
     readonly $container: Conjunction | Disjunction | Group | NamedArgument | Negation;
     readonly $type: 'Disjunction';
-    left: Condition
-    right: Condition
+    left: Condition;
+    right: Condition;
 }
 
 export const Disjunction = 'Disjunction';
@@ -145,15 +145,15 @@ export function isDisjunction(item: unknown): item is Disjunction {
 
 export interface Grammar extends AstNode {
     readonly $type: 'Grammar';
-    definesHiddenTokens: boolean
-    hiddenTokens: Array<Reference<AbstractRule>>
-    imports: Array<GrammarImport>
-    interfaces: Array<Interface>
-    isDeclared: boolean
-    name?: string
-    rules: Array<AbstractRule>
-    types: Array<Type>
-    usedGrammars: Array<Reference<Grammar>>
+    definesHiddenTokens: boolean;
+    hiddenTokens: Array<Reference<AbstractRule>>;
+    imports: Array<GrammarImport>;
+    interfaces: Array<Interface>;
+    isDeclared: boolean;
+    name?: string;
+    rules: Array<AbstractRule>;
+    types: Array<Type>;
+    usedGrammars: Array<Reference<Grammar>>;
 }
 
 export const Grammar = 'Grammar';
@@ -165,7 +165,7 @@ export function isGrammar(item: unknown): item is Grammar {
 export interface GrammarImport extends AstNode {
     readonly $container: Grammar;
     readonly $type: 'GrammarImport';
-    path: string
+    path: string;
 }
 
 export const GrammarImport = 'GrammarImport';
@@ -177,7 +177,7 @@ export function isGrammarImport(item: unknown): item is GrammarImport {
 export interface InferredType extends AstNode {
     readonly $container: Action | ParserRule;
     readonly $type: 'InferredType';
-    name: string
+    name: string;
 }
 
 export const InferredType = 'InferredType';
@@ -189,9 +189,9 @@ export function isInferredType(item: unknown): item is InferredType {
 export interface Interface extends AstNode {
     readonly $container: Grammar;
     readonly $type: 'Interface';
-    attributes: Array<TypeAttribute>
-    name: string
-    superTypes: Array<Reference<AbstractType>>
+    attributes: Array<TypeAttribute>;
+    name: string;
+    superTypes: Array<Reference<AbstractType>>;
 }
 
 export const Interface = 'Interface';
@@ -203,9 +203,9 @@ export function isInterface(item: unknown): item is Interface {
 export interface NamedArgument extends AstNode {
     readonly $container: RuleCall;
     readonly $type: 'NamedArgument';
-    calledByName: boolean
-    parameter?: Reference<Parameter>
-    value: Condition
+    calledByName: boolean;
+    parameter?: Reference<Parameter>;
+    value: Condition;
 }
 
 export const NamedArgument = 'NamedArgument';
@@ -217,7 +217,7 @@ export function isNamedArgument(item: unknown): item is NamedArgument {
 export interface Negation extends AstNode {
     readonly $container: Conjunction | Disjunction | Group | NamedArgument | Negation;
     readonly $type: 'Negation';
-    value: Condition
+    value: Condition;
 }
 
 export const Negation = 'Negation';
@@ -229,7 +229,7 @@ export function isNegation(item: unknown): item is Negation {
 export interface NumberLiteral extends AstNode {
     readonly $container: ArrayLiteral | TypeAttribute;
     readonly $type: 'NumberLiteral';
-    value: number
+    value: number;
 }
 
 export const NumberLiteral = 'NumberLiteral';
@@ -241,7 +241,7 @@ export function isNumberLiteral(item: unknown): item is NumberLiteral {
 export interface Parameter extends AstNode {
     readonly $container: ParserRule;
     readonly $type: 'Parameter';
-    name: string
+    name: string;
 }
 
 export const Parameter = 'Parameter';
@@ -253,7 +253,7 @@ export function isParameter(item: unknown): item is Parameter {
 export interface ParameterReference extends AstNode {
     readonly $container: Conjunction | Disjunction | Group | NamedArgument | Negation;
     readonly $type: 'ParameterReference';
-    parameter: Reference<Parameter>
+    parameter: Reference<Parameter>;
 }
 
 export const ParameterReference = 'ParameterReference';
@@ -265,17 +265,17 @@ export function isParameterReference(item: unknown): item is ParameterReference 
 export interface ParserRule extends AstNode {
     readonly $container: Grammar;
     readonly $type: 'ParserRule';
-    dataType?: PrimitiveType
-    definesHiddenTokens: boolean
-    definition: AbstractElement
-    entry: boolean
-    fragment: boolean
-    hiddenTokens: Array<Reference<AbstractRule>>
-    inferredType?: InferredType
-    name: string
-    parameters: Array<Parameter>
-    returnType?: Reference<AbstractType>
-    wildcard: boolean
+    dataType?: PrimitiveType;
+    definesHiddenTokens: boolean;
+    definition: AbstractElement;
+    entry: boolean;
+    fragment: boolean;
+    hiddenTokens: Array<Reference<AbstractRule>>;
+    inferredType?: InferredType;
+    name: string;
+    parameters: Array<Parameter>;
+    returnType?: Reference<AbstractType>;
+    wildcard: boolean;
 }
 
 export const ParserRule = 'ParserRule';
@@ -287,7 +287,7 @@ export function isParserRule(item: unknown): item is ParserRule {
 export interface ReferenceType extends AstNode {
     readonly $container: ArrayType | ReferenceType | Type | TypeAttribute | UnionType;
     readonly $type: 'ReferenceType';
-    referenceType: TypeDefinition
+    referenceType: TypeDefinition;
 }
 
 export const ReferenceType = 'ReferenceType';
@@ -299,7 +299,7 @@ export function isReferenceType(item: unknown): item is ReferenceType {
 export interface ReturnType extends AstNode {
     readonly $container: TerminalRule;
     readonly $type: 'ReturnType';
-    name: PrimitiveType | string
+    name: PrimitiveType | string;
 }
 
 export const ReturnType = 'ReturnType';
@@ -311,9 +311,9 @@ export function isReturnType(item: unknown): item is ReturnType {
 export interface SimpleType extends AstNode {
     readonly $container: ArrayType | ReferenceType | Type | TypeAttribute | UnionType;
     readonly $type: 'SimpleType';
-    primitiveType?: PrimitiveType
-    stringType?: string
-    typeRef?: Reference<AbstractType>
+    primitiveType?: PrimitiveType;
+    stringType?: string;
+    typeRef?: Reference<AbstractType>;
 }
 
 export const SimpleType = 'SimpleType';
@@ -325,7 +325,7 @@ export function isSimpleType(item: unknown): item is SimpleType {
 export interface StringLiteral extends AstNode {
     readonly $container: ArrayLiteral | TypeAttribute;
     readonly $type: 'StringLiteral';
-    value: string
+    value: string;
 }
 
 export const StringLiteral = 'StringLiteral';
@@ -337,11 +337,11 @@ export function isStringLiteral(item: unknown): item is StringLiteral {
 export interface TerminalRule extends AstNode {
     readonly $container: Grammar;
     readonly $type: 'TerminalRule';
-    definition: AbstractElement
-    fragment: boolean
-    hidden: boolean
-    name: string
-    type?: ReturnType
+    definition: AbstractElement;
+    fragment: boolean;
+    hidden: boolean;
+    name: string;
+    type?: ReturnType;
 }
 
 export const TerminalRule = 'TerminalRule';
@@ -353,8 +353,8 @@ export function isTerminalRule(item: unknown): item is TerminalRule {
 export interface Type extends AstNode {
     readonly $container: Grammar;
     readonly $type: 'Type';
-    name: string
-    type: TypeDefinition
+    name: string;
+    type: TypeDefinition;
 }
 
 export const Type = 'Type';
@@ -366,10 +366,10 @@ export function isType(item: unknown): item is Type {
 export interface TypeAttribute extends AstNode {
     readonly $container: Interface;
     readonly $type: 'TypeAttribute';
-    defaultValue?: ValueLiteral
-    isOptional: boolean
-    name: FeatureName
-    type: TypeDefinition
+    defaultValue?: ValueLiteral;
+    isOptional: boolean;
+    name: FeatureName;
+    type: TypeDefinition;
 }
 
 export const TypeAttribute = 'TypeAttribute';
@@ -381,7 +381,7 @@ export function isTypeAttribute(item: unknown): item is TypeAttribute {
 export interface UnionType extends AstNode {
     readonly $container: ArrayType | ReferenceType | Type | TypeAttribute | UnionType;
     readonly $type: 'UnionType';
-    types: Array<TypeDefinition>
+    types: Array<TypeDefinition>;
 }
 
 export const UnionType = 'UnionType';
@@ -392,10 +392,10 @@ export function isUnionType(item: unknown): item is UnionType {
 
 export interface Action extends AbstractElement {
     readonly $type: 'Action';
-    feature?: FeatureName
-    inferredType?: InferredType
-    operator?: '+=' | '='
-    type?: Reference<AbstractType>
+    feature?: FeatureName;
+    inferredType?: InferredType;
+    operator?: '+=' | '=';
+    type?: Reference<AbstractType>;
 }
 
 export const Action = 'Action';
@@ -406,7 +406,7 @@ export function isAction(item: unknown): item is Action {
 
 export interface Alternatives extends AbstractElement {
     readonly $type: 'Alternatives';
-    elements: Array<AbstractElement>
+    elements: Array<AbstractElement>;
 }
 
 export const Alternatives = 'Alternatives';
@@ -417,9 +417,9 @@ export function isAlternatives(item: unknown): item is Alternatives {
 
 export interface Assignment extends AbstractElement {
     readonly $type: 'Assignment';
-    feature: FeatureName
-    operator: '+=' | '=' | '?='
-    terminal: AbstractElement
+    feature: FeatureName;
+    operator: '+=' | '=' | '?=';
+    terminal: AbstractElement;
 }
 
 export const Assignment = 'Assignment';
@@ -430,8 +430,8 @@ export function isAssignment(item: unknown): item is Assignment {
 
 export interface CharacterRange extends AbstractElement {
     readonly $type: 'CharacterRange';
-    left: Keyword
-    right?: Keyword
+    left: Keyword;
+    right?: Keyword;
 }
 
 export const CharacterRange = 'CharacterRange';
@@ -442,9 +442,9 @@ export function isCharacterRange(item: unknown): item is CharacterRange {
 
 export interface CrossReference extends AbstractElement {
     readonly $type: 'CrossReference';
-    deprecatedSyntax: boolean
-    terminal?: AbstractElement
-    type: Reference<AbstractType>
+    deprecatedSyntax: boolean;
+    terminal?: AbstractElement;
+    type: Reference<AbstractType>;
 }
 
 export const CrossReference = 'CrossReference';
@@ -465,8 +465,8 @@ export function isEndOfFile(item: unknown): item is EndOfFile {
 
 export interface Group extends AbstractElement {
     readonly $type: 'Group';
-    elements: Array<AbstractElement>
-    guardCondition?: Condition
+    elements: Array<AbstractElement>;
+    guardCondition?: Condition;
 }
 
 export const Group = 'Group';
@@ -478,7 +478,7 @@ export function isGroup(item: unknown): item is Group {
 export interface Keyword extends AbstractElement {
     readonly $container: CharacterRange;
     readonly $type: 'Keyword';
-    value: string
+    value: string;
 }
 
 export const Keyword = 'Keyword';
@@ -489,7 +489,7 @@ export function isKeyword(item: unknown): item is Keyword {
 
 export interface NegatedToken extends AbstractElement {
     readonly $type: 'NegatedToken';
-    terminal: AbstractElement
+    terminal: AbstractElement;
 }
 
 export const NegatedToken = 'NegatedToken';
@@ -500,7 +500,7 @@ export function isNegatedToken(item: unknown): item is NegatedToken {
 
 export interface RegexToken extends AbstractElement {
     readonly $type: 'RegexToken';
-    regex: string
+    regex: string;
 }
 
 export const RegexToken = 'RegexToken';
@@ -511,8 +511,8 @@ export function isRegexToken(item: unknown): item is RegexToken {
 
 export interface RuleCall extends AbstractElement {
     readonly $type: 'RuleCall';
-    arguments: Array<NamedArgument>
-    rule: Reference<AbstractRule>
+    arguments: Array<NamedArgument>;
+    rule: Reference<AbstractRule>;
 }
 
 export const RuleCall = 'RuleCall';
@@ -523,7 +523,7 @@ export function isRuleCall(item: unknown): item is RuleCall {
 
 export interface TerminalAlternatives extends AbstractElement {
     readonly $type: 'TerminalAlternatives';
-    elements: Array<AbstractElement>
+    elements: Array<AbstractElement>;
 }
 
 export const TerminalAlternatives = 'TerminalAlternatives';
@@ -534,7 +534,7 @@ export function isTerminalAlternatives(item: unknown): item is TerminalAlternati
 
 export interface TerminalGroup extends AbstractElement {
     readonly $type: 'TerminalGroup';
-    elements: Array<AbstractElement>
+    elements: Array<AbstractElement>;
 }
 
 export const TerminalGroup = 'TerminalGroup';
@@ -545,7 +545,7 @@ export function isTerminalGroup(item: unknown): item is TerminalGroup {
 
 export interface TerminalRuleCall extends AbstractElement {
     readonly $type: 'TerminalRuleCall';
-    rule: Reference<TerminalRule>
+    rule: Reference<TerminalRule>;
 }
 
 export const TerminalRuleCall = 'TerminalRuleCall';
@@ -556,7 +556,7 @@ export function isTerminalRuleCall(item: unknown): item is TerminalRuleCall {
 
 export interface UnorderedGroup extends AbstractElement {
     readonly $type: 'UnorderedGroup';
-    elements: Array<AbstractElement>
+    elements: Array<AbstractElement>;
 }
 
 export const UnorderedGroup = 'UnorderedGroup';
@@ -567,7 +567,7 @@ export function isUnorderedGroup(item: unknown): item is UnorderedGroup {
 
 export interface UntilToken extends AbstractElement {
     readonly $type: 'UntilToken';
-    terminal: AbstractElement
+    terminal: AbstractElement;
 }
 
 export const UntilToken = 'UntilToken';

--- a/packages/langium/test/grammar/type-system/inferred-types.test.ts
+++ b/packages/langium/test/grammar/type-system/inferred-types.test.ts
@@ -26,17 +26,17 @@ describe('Inferred types', () => {
         `, expandToString`
             export interface A extends AstNode {
                 readonly $type: 'A';
-                name: string
-                value?: number
+                name: string;
+                value?: number;
             }
             export interface B extends AstNode {
                 readonly $type: 'B';
-                name: FQN
-                values: Array<number>
+                name: FQN;
+                values: Array<number>;
             }
             export interface C extends AstNode {
                 readonly $type: 'C';
-                ref: Reference<A>
+                ref: Reference<A>;
             }
             export type FQN = string;
         `);
@@ -55,20 +55,20 @@ describe('Inferred types', () => {
         `, expandToString`
             export interface D extends AstNode {
                 readonly $type: 'A' | 'B' | 'D';
-                name: string
+                name: string;
             }
             export interface E extends AstNode {
                 readonly $type: 'E';
-                name?: string
-                value?: number
+                name?: string;
+                value?: number;
             }
             export interface A extends D {
                 readonly $type: 'A';
-                name: number | string
+                name: number | string;
             }
             export interface B extends D {
                 readonly $type: 'B';
-                name: number | string
+                name: number | string;
             }
             export type C = A | B;
         `);
@@ -81,8 +81,8 @@ describe('Inferred types', () => {
         `, expandToString`
             export interface A extends AstNode {
                 readonly $type: 'A';
-                a: string
-                b?: string
+                a: string;
+                b?: string;
             }
         `);
     });
@@ -94,18 +94,18 @@ describe('Inferred types', () => {
         `, expandToString`
             export interface A extends AstNode {
                 readonly $type: 'A' | 'B' | 'C';
-                a: string
-                d: string
+                a: string;
+                d: string;
             }
             export interface B extends A {
                 readonly $type: 'B' | 'C';
-                b: string
-                d: string
+                b: string;
+                d: string;
             }
             export interface C extends B {
                 readonly $type: 'C';
-                c: string
-                d: string
+                c: string;
+                d: string;
             }
         `);
     });
@@ -119,9 +119,9 @@ describe('Inferred types', () => {
             export interface B extends AstNode {
                 readonly $container: B;
                 readonly $type: 'B';
-                a?: string
-                b?: B
-                c?: string
+                a?: string;
+                b?: B;
+                c?: string;
             }
             export type A = B;
         `);
@@ -135,8 +135,8 @@ describe('Inferred types', () => {
             export interface A extends AstNode {
                 readonly $container: A;
                 readonly $type: 'A';
-                item?: A
-                value: string
+                item?: A;
+                value: string;
             }
         `);
     });
@@ -148,23 +148,23 @@ describe('Inferred types', () => {
         `, expandToString`
             export interface B extends AstNode {
                 readonly $type: 'B';
-                back: string
-                front: X | Y | Z
+                back: string;
+                front: X | Y | Z;
             }
             export interface X extends AstNode {
                 readonly $container: B;
                 readonly $type: 'X';
-                x: string
+                x: string;
             }
             export interface Y extends AstNode {
                 readonly $container: B;
                 readonly $type: 'Y';
-                y: string
+                y: string;
             }
             export interface Z extends AstNode {
                 readonly $container: B;
                 readonly $type: 'Z';
-                z: string
+                z: string;
             }
             export type A = B | X | Y | Z;
         `);
@@ -178,11 +178,11 @@ describe('Inferred types', () => {
         `, expandToString`
             export interface A extends AstNode {
                 readonly $type: 'A' | 'B';
-                a: string
+                a: string;
             }
             export interface B extends A {
                 readonly $type: 'B';
-                b: string
+                b: string;
             }
         `);
     });
@@ -213,28 +213,28 @@ describe('Inferred types', () => {
         `, expandToString`
             export interface Access extends AstNode {
                 readonly $type: 'Access';
-                member: string
-                receiver?: Ref
+                member: string;
+                receiver?: Ref;
             }
             export interface FirstBranch extends AstNode {
                 readonly $type: 'FirstBranch';
-                first: string
-                value: IdRule
+                first: string;
+                value: IdRule;
             }
             export interface IdRule extends AstNode {
                 readonly $container: FirstBranch | SecondBranch;
                 readonly $type: 'IdRule';
-                name: string
+                name: string;
             }
             export interface Ref extends AstNode {
                 readonly $container: Access;
                 readonly $type: 'Ref';
-                ref: string
+                ref: string;
             }
             export interface SecondBranch extends AstNode {
                 readonly $type: 'SecondBranch';
-                second: string
-                value: IdRule
+                second: string;
+                value: IdRule;
             }
             export type Entry = Expr;
             export type Expr = Access | Ref;
@@ -252,9 +252,9 @@ describe('Inferred types', () => {
         `, expandToString`
             export interface X extends AstNode {
                 readonly $type: 'X';
-                a: string
-                b?: string
-                c?: string
+                a: string;
+                b?: string;
+                c?: string;
             }
         `);
     });
@@ -271,22 +271,22 @@ describe('Inferred types', () => {
         `, expandToString`
             export interface A extends AstNode {
                 readonly $type: 'A';
-                a: string
+                a: string;
             }
             export interface B extends AstNode {
                 readonly $type: 'B';
-                b: string
+                b: string;
             }
             export interface C extends AstNode {
                 readonly $container: C;
                 readonly $type: 'C' | 'Y';
-                item: Y
-                value: string
+                item: Y;
+                value: string;
             }
             export interface Y extends C {
                 readonly $container: C;
                 readonly $type: 'Y';
-                y: string
+                y: string;
             }
             export type X = A | B;
         `);
@@ -330,7 +330,7 @@ describe('Inferred types', () => {
         `, expandToString`
             export interface X extends AstNode {
                 readonly $type: 'X' | 'Y' | 'Z';
-                id: string
+                id: string;
             }
             export interface Y extends X {
                 readonly $type: 'Y';
@@ -351,8 +351,8 @@ describe('inferred types that are used by the grammar', () => {
         `, expandToString`
             export interface B extends AstNode {
                 readonly $type: 'B';
-                name: string
-                otherA?: Reference<B>
+                name: string;
+                otherA?: Reference<B>;
             }
         `);
     });
@@ -372,11 +372,11 @@ describe('inferred and declared types', () => {
             }
             export interface Y extends X {
                 readonly $type: 'Y';
-                y: 'y'
+                y: 'y';
             }
             export interface Z extends X {
                 readonly $type: 'Z';
-                z: 'z'
+                z: 'z';
             }
         `);
     });
@@ -449,12 +449,12 @@ describe('expression rules with inferred and declared interfaces', () => {
             export interface BooleanLiteral extends AstNode {
                 readonly $container: MemberAccess;
                 readonly $type: 'BooleanLiteral';
-                value: boolean
+                value: boolean;
             }
             export interface MemberAccess extends AstNode {
                 readonly $type: 'MemberAccess' | 'SuperMemberAccess';
-                member: Reference<Symbol>
-                receiver: PrimaryExpression
+                member: Reference<Symbol>;
+                receiver: PrimaryExpression;
             }
             export interface Symbol extends AstNode {
                 readonly $type: 'Symbol';
@@ -482,23 +482,23 @@ describe('types of `$container` and `$type` are correct', () => {
         `, expandToString`
             export interface A extends AstNode {
                 readonly $type: 'A' | 'C';
-                strA: string
+                strA: string;
             }
             export interface B extends AstNode {
                 readonly $type: 'B' | 'C';
-                strB: string
+                strB: string;
             }
             export interface D extends AstNode {
                 readonly $type: 'D';
-                a: A
+                a: A;
             }
             export interface E extends AstNode {
                 readonly $type: 'E';
-                b: B
+                b: B;
             }
             export interface C extends A, B {
                 readonly $type: 'C';
-                strC: string
+                strC: string;
             }
         `);
     });
@@ -515,23 +515,23 @@ describe('types of `$container` and `$type` are correct', () => {
         `, expandToString`
             export interface A extends AstNode {
                 readonly $type: 'A' | 'C';
-                strA: string
+                strA: string;
             }
             export interface B extends AstNode {
                 readonly $type: 'B' | 'C';
-                strB: string
+                strB: string;
             }
             export interface D extends AstNode {
                 readonly $type: 'D';
-                a: A
+                a: A;
             }
             export interface E extends AstNode {
                 readonly $type: 'E';
-                b: B
+                b: B;
             }
             export interface C extends A, B {
                 readonly $type: 'C';
-                strC: string
+                strC: string;
             }
         `);
     });
@@ -548,15 +548,15 @@ describe('types of `$container` and `$type` are correct', () => {
             export interface C extends AstNode {
                 readonly $container: D | E;
                 readonly $type: 'C';
-                strC: string
+                strC: string;
             }
             export interface D extends AstNode {
                 readonly $type: 'D';
-                a: A
+                a: A;
             }
             export interface E extends AstNode {
                 readonly $type: 'E';
-                b: B
+                b: B;
             }
             export type A = C;
             export type B = C;
@@ -577,38 +577,38 @@ describe('types of `$container` and `$type` are correct', () => {
             export interface A extends AstNode {
                 readonly $container: E | F | G;
                 readonly $type: 'A' | 'C' | 'D';
-                strA: string
+                strA: string;
             }
             export interface B extends AstNode {
                 readonly $container: E | F | H;
                 readonly $type: 'B' | 'C' | 'D';
-                strB: string
+                strB: string;
             }
             export interface E extends AstNode {
                 readonly $type: 'E';
-                c: C
+                c: C;
             }
             export interface F extends AstNode {
                 readonly $type: 'F';
-                d: D
+                d: D;
             }
             export interface G extends AstNode {
                 readonly $type: 'G';
-                a: A
+                a: A;
             }
             export interface H extends AstNode {
                 readonly $type: 'H';
-                b: B
+                b: B;
             }
             export interface C extends A, B {
                 readonly $container: E;
                 readonly $type: 'C';
-                strC: string
+                strC: string;
             }
             export interface D extends A, B {
                 readonly $container: F;
                 readonly $type: 'D';
-                strC: string
+                strC: string;
             }
         `);
     });
@@ -629,41 +629,41 @@ describe('types of `$container` and `$type` are correct', () => {
         `, expandToString`
             export interface A extends AstNode {
                 readonly $type: 'A' | 'C' | 'D' | 'X';
-                strA: string
+                strA: string;
             }
             export interface B extends AstNode {
                 readonly $type: 'B' | 'C' | 'D' | 'X';
-                strB: string
+                strB: string;
             }
             export interface E extends AstNode {
                 readonly $type: 'E';
-                c: C
+                c: C;
             }
             export interface F extends AstNode {
                 readonly $type: 'F';
-                d: D
+                d: D;
             }
             export interface G extends AstNode {
                 readonly $type: 'G';
-                a: A
+                a: A;
             }
             export interface H extends AstNode {
                 readonly $type: 'H';
-                b: B
+                b: B;
             }
             export interface C extends A, B {
                 readonly $container: E;
                 readonly $type: 'C';
-                strC: string
+                strC: string;
             }
             export interface D extends A, B {
                 readonly $container: F;
                 readonly $type: 'D';
-                strC: string
+                strC: string;
             }
             export interface X extends A, B {
                 readonly $type: 'X';
-                strC: string
+                strC: string;
             }
         `);
     });
@@ -682,23 +682,23 @@ describe('types of `$container` and `$type` are correct', () => {
         `, expandToString`
             export interface A extends AstNode {
                 readonly $type: 'A' | 'C';
-                strA: string
+                strA: string;
             }
             export interface B extends AstNode {
                 readonly $type: 'B' | 'C';
-                strB: string
+                strB: string;
             }
             export interface D extends AstNode {
                 readonly $type: 'D';
-                a: A
+                a: A;
             }
             export interface E extends AstNode {
                 readonly $type: 'E';
-                b: B
+                b: B;
             }
             export interface C extends A, B {
                 readonly $type: 'C';
-                strC: string
+                strC: string;
             }
         `);
     });


### PR DESCRIPTION
Closes #1332 

Add a semicolon after interfaces properties for consistency in generated `ast.ts`.
Also updated relevant test files and generated ast files in examples and Langium grammar.