### PR TITLE
Implement async parsers

### DIFF
--- a/packages/langium/src/default-module.ts
+++ b/packages/langium/src/default-module.ts
@@ -34,6 +34,7 @@ import { DefaultCommentProvider } from './documentation/comment-provider.js';
 import { LangiumParserErrorMessageProvider } from './parser/langium-parser.js';
 import { DefaultAsyncParser } from './parser/async-parser.js';
 import { DefaultWorkspaceLock } from './workspace/workspace-lock.js';
+import { DefaultHydrator } from './serializer/hydrator.js';
 
 /**
  * Context required for creating the default language-specific dependency injection module.
@@ -75,6 +76,7 @@ export function createDefaultCoreModule(context: DefaultCoreModuleContext): Modu
             References: (services) => new DefaultReferences(services)
         },
         serializer: {
+            Hydrator: (services) => new DefaultHydrator(services),
             JsonSerializer: (services) => new DefaultJsonSerializer(services)
         },
         validation: {

--- a/packages/langium/src/grammar/langium-grammar-module.ts
+++ b/packages/langium/src/grammar/langium-grammar-module.ts
@@ -67,10 +67,12 @@ export const LangiumGrammarModule: Module<LangiumGrammarServices, PartialLangium
  *
  * @param context Shared module context, used to create additional shared modules
  * @param sharedModule Existing shared module to inject together with new shared services
+ * @param module Additional/modified service implementations for the language services
  * @returns Shared services enriched with LSP services + Grammar services, per usual
  */
 export function createLangiumGrammarServices(context: DefaultSharedModuleContext,
-    sharedModule?: Module<LangiumSharedServices, PartialLangiumSharedServices>): {
+    sharedModule?: Module<LangiumSharedServices, PartialLangiumSharedServices>,
+    module?: Module<LangiumServices, PartialLangiumServices>): {
         shared: LangiumSharedServices,
         grammar: LangiumGrammarServices
     } {
@@ -82,7 +84,8 @@ export function createLangiumGrammarServices(context: DefaultSharedModuleContext
     const grammar = inject(
         createDefaultModule({ shared }),
         LangiumGrammarGeneratedModule,
-        LangiumGrammarModule
+        LangiumGrammarModule,
+        module
     );
     addTypeCollectionPhase(shared, grammar);
     shared.ServiceRegistry.register(grammar);

--- a/packages/langium/src/node/index.ts
+++ b/packages/langium/src/node/index.ts
@@ -5,3 +5,4 @@
  ******************************************************************************/
 
 export * from './node-file-system-provider.js';
+export * from './worker-thread-async-parser.js';

--- a/packages/langium/src/node/worker-thread-async-parser.ts
+++ b/packages/langium/src/node/worker-thread-async-parser.ts
@@ -4,14 +4,23 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import { ParserWorker } from '../index.js';
+import type { LangiumCoreServices } from '../services.js';
+import { ParserWorker } from '../parser/async-parser.js';
 import { AbstractThreadedAsyncParser } from '../parser/async-parser.js';
 import { Worker } from 'node:worker_threads';
 
-export abstract class AbstractWorkerThreadAsyncParser extends AbstractThreadedAsyncParser {
+export class WorkerThreadAsyncParser extends AbstractThreadedAsyncParser {
+
+    protected workerPath: string | (() => string);
+
+    constructor(services: LangiumCoreServices, workerPath: string | (() => string)) {
+        super(services);
+        this.workerPath = workerPath;
+    }
 
     protected override createWorker(): ParserWorker {
-        const worker = new Worker(this.getWorkerPath());
+        const path = typeof this.workerPath === 'function' ? this.workerPath() : this.workerPath;
+        const worker = new Worker(path);
         const parserWorker = new WorkerThreadParserWorker(worker);
         return parserWorker;
     }

--- a/packages/langium/src/node/worker-thread-async-parser.ts
+++ b/packages/langium/src/node/worker-thread-async-parser.ts
@@ -1,0 +1,32 @@
+/******************************************************************************
+ * Copyright 2023 TypeFox GmbH
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License, which is available in the project root.
+ ******************************************************************************/
+
+import { ParserWorker } from '../index.js';
+import { AbstractThreadedAsyncParser } from '../parser/async-parser.js';
+import { Worker } from 'node:worker_threads';
+
+export abstract class AbstractWorkerThreadAsyncParser extends AbstractThreadedAsyncParser {
+
+    protected override createWorker(): ParserWorker {
+        const worker = new Worker(this.getWorkerPath());
+        const parserWorker = new WorkerThreadParserWorker(worker);
+        return parserWorker;
+    }
+
+}
+
+export class WorkerThreadParserWorker extends ParserWorker {
+
+    constructor(worker: Worker) {
+        super(
+            (message) => worker.postMessage(message),
+            cb => worker.on('message', cb),
+            cb => worker.on('error', cb),
+            () => worker.terminate()
+        );
+    }
+
+}

--- a/packages/langium/src/parser/async-parser.ts
+++ b/packages/langium/src/parser/async-parser.ts
@@ -177,9 +177,6 @@ export class ParserWorker {
     }
 
     parse(text: string): Promise<ParseResult> {
-        if (!this._ready) {
-            throw new Error('Parser is not ready yet');
-        }
         this.deferred = new Deferred();
         this.sendMessage(text);
         return this.deferred.promise;

--- a/packages/langium/src/parser/async-parser.ts
+++ b/packages/langium/src/parser/async-parser.ts
@@ -40,8 +40,15 @@ export class DefaultAsyncParser implements AsyncParser {
 
 export abstract class AbstractThreadedAsyncParser implements AsyncParser {
 
-    // Default thread count, can be changed as desired
-    protected threadCount = 4;
+    /**
+     * The thread count determines how many threads are used to parse files in parallel.
+     * The default value is 8. Decreasing this value increases startup performance, but decreases parsing performance.
+     */
+    protected threadCount = 8;
+    /**
+     * The termination delay determines how long the parser waits for a thread to finish after a cancellation request.
+     * The default value is 200(ms).
+     */
     protected terminationDelay = 200;
     protected workerPool: ParserWorker[] = [];
     protected queue: Array<Deferred<ParserWorker>> = [];

--- a/packages/langium/src/parser/async-parser.ts
+++ b/packages/langium/src/parser/async-parser.ts
@@ -138,7 +138,8 @@ export class ParserWorker {
     protected readonly onReadyEmitter = new Emitter<void>();
 
     protected deferred = new Deferred<ParseResult>();
-    protected _ready: boolean = true;
+    protected _ready = true;
+    protected _parsing = false;
 
     get ready(): boolean {
         return this._ready;
@@ -173,10 +174,15 @@ export class ParserWorker {
 
     unlock(): void {
         this._ready = true;
+        this._parsing = false;
         this.onReadyEmitter.fire();
     }
 
     parse(text: string): Promise<ParseResult> {
+        if (this._parsing) {
+            throw new Error('This parser worker is already busy');
+        }
+        this._parsing = true;
         this.deferred = new Deferred();
         this.sendMessage(text);
         return this.deferred.promise;

--- a/packages/langium/src/serializer/hydrator.ts
+++ b/packages/langium/src/serializer/hydrator.ts
@@ -11,7 +11,7 @@ import { CompositeCstNodeImpl, LeafCstNodeImpl, RootCstNodeImpl } from '../index
 import { isAbstractElement, type AbstractElement, type Grammar } from '../languages/generated/ast.js';
 import type { Linker } from '../references/linker.js';
 import type { Lexer } from '../parser/lexer.js';
-import type { LangiumServices } from '../services.js';
+import type { LangiumCoreServices } from '../services.js';
 import type { Reference, AstNode, CstNode, LeafCstNode, GenericAstNode, Mutable } from '../syntax-tree.js';
 import { isRootCstNode, isCompositeCstNode, isLeafCstNode, isAstNode, isReference } from '../syntax-tree.js';
 import { streamAst } from '../utils/ast-utils.js';
@@ -52,7 +52,7 @@ export class DefaultHydrator implements Hydrator {
     protected readonly grammarElementIdMap = new BiMap<AbstractElement, number>();
     protected readonly tokenTypeIdMap = new BiMap<number, TokenType>();
 
-    constructor(services: LangiumServices) {
+    constructor(services: LangiumCoreServices) {
         this.grammar = services.Grammar;
         this.lexer = services.parser.Lexer;
         this.linker = () => services.references.Linker;

--- a/packages/langium/src/serializer/hydrator.ts
+++ b/packages/langium/src/serializer/hydrator.ts
@@ -1,0 +1,303 @@
+/******************************************************************************
+ * Copyright 2024 TypeFox GmbH
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License, which is available in the project root.
+ ******************************************************************************/
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import type { TokenType } from 'chevrotain';
+import { CompositeCstNodeImpl, LeafCstNodeImpl, RootCstNodeImpl } from '../index.js';
+import { isAbstractElement, type AbstractElement, type Grammar } from '../languages/generated/ast.js';
+import type { Linker } from '../references/linker.js';
+import type { Lexer } from '../parser/lexer.js';
+import type { LangiumServices } from '../services.js';
+import type { Reference, AstNode, CstNode, LeafCstNode, GenericAstNode, Mutable } from '../syntax-tree.js';
+import { isRootCstNode, isCompositeCstNode, isLeafCstNode, isAstNode, isReference } from '../syntax-tree.js';
+import { streamAst } from '../utils/ast-utils.js';
+import { BiMap } from '../utils/collections.js';
+import { streamCst } from '../utils/cst-utils.js';
+
+/**
+ * The hydrator service is responsible for allowing AST nodes to be sent across worker threads.
+ */
+export interface Hydrator {
+    /**
+     * Converts an AST node to a plain object. The resulting object can be sent across worker threads.
+     */
+    dehydrate(node: AstNode): object;
+    /**
+     * Converts a plain object to an AST node. The resulting AST node can be used in the main thread.
+     * Calling this method on non-plain objects will result in undefined behavior.
+     */
+    hydrate(node: object): AstNode;
+}
+
+export interface DehydrateContext {
+    astNodes: Map<AstNode, any>;
+    cstNodes: Map<CstNode, any>;
+}
+
+export interface HydrateContext {
+    astNodes: Map<any, AstNode>;
+    cstNodes: Map<any, CstNode>;
+}
+
+export class DefaultHydrator implements Hydrator {
+
+    protected readonly grammar: Grammar;
+    protected readonly lexer: Lexer;
+    protected readonly linker: () => Linker;
+
+    protected readonly grammarElementIdMap = new BiMap<AbstractElement, number>();
+    protected readonly tokenTypeIdMap = new BiMap<number, TokenType>();
+
+    constructor(services: LangiumServices) {
+        this.grammar = services.Grammar;
+        this.lexer = services.parser.Lexer;
+        this.linker = () => services.references.Linker;
+    }
+
+    dehydrate(node: AstNode): object {
+        return this.dehydrateAstNode(node, this.createDehyrationContext(node));
+    }
+
+    protected dehydrateAstNode(node: AstNode, context: DehydrateContext): object {
+        const obj = context.astNodes.get(node) as Record<string, any>;
+        obj.$type = node.$type;
+        obj.$containerIndex = node.$containerIndex;
+        obj.$containerProperty = node.$containerProperty;
+        if (node.$cstNode !== undefined) {
+            obj.$cstNode = this.dehydrateCstNode(node.$cstNode, context);
+        }
+        for (const [name, value] of Object.entries(node)) {
+            if (name.startsWith('$')) {
+                continue;
+            }
+            if (Array.isArray(value)) {
+                const arr: any[] = [];
+                obj[name] = arr;
+                for (const item of value) {
+                    if (isAstNode(item)) {
+                        arr.push(this.dehydrateAstNode(item, context));
+                    } else if (isReference(item)) {
+                        arr.push(this.dehydrateReference(item, context));
+                    } else {
+                        arr.push(item);
+                    }
+                }
+            } else if (isAstNode(value)) {
+                obj[name] = this.dehydrateAstNode(value, context);
+            } else if (isReference(value)) {
+                obj[name] = this.dehydrateReference(value, context);
+            } else if (value !== undefined) {
+                obj[name] = value;
+            }
+        }
+        return obj;
+    }
+
+    protected dehydrateReference(reference: Reference, context: DehydrateContext): any {
+        const obj: Record<string, unknown> = {};
+        obj.$refText = reference.$refText;
+        if (reference.$refNode) {
+            obj.$refNode = context.cstNodes.get(reference.$refNode);
+        }
+        return obj;
+    }
+
+    protected createDehyrationContext(node: AstNode): DehydrateContext {
+        const astNodes = new Map<AstNode, any>();
+        const cstNodes = new Map<CstNode, any>();
+        for (const astNode of streamAst(node)) {
+            astNodes.set(astNode, {});
+        }
+        if (node.$cstNode) {
+            for (const cstNode of streamCst(node.$cstNode)) {
+                cstNodes.set(cstNode, {});
+            }
+        }
+        return {
+            astNodes,
+            cstNodes
+        };
+    }
+
+    protected dehydrateCstNode(node: CstNode, context: DehydrateContext): any {
+        const cstNode = context.cstNodes.get(node) as Record<string, any>;
+        if (isRootCstNode(node)) {
+            cstNode.fullText = node.fullText;
+        } else {
+            cstNode.grammarSource = this.getGrammarElementId(node.grammarSource);
+        }
+        cstNode.hidden = node.hidden;
+        cstNode.astNode = context.astNodes.get(node.astNode);
+        if (isCompositeCstNode(node)) {
+            cstNode.content = node.content.map(child => this.dehydrateCstNode(child, context));
+        } else if (isLeafCstNode(node)) {
+            cstNode.tokenType = node.tokenType.name;
+            cstNode.offset = node.offset;
+            cstNode.length = node.length;
+            cstNode.startLine = node.range.start.line;
+            cstNode.startColumn = node.range.start.character;
+            cstNode.endLine = node.range.end.line;
+            cstNode.endColumn = node.range.end.character;
+        }
+        return cstNode;
+    }
+
+    hydrate(node: object): AstNode {
+        const context = this.createHydrationContext(node);
+        if ('$cstNode' in node) {
+            this.hydrateCstNode(node.$cstNode, context);
+        }
+        return this.hydrateAstNode(node, context);
+    }
+
+    protected hydrateAstNode(node: any, context: HydrateContext): AstNode {
+        const astNode = context.astNodes.get(node) as Mutable<GenericAstNode>;
+        astNode.$type = node.$type;
+        astNode.$containerIndex = node.$containerIndex;
+        astNode.$containerProperty = node.$containerProperty;
+        if (node.$cstNode) {
+            astNode.$cstNode = context.cstNodes.get(node.$cstNode);
+        }
+        for (const [name, value] of Object.entries(node)) {
+            if (name.startsWith('$')) {
+                continue;
+            }
+            if (Array.isArray(value)) {
+                const arr: unknown[] = [];
+                astNode[name] = arr;
+                for (const item of value) {
+                    if (isAstNode(item)) {
+                        arr.push(this.setParent(this.hydrate(item), astNode));
+                    } else if (isReference(item)) {
+                        arr.push(this.hydrateReference(item, astNode, name, context));
+                    } else {
+                        arr.push(item);
+                    }
+                }
+            } else if (isAstNode(value)) {
+                astNode[name] = this.setParent(this.hydrate(value), astNode);
+            } else if (isReference(value)) {
+                astNode[name] = this.hydrateReference(value, astNode, name, context);
+            } else if (value !== undefined) {
+                astNode[name] = value;
+            }
+        }
+        return astNode;
+    }
+
+    protected createHydrationContext(node: any): HydrateContext {
+        const astNodes = new Map<any, AstNode>();
+        const cstNodes = new Map<any, CstNode>();
+        for (const astNode of streamAst(node)) {
+            astNodes.set(astNode, {} as AstNode);
+        }
+        if (node.$cstNode) {
+            for (const cstNode of streamCst(node.$cstNode)) {
+                let cst: CstNode | undefined;
+                if ('fullText' in cstNode) {
+                    cst = new RootCstNodeImpl(cstNode.fullText as string);
+                } else if ('content' in cstNode) {
+                    cst = new CompositeCstNodeImpl();
+                } else if ('tokenType' in cstNode) {
+                    cst = this.hydrateCstLeafNode(cstNode);
+                }
+                if (cst) {
+                    cstNodes.set(cstNode, cst);
+                }
+            }
+        }
+        return {
+            astNodes,
+            cstNodes
+        };
+    }
+
+    protected hydrateReference(reference: any, node: AstNode, name: string, context: HydrateContext): Reference {
+        return this.linker().buildReference(node, name, context.cstNodes.get(reference.$refNode)!, reference.$refText);
+    }
+
+    protected setParent(node: any, parent: any): any {
+        node.$container = parent as AstNode;
+        return node;
+    }
+
+    protected hydrateCstNode(cstNode: any, context: HydrateContext, num = 0): CstNode {
+        const cstNodeObj = context.cstNodes.get(cstNode) as Mutable<CstNode>;
+        if (typeof cstNode.grammarSource === 'number') {
+            cstNodeObj.grammarSource = this.getGrammarElement(cstNode.grammarSource);
+        }
+        cstNodeObj.astNode = context.astNodes.get(cstNode.astNode)!;
+        if (isCompositeCstNode(cstNodeObj)) {
+            for (const child of cstNode.content) {
+                const hydrated = this.hydrateCstNode(child, context, num++);
+                cstNodeObj.content.push(hydrated);
+            }
+        }
+        return cstNodeObj;
+    }
+
+    protected hydrateCstLeafNode(cstNode: any): LeafCstNode {
+        const tokenType = this.getTokenType(cstNode.tokenType);
+        const offset = cstNode.offset;
+        const length = cstNode.length;
+        const startLine = cstNode.startLine;
+        const startColumn = cstNode.startColumn;
+        const endLine = cstNode.endLine;
+        const endColumn = cstNode.endColumn;
+        const hidden = cstNode.hidden;
+        const node = new LeafCstNodeImpl(
+            offset,
+            length,
+            {
+                start: {
+                    line: startLine,
+                    character: startColumn
+                },
+                end: {
+                    line: endLine,
+                    character: endColumn
+                }
+            },
+            tokenType,
+            hidden
+        );
+        return node;
+    }
+
+    protected getTokenType(name: string): TokenType {
+        return this.lexer.definition[name];
+    }
+
+    protected getGrammarElementId(node: AbstractElement): number {
+        if (this.grammarElementIdMap.size === 0) {
+            this.createGrammarElementIdMap();
+        }
+        return this.grammarElementIdMap.get(node) ?? -1;
+    }
+
+    protected getGrammarElement(id: number): AbstractElement {
+        if (this.grammarElementIdMap.size === 0) {
+            this.createGrammarElementIdMap();
+        }
+        const element = this.grammarElementIdMap.getKey(id);
+        if (element) {
+            return element;
+        } else {
+            throw new Error('Invalid grammar element id: ' + id);
+        }
+    }
+
+    protected createGrammarElementIdMap(): void {
+        let id = 0;
+        for (const element of streamAst(this.grammar)) {
+            if (isAbstractElement(element)) {
+                this.grammarElementIdMap.set(element, id++);
+            }
+        }
+    }
+
+}

--- a/packages/langium/src/serializer/index.ts
+++ b/packages/langium/src/serializer/index.ts
@@ -4,4 +4,5 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
+export * from './hydrator.js';
 export * from './json-serializer.js';

--- a/packages/langium/src/services.ts
+++ b/packages/langium/src/services.ts
@@ -37,6 +37,7 @@ import type { LangiumDocumentFactory, LangiumDocuments, TextDocumentProvider } f
 import type { FileSystemProvider } from './workspace/file-system-provider.js';
 import type { IndexManager } from './workspace/index-manager.js';
 import type { WorkspaceLock } from './workspace/workspace-lock.js';
+import type { Hydrator } from './serializer/hydrator.js';
 import type { WorkspaceManager } from './workspace/workspace-manager.js';
 
 export type {
@@ -86,6 +87,7 @@ export type LangiumDefaultCoreServices = {
         ScopeComputation: ScopeComputation
     }
     serializer: {
+        Hydrator: Hydrator
         JsonSerializer: JsonSerializer
     }
     validation: {

--- a/packages/langium/src/utils/collections.ts
+++ b/packages/langium/src/utils/collections.ts
@@ -164,3 +164,52 @@ export class MultiMap<K, V> {
     }
 
 }
+
+export class BiMap<K, V> {
+
+    private map = new Map<K, V>();
+    private inverse = new Map<V, K>();
+
+    get size(): number {
+        return this.map.size;
+    }
+
+    constructor()
+    constructor(elements: Array<[K, V]>)
+    constructor(elements?: Array<[K, V]>) {
+        if (elements) {
+            for (const [key, value] of elements) {
+                this.set(key, value);
+            }
+        }
+    }
+
+    clear(): void {
+        this.map.clear();
+        this.inverse.clear();
+    }
+
+    set(key: K, value: V): this {
+        this.map.set(key, value);
+        this.inverse.set(value, key);
+        return this;
+    }
+
+    get(key: K): V | undefined {
+        return this.map.get(key);
+    }
+
+    getKey(value: V): K | undefined {
+        return this.inverse.get(value);
+    }
+
+    delete(key: K): boolean {
+        const value = this.map.get(key);
+        if (value !== undefined) {
+            this.map.delete(key);
+            this.inverse.delete(value);
+            return true;
+        }
+        return false;
+    }
+}

--- a/packages/langium/src/utils/event.ts
+++ b/packages/langium/src/utils/event.ts
@@ -5,4 +5,4 @@
  ******************************************************************************/
 
 // eslint-disable-next-line no-restricted-imports
-export * from 'vscode-jsonrpc/lib/common/cancellation.js';
+export * from 'vscode-jsonrpc/lib/common/events.js';

--- a/packages/langium/src/utils/index.ts
+++ b/packages/langium/src/utils/index.ts
@@ -5,6 +5,7 @@
  ******************************************************************************/
 
 export * from './caching.js';
+export * from './event.js';
 export * from './collections.js';
 export * from './disposable.js';
 export * from './errors.js';

--- a/packages/langium/src/utils/promise-utils.ts
+++ b/packages/langium/src/utils/promise-utils.ts
@@ -5,6 +5,7 @@
  ******************************************************************************/
 
 import { CancellationToken, CancellationTokenSource, type AbstractCancellationTokenSource } from '../utils/cancellation.js';
+import type { Disposable } from './disposable.js';
 
 export type MaybePromise<T> = T | Promise<T>
 
@@ -88,18 +89,28 @@ export async function interruptAndCheck(token: CancellationToken): Promise<void>
  * Simple implementation of the deferred pattern.
  * An object that exposes a promise and functions to resolve and reject it.
  */
-export class Deferred<T = void> {
+export class Deferred<T = void> implements Disposable {
     resolve: (value: T) => this;
     reject: (err?: unknown) => this;
 
+    disposables: Disposable[] = [];
+
     promise = new Promise<T>((resolve, reject) => {
         this.resolve = (arg) => {
+            this.dispose();
             resolve(arg);
             return this;
         };
         this.reject = (err) => {
+            this.dispose();
             reject(err);
             return this;
         };
     });
+
+    dispose(): void {
+        for (const disposable of this.disposables) {
+            disposable.dispose();
+        }
+    }
 }

--- a/packages/langium/src/utils/promise-utils.ts
+++ b/packages/langium/src/utils/promise-utils.ts
@@ -88,28 +88,18 @@ export async function interruptAndCheck(token: CancellationToken): Promise<void>
  * Simple implementation of the deferred pattern.
  * An object that exposes a promise and functions to resolve and reject it.
  */
-export class Deferred<T = void> implements Disposable {
+export class Deferred<T = void> {
     resolve: (value: T) => this;
     reject: (err?: unknown) => this;
 
-    disposables: Disposable[] = [];
-
     promise = new Promise<T>((resolve, reject) => {
         this.resolve = (arg) => {
-            this.dispose();
             resolve(arg);
             return this;
         };
         this.reject = (err) => {
-            this.dispose();
             reject(err);
             return this;
         };
     });
-
-    dispose(): void {
-        for (const disposable of this.disposables) {
-            disposable.dispose();
-        }
-    }
 }

--- a/packages/langium/src/utils/promise-utils.ts
+++ b/packages/langium/src/utils/promise-utils.ts
@@ -92,24 +92,13 @@ export class Deferred<T = void> {
     resolve: (value: T) => this;
     reject: (err?: unknown) => this;
 
-    private callbacks: Array<() => void> = [];
-
-    finally(callback: () => void): this {
-        this.callbacks.push(callback);
-        return this;
-    }
-
     promise = new Promise<T>((resolve, reject) => {
         this.resolve = (arg) => {
             resolve(arg);
-            this.callbacks.forEach(cb => cb());
-            this.callbacks = [];
             return this;
         };
         this.reject = (err) => {
             reject(err);
-            this.callbacks.forEach(cb => cb());
-            this.callbacks = [];
             return this;
         };
     });

--- a/packages/langium/src/utils/promise-utils.ts
+++ b/packages/langium/src/utils/promise-utils.ts
@@ -88,12 +88,28 @@ export async function interruptAndCheck(token: CancellationToken): Promise<void>
  * Simple implementation of the deferred pattern.
  * An object that exposes a promise and functions to resolve and reject it.
  */
-export class Deferred<T = void> {
+export class Deferred<T = void> implements Disposable {
     resolve: (value: T) => this;
     reject: (err?: unknown) => this;
 
+    disposables: Disposable[] = [];
+
     promise = new Promise<T>((resolve, reject) => {
-        this.resolve = (arg) => (resolve(arg), this);
-        this.reject = (err) => (reject(err), this);
+        this.resolve = (arg) => {
+            this.dispose();
+            resolve(arg);
+            return this;
+        };
+        this.reject = (err) => {
+            this.dispose();
+            reject(err);
+            return this;
+        };
     });
+
+    dispose(): void {
+        for (const disposable of this.disposables) {
+            disposable.dispose();
+        }
+    }
 }

--- a/packages/langium/test/parser/worker-thread-async-parser.test.ts
+++ b/packages/langium/test/parser/worker-thread-async-parser.test.ts
@@ -58,7 +58,8 @@ describe('WorkerThreadAsyncParser', () => {
             expect(isOperationCancelled(err)).toBe(true);
         }
         const end = Date.now();
-        expect(end - start).toBeLessThan(500);
+        // The whole parsing process should have been successfully cancelled within a second
+        expect(end - start).toBeLessThan(1000);
     });
 
     function createLargeFile(size: number): string {

--- a/packages/langium/test/parser/worker-thread-async-parser.test.ts
+++ b/packages/langium/test/parser/worker-thread-async-parser.test.ts
@@ -1,0 +1,71 @@
+/******************************************************************************
+ * Copyright 2023 TypeFox GmbH
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License, which is available in the project root.
+ ******************************************************************************/
+
+import { describe, expect, test } from 'vitest';
+import { AbstractWorkerThreadAsyncParser } from 'langium/node';
+import { createLangiumGrammarServices } from 'langium/grammar';
+import type { Grammar, ParseResult } from 'langium';
+import { EmptyFileSystem, GrammarUtils, isOperationCancelled } from 'langium';
+import { CancellationToken, CancellationTokenSource } from 'vscode-languageserver';
+import { fail } from 'node:assert';
+
+class TestAsyncParser extends AbstractWorkerThreadAsyncParser {
+    protected getWorkerPath(): string {
+        return __dirname + '/worker-thread.js';
+    }
+}
+
+describe('WorkerThreadAsyncParser', () => {
+
+    test('performs async parsing in parallel', async () => {
+        const services = createLangiumGrammarServices(EmptyFileSystem, undefined, {
+            parser: {
+                AsyncParser: (services) => new TestAsyncParser(services)
+            }
+        }).grammar;
+        const file = createLargeFile(10);
+        const asyncParser = services.parser.AsyncParser;
+        const promises: Array<Promise<ParseResult<Grammar>>> = [];
+        for (let i = 0; i < 16; i++) {
+            promises.push(asyncParser.parse<Grammar>(file, CancellationToken.None));
+        }
+        const result = await Promise.all(promises);
+        for (const parseResult of result) {
+            expect(parseResult.value.name).toBe('Test');
+            expect(GrammarUtils.findNodeForProperty(parseResult.value.$cstNode, 'name')!.offset).toBe(8);
+        }
+    });
+
+    test('async parsing can be cancelled', async () => {
+        const services = createLangiumGrammarServices(EmptyFileSystem, undefined, {
+            parser: {
+                AsyncParser: (services) => new TestAsyncParser(services)
+            }
+        }).grammar;
+        // This file should take a few seconds to parse
+        const file = createLargeFile(100000);
+        const asyncParser = services.parser.AsyncParser;
+        const cancellationTokenSource = new CancellationTokenSource();
+        setTimeout(() => cancellationTokenSource.cancel(), 50);
+        const start = Date.now();
+        try {
+            await asyncParser.parse<Grammar>(file, cancellationTokenSource.token);
+            fail('Parsing should have been cancelled');
+        } catch (err) {
+            expect(isOperationCancelled(err)).toBe(true);
+        }
+        const end = Date.now();
+        expect(end - start).toBeLessThan(500);
+    });
+
+    function createLargeFile(size: number): string {
+        let result = 'grammar Test;\n';
+        for (let i = 0; i < size; i++) {
+            result += 'TestRule' + i + ': name="Hello";\n';
+        }
+        return result;
+    }
+});

--- a/packages/langium/test/parser/worker-thread-async-parser.test.ts
+++ b/packages/langium/test/parser/worker-thread-async-parser.test.ts
@@ -1,20 +1,21 @@
 /******************************************************************************
- * Copyright 2023 TypeFox GmbH
+ * Copyright 2024 TypeFox GmbH
  * This program and the accompanying materials are made available under the
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
 import { describe, expect, test } from 'vitest';
-import { AbstractWorkerThreadAsyncParser } from 'langium/node';
+import { WorkerThreadAsyncParser } from 'langium/node';
 import { createLangiumGrammarServices } from 'langium/grammar';
-import type { Grammar, ParseResult } from 'langium';
+import type { Grammar, LangiumCoreServices, ParseResult } from 'langium';
 import { EmptyFileSystem, GrammarUtils, isOperationCancelled } from 'langium';
 import { CancellationToken, CancellationTokenSource } from 'vscode-languageserver';
 import { fail } from 'node:assert';
+import { fileURLToPath } from 'node:url';
 
-class TestAsyncParser extends AbstractWorkerThreadAsyncParser {
-    protected getWorkerPath(): string {
-        return __dirname + '/worker-thread.js';
+class TestAsyncParser extends WorkerThreadAsyncParser {
+    constructor(services: LangiumCoreServices) {
+        super(services, () => fileURLToPath(new URL('.', import.meta.url)) + '/worker-thread.js');
     }
 }
 

--- a/packages/langium/test/parser/worker-thread.js
+++ b/packages/langium/test/parser/worker-thread.js
@@ -1,0 +1,22 @@
+/******************************************************************************
+ * Copyright 2023 TypeFox GmbH
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License, which is available in the project root.
+ ******************************************************************************/
+
+import { EmptyFileSystem } from 'langium';
+import { createLangiumGrammarServices } from 'langium/grammar';
+import { parentPort } from 'node:worker_threads';
+
+const services = createLangiumGrammarServices(EmptyFileSystem).grammar;
+const parser = services.parser.LangiumParser;
+const hydrator = services.serializer.Hydrator;
+
+parentPort.on('message', text => {
+    const result = parser.parse(text);
+    const dehydrated = hydrator.dehydrate(result.value);
+    parentPort.postMessage({
+        ...result,
+        value: dehydrated
+    });
+});


### PR DESCRIPTION
A follow up on https://github.com/eclipse-langium/langium/pull/1306.

Implements the basics to create an async parser based on node worker threads. While in theory this should be faster than the sync parser implementation (due to parallelisation), it might be slower on startup due to the time it takes for all the workers to start up. Once the threads are all up and running, it is indeed faster. The break even point is fairly late though, roughly after parsing ~2 million LoC.

The main benefit of this change is that it allows parser cancellation by simply killing workers. The cancellation happens after a timeout, since it needs to take the time it takes to create a new worker into account. The default is 200ms, but can be arbitrarily changed by adopters.

Most of the change is actually just the new `Hydrator` service which tries to dehydrate/hydrate AST nodes to be processed by the structured cloning algorithm of workers.