### PR TITLE
Support terminal lookbehind

### DIFF
--- a/packages/langium/src/grammar/generated/grammar.ts
+++ b/packages/langium/src/grammar/generated/grammar.ts
@@ -3430,6 +3430,14 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 {
                   "$type": "Keyword",
                   "value": "?!"
+                },
+                {
+                  "$type": "Keyword",
+                  "value": "?<="
+                },
+                {
+                  "$type": "Keyword",
+                  "value": "?<!"
                 }
               ]
             },

--- a/packages/langium/src/grammar/langium-grammar.langium
+++ b/packages/langium/src/grammar/langium-grammar.langium
@@ -198,7 +198,7 @@ TerminalTokenElement infers AbstractElement:
     CharacterRange | TerminalRuleCall | ParenthesizedTerminalElement | NegatedToken | UntilToken | RegexToken | Wildcard;
 
 ParenthesizedTerminalElement infers AbstractElement:
-    '(' (lookahead=('?='|'?!'))? TerminalAlternatives ')';
+    '(' (lookahead=('?='|'?!'|'?<='|'?<!'))? TerminalAlternatives ')';
 
 TerminalRuleCall infers AbstractElement:
     {infer TerminalRuleCall} rule=[TerminalRule:ID];

--- a/packages/langium/src/languages/generated/ast.ts
+++ b/packages/langium/src/languages/generated/ast.ts
@@ -72,7 +72,7 @@ export function isValueLiteral(item: unknown): item is ValueLiteral {
 export interface AbstractElement extends AstNode {
     readonly $type: 'AbstractElement' | 'Action' | 'Alternatives' | 'Assignment' | 'CharacterRange' | 'CrossReference' | 'EndOfFile' | 'Group' | 'Keyword' | 'NegatedToken' | 'RegexToken' | 'RuleCall' | 'TerminalAlternatives' | 'TerminalGroup' | 'TerminalRuleCall' | 'UnorderedGroup' | 'UntilToken' | 'Wildcard';
     cardinality?: '*' | '+' | '?';
-    lookahead?: '?!' | '?=';
+    lookahead?: '?!' | '?<!' | '?<=' | '?=';
 }
 
 export const AbstractElement = 'AbstractElement';

--- a/packages/langium/test/grammar/grammar-util.test.ts
+++ b/packages/langium/test/grammar/grammar-util.test.ts
@@ -170,6 +170,18 @@ describe('TerminalRule to regex', () => {
         expect(regex).toEqual(/(a(?!b))/);
     });
 
+    test('Should create negative lookbehind group', async () => {
+        const terminal = await getTerminal("terminal X: 'a' (?<!'b');");
+        const regex = terminalRegex(terminal);
+        expect(regex).toEqual(/(a(?<!b))/);
+    });
+
+    test('Should create positive lookbehind group', async () => {
+        const terminal = await getTerminal("terminal X: 'a' (?<='b');");
+        const regex = terminalRegex(terminal);
+        expect(regex).toEqual(/(a(?<=b))/);
+    });
+
     test('Should create terminal reference in terminal definition', async () => {
         const terminal = await getTerminal(`
         terminal X: Y Y;


### PR DESCRIPTION
Closes https://github.com/eclipse-langium/langium/issues/1355

Allows adopters to write positive/negative lookbehind in both EBNF and Regex notation, with full support in the lexer/parser phase.