### PR TITLE
Fix unassigned data type rule usage

### DIFF
--- a/packages/langium/src/parser/langium-parser.ts
+++ b/packages/langium/src/parser/langium-parser.ts
@@ -239,7 +239,7 @@ export class LangiumParser extends AbstractLangiumParser {
             const current = this.current;
             if (isDataTypeNode(current)) {
                 current.value += result.toString();
-            } else {
+            } else if (typeof result === 'object' && result) { // Check whether it's an AST node
                 const resultKind = result.$type;
                 const object = this.assignWithoutOverride(result, current);
                 if (resultKind) {

--- a/packages/langium/src/parser/langium-parser.ts
+++ b/packages/langium/src/parser/langium-parser.ts
@@ -19,7 +19,7 @@ import { isAssignment, isCrossReference, isKeyword } from '../languages/generate
 import { getTypeName, isDataTypeRule } from '../utils/grammar-utils.js';
 import { assignMandatoryProperties, getContainerOfType, linkContentToContainer } from '../utils/ast-utils.js';
 import { CstNodeBuilder } from './cst-node-builder.js';
-import { isAstNode } from '../../lib/syntax-tree.js';
+import { isAstNode } from '../syntax-tree.js';
 
 export type ParseResult<T = AstNode> = {
     value: T,

--- a/packages/langium/src/parser/langium-parser.ts
+++ b/packages/langium/src/parser/langium-parser.ts
@@ -19,7 +19,6 @@ import { isAssignment, isCrossReference, isKeyword } from '../languages/generate
 import { getTypeName, isDataTypeRule } from '../utils/grammar-utils.js';
 import { assignMandatoryProperties, getContainerOfType, linkContentToContainer } from '../utils/ast-utils.js';
 import { CstNodeBuilder } from './cst-node-builder.js';
-import { isAstNode } from '../syntax-tree.js';
 
 export type ParseResult<T = AstNode> = {
     value: T,
@@ -242,7 +241,7 @@ export class LangiumParser extends AbstractLangiumParser {
             const current = this.current;
             if (isDataTypeNode(current)) {
                 current.value += result.toString();
-            } else if (isAstNode(result)) {
+            } else if (typeof result === 'object' && result) {
                 const resultKind = result.$type;
                 const object = this.assignWithoutOverride(result, current);
                 if (resultKind) {

--- a/packages/langium/test/parser/langium-parser-builder.test.ts
+++ b/packages/langium/test/parser/langium-parser-builder.test.ts
@@ -841,7 +841,7 @@ describe('Unassigned data type rules', () => {
 
             hidden terminal WS: /[ \\t]+/;
             terminal ID: /[_a-zA-Z][\\w_]*/;
-            terminal NEWLINE: '\\n';
+            terminal NEWLINE: /\\r?\\n/;
             EOL returns string:
                 NEWLINE | EOF;`
         );


### PR DESCRIPTION
Closes https://github.com/eclipse-langium/langium/issues/1358

Adds a check that the value we're trying assign is actually an object and not the result of a data type rule (a primitive).