### PR TITLE
re-fix configuration provider initialization

### DIFF
--- a/packages/langium/src/lsp/language-server.ts
+++ b/packages/langium/src/lsp/language-server.ts
@@ -199,13 +199,16 @@ export class DefaultLanguageServer implements LanguageServer {
         const configurationParams = connection ? <ConfigurationInitializedParams>{
             ...params,
             register: params => connection.client.register(DidChangeConfigurationNotification.type, params),
-            getConfiguration: params => connection.workspace.getConfiguration(params)
+            fetchConfiguration: params => connection.workspace.getConfiguration(params)
         } : params;
 
-        this.services.workspace.WorkspaceManager.initialized(params)
-            .catch(err => console.error('Error in WorkspaceManager initialization:', err));
+        // do not await the promises of the following calls, as they must not block the initialization process!
+        //  otherwise, there is the danger of out-of-order processing of subsequent incoming messages from the language client
+        // however, awaiting should be possible in general, e.g. in unit test scenarios
         this.services.workspace.ConfigurationProvider.initialized(configurationParams)
             .catch(err => console.error('Error in ConfigurationProvider initialization:', err));
+        this.services.workspace.WorkspaceManager.initialized(params)
+            .catch(err => console.error('Error in WorkspaceManager initialization:', err));
     }
 }
 


### PR DESCRIPTION
This change restores the original configuration provider initialization approach contributed in #519.

To be tested:
* Proper application of the `langium.build.ignorePatterns` during workspace init of the grammar language server (see https://github.com/eclipse-langium/langium/blob/1bc7009287d46ef82b5432f8eabd5f924cbd658c/packages/langium-vscode/src/language-server/grammar-workspace-manager.ts#L33-L38), expected default values are defined here: https://github.com/eclipse-langium/langium/blob/main/packages/langium-vscode/package.json#L69-L78.
--> Looks good AFAICS.