### PR TITLE
Improve workspace manager startup behavior

### DIFF
--- a/packages/langium/src/lsp/document-update-handler.ts
+++ b/packages/langium/src/lsp/document-update-handler.ts
@@ -72,11 +72,15 @@ export class DefaultDocumentUpdateHandler implements DocumentUpdateHandler {
         }
     }
 
-    protected async fireDocumentUpdate(changed: URI[], deleted: URI[]): Promise<void> {
+    protected fireDocumentUpdate(changed: URI[], deleted: URI[]): void {
         // Only fire the document update when the workspace manager is ready
         // Otherwise, we might miss the initial indexing of the workspace
-        await this.workspaceManager.ready;
-        this.workspaceLock.write(token => this.documentBuilder.update(changed, deleted, token));
+        this.workspaceManager.ready.then(() => {
+            this.workspaceLock.write(token => this.documentBuilder.update(changed, deleted, token));
+        }).catch(err => {
+            // This should never happen, but if it does, we want to know about it
+            console.error('Workspace initialization failed. Could not perform document update.', err);
+        });
     }
 
     didChangeContent(change: TextDocumentChangeEvent<TextDocument>): void {

--- a/packages/langium/src/parser/async-parser.ts
+++ b/packages/langium/src/parser/async-parser.ts
@@ -125,7 +125,7 @@ export abstract class AbstractThreadedAsyncParser implements AsyncParser {
             if (index >= 0) {
                 this.queue.splice(index, 1);
             }
-            deferred.reject('OperationCancelled');
+            deferred.reject(OperationCancelled);
         });
         this.queue.push(deferred);
         return deferred.promise;

--- a/packages/langium/src/workspace/configuration.ts
+++ b/packages/langium/src/workspace/configuration.ts
@@ -94,6 +94,8 @@ export class DefaultConfigurationProvider implements ConfigurationProvider {
 
     protected async initializeConfiguration(params: ConfigurationInitializedParams): Promise<void> {
         if (params.fetchConfiguration) {
+            // params.fetchConfiguration(...) is a function to be provided by the calling language server for the sake of
+            //  decoupling this implementation from the concrete LSP implementations, specifically the LSP Connection
             const configToUpdate = this.serviceRegistry.all.map(lang => <ConfigurationItem>{
                 // Fetch the configuration changes for all languages
                 section: this.toSectionName(lang.LanguageMetaData.languageId)

--- a/packages/langium/src/workspace/document-builder.ts
+++ b/packages/langium/src/workspace/document-builder.ts
@@ -254,9 +254,9 @@ export class DefaultDocumentBuilder implements DocumentBuilder {
     protected async buildDocuments(documents: LangiumDocument[], options: BuildOptions, cancelToken: CancellationToken): Promise<void> {
         this.prepareBuild(documents, options);
         // 0. Parse content
-        await this.runCancelable(documents, DocumentState.Parsed, cancelToken, async doc => {
-            await this.langiumDocumentFactory.update(doc, cancelToken);
-        });
+        await this.runCancelable(documents, DocumentState.Parsed, cancelToken, doc =>
+            this.langiumDocumentFactory.update(doc, cancelToken)
+        );
         // 1. Index content
         await this.runCancelable(documents, DocumentState.IndexedContent, cancelToken, doc =>
             this.indexManager.updateContent(doc, cancelToken)
@@ -308,7 +308,7 @@ export class DefaultDocumentBuilder implements DocumentBuilder {
     }
 
     protected async runCancelable(documents: LangiumDocument[], targetState: DocumentState, cancelToken: CancellationToken,
-        callback: (document: LangiumDocument) => MaybePromise<void>): Promise<void> {
+        callback: (document: LangiumDocument) => MaybePromise<unknown>): Promise<void> {
         const filtered = documents.filter(e => e.state < targetState);
         for (const document of filtered) {
             await interruptAndCheck(cancelToken);

--- a/packages/langium/src/workspace/document-builder.ts
+++ b/packages/langium/src/workspace/document-builder.ts
@@ -254,8 +254,8 @@ export class DefaultDocumentBuilder implements DocumentBuilder {
     protected async buildDocuments(documents: LangiumDocument[], options: BuildOptions, cancelToken: CancellationToken): Promise<void> {
         this.prepareBuild(documents, options);
         // 0. Parse content
-        await this.runCancelable(documents, DocumentState.Parsed, cancelToken, doc => {
-            this.langiumDocumentFactory.update(doc, cancelToken);
+        await this.runCancelable(documents, DocumentState.Parsed, cancelToken, async doc => {
+            await this.langiumDocumentFactory.update(doc, cancelToken);
         });
         // 1. Index content
         await this.runCancelable(documents, DocumentState.IndexedContent, cancelToken, doc =>

--- a/packages/langium/test/workspace/configuration.test.ts
+++ b/packages/langium/test/workspace/configuration.test.ts
@@ -14,6 +14,7 @@ describe('ConfigurationProvider', () => {
     const grammarServices = createLangiumGrammarServices(EmptyFileSystem).grammar;
     const langId = grammarServices.LanguageMetaData.languageId;
     const configs = grammarServices.shared.workspace.ConfigurationProvider;
+    configs.initialized({});
     beforeEach(() => {
         (configs as any).settings = {};
     });


### PR DESCRIPTION
Updates our `ConfigurationProvider` and `WorkspaceManager` to expose `ready` promises. Downstream services can use these promises to ensure that the services are ready to be used.