### PR TITLE
Support users to replace parser rules which are used only as type for cross-references by type declarations

### DIFF
--- a/packages/langium/src/grammar/generated/grammar.ts
+++ b/packages/langium/src/grammar/generated/grammar.ts
@@ -3923,12 +3923,6 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "typeRef": {
               "$ref": "#/rules@18"
             }
-          },
-          {
-            "$type": "SimpleType",
-            "typeRef": {
-              "$ref": "#/rules@14"
-            }
           }
         ]
       }

--- a/packages/langium/src/grammar/generated/grammar.ts
+++ b/packages/langium/src/grammar/generated/grammar.ts
@@ -3923,6 +3923,12 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "typeRef": {
               "$ref": "#/rules@18"
             }
+          },
+          {
+            "$type": "SimpleType",
+            "typeRef": {
+              "$ref": "#/rules@14"
+            }
           }
         ]
       }

--- a/packages/langium/src/grammar/lsp/grammar-code-actions.ts
+++ b/packages/langium/src/grammar/lsp/grammar-code-actions.ts
@@ -184,8 +184,10 @@ export class LangiumGrammarCodeActionProvider implements CodeActionProvider {
     }
 
     private isRuleReplaceable(rule: ast.ParserRule): boolean {
-        // OK are: definition use only Alternatives! infers!
-        // "returns" is not relevant, since cross-references would not refer to the parser rule, but to its "return type" instead
+        /** at the moment, only "pure" parser rules are supported:
+         * - supported are only Alternatives (recursively) and "infers"
+         * - "returns" is not relevant, since cross-references would not refer to the parser rule, but to its "return type" instead
+         */
         return !rule.fragment && !rule.entry && rule.parameters.length === 0 && !rule.definesHiddenTokens && !rule.wildcard && !rule.returnType && !rule.dataType;
     }
     private replaceRule(rule: ast.ParserRule): string {
@@ -199,9 +201,6 @@ export class LangiumGrammarCodeActionProvider implements CodeActionProvider {
         if (ast.isAlternatives(node)) {
             return node.elements.every(child => this.isDefinitionReplaceable(child));
         }
-        if (ast.isUnorderedGroup(node)) {
-            return node.elements.every(child => this.isDefinitionReplaceable(child));
-        }
         return false;
     }
     private replaceDefinition(node: ast.AbstractElement, requiresBraces: boolean): string {
@@ -210,10 +209,6 @@ export class LangiumGrammarCodeActionProvider implements CodeActionProvider {
         }
         if (ast.isAlternatives(node)) {
             const result = node.elements.map(child => this.replaceDefinition(child, true)).join(' | ');
-            return requiresBraces && node.elements.length >= 2 ? `(${result})` : result;
-        }
-        if (ast.isUnorderedGroup(node)) {
-            const result = node.elements.map(child => this.replaceDefinition(child, true)).join(' & '); // TODO
             return requiresBraces && node.elements.length >= 2 ? `(${result})` : result;
         }
         throw new Error('missing code for ' + node);

--- a/packages/langium/src/grammar/lsp/grammar-code-actions.ts
+++ b/packages/langium/src/grammar/lsp/grammar-code-actions.ts
@@ -215,8 +215,8 @@ export class LangiumGrammarCodeActionProvider implements CodeActionProvider {
             const cstNode = findLeafNodeAtOffset(rootCst, offset);
             const rule = getContainerOfType(cstNode?.astNode, ast.isParserRule);
             if (rule && rule.$cstNode) {
-                const isFixable = this.isReplaceableRule(rule) && this.isReplaceable(rule.definition);
-                if (isFixable) {
+                const isRuleReplaceable = this.isReplaceableRule(rule) && this.isReplaceable(rule.definition);
+                if (isRuleReplaceable) {
                     const newText = `type ${this.replaceRule(rule)} = ${this.replace(rule.definition)};`;
                     return {
                         title: 'Replace parser rule by type declaration',

--- a/packages/langium/src/grammar/validation/validator.ts
+++ b/packages/langium/src/grammar/validation/validator.ts
@@ -16,14 +16,13 @@ import { DiagnosticTag } from 'vscode-languageserver-types';
 import { getContainerOfType, streamAllContents } from '../../utils/ast-utils.js';
 import { MultiMap } from '../../utils/collections.js';
 import { toDocumentSegment } from '../../utils/cst-utils.js';
-import { findNameAssignment, findNodeForKeyword, findNodeForProperty, getAllReachableRules, getAllRulesUsedForCrossReferences } from '../../utils/grammar-util.js';
 import { stream } from '../../utils/stream.js';
 import { diagnosticData } from '../../validation/validation-registry.js';
 import * as ast from '../../languages/generated/ast.js';
 import { getTypeNameWithoutError, hasDataTypeReturn, isPrimitiveGrammarType, isStringGrammarType, resolveImport, resolveTransitiveImports } from '../internal-grammar-util.js';
 import { typeDefinitionToPropertyType } from '../type-system/type-collector/declared-types.js';
 import { flattenPlainType, isPlainReferenceType } from '../type-system/type-collector/plain-types.js';
-import { isDataTypeRule, terminalRegex, isOptionalCardinality } from '../../utils/grammar-utils.js';
+import { isDataTypeRule, terminalRegex, isOptionalCardinality, findNameAssignment, findNodeForKeyword, findNodeForProperty, getAllReachableRules, getAllRulesUsedForCrossReferences } from '../../utils/grammar-utils.js';
 
 export function registerValidationChecks(services: LangiumGrammarServices): void {
     const registry = services.validation.ValidationRegistry;

--- a/packages/langium/src/grammar/validation/validator.ts
+++ b/packages/langium/src/grammar/validation/validator.ts
@@ -16,13 +16,14 @@ import { DiagnosticTag } from 'vscode-languageserver-types';
 import { getContainerOfType, streamAllContents } from '../../utils/ast-utils.js';
 import { MultiMap } from '../../utils/collections.js';
 import { toDocumentSegment } from '../../utils/cst-utils.js';
-import { findNameAssignment, findNodeForKeyword, findNodeForProperty, getAllReachableRules, isDataTypeRule, isOptionalCardinality, terminalRegex } from '../../utils/grammar-utils.js';
+import { findNameAssignment, findNodeForKeyword, findNodeForProperty, getAllReachableRules, getAllRulesUsedForCrossReferences } from '../../utils/grammar-util.js';
 import { stream } from '../../utils/stream.js';
 import { diagnosticData } from '../../validation/validation-registry.js';
 import * as ast from '../../languages/generated/ast.js';
 import { getTypeNameWithoutError, hasDataTypeReturn, isPrimitiveGrammarType, isStringGrammarType, resolveImport, resolveTransitiveImports } from '../internal-grammar-util.js';
 import { typeDefinitionToPropertyType } from '../type-system/type-collector/declared-types.js';
 import { flattenPlainType, isPlainReferenceType } from '../type-system/type-collector/plain-types.js';
+import { isDataTypeRule, terminalRegex, isOptionalCardinality } from '../../utils/grammar-utils.js';
 
 export function registerValidationChecks(services: LangiumGrammarServices): void {
     const registry = services.validation.ValidationRegistry;
@@ -554,17 +555,25 @@ export class LangiumGrammarValidator {
 
     checkGrammarForUnusedRules(grammar: ast.Grammar, accept: ValidationAcceptor): void {
         const reachableRules = getAllReachableRules(grammar, true);
+        const parserRulesUsedByCrossReferences = getAllRulesUsedForCrossReferences(grammar);
 
         for (const rule of grammar.rules) {
             if (ast.isTerminalRule(rule) && rule.hidden || isEmptyRule(rule)) {
                 continue;
             }
             if (!reachableRules.has(rule)) {
-                accept('hint', 'This rule is declared but never referenced.', {
-                    node: rule,
-                    property: 'name',
-                    tags: [DiagnosticTag.Unnecessary]
-                });
+                if (ast.isParserRule(rule) && parserRulesUsedByCrossReferences.has(rule)) {
+                    accept('hint', 'This parser rule is not used for parsing, but referenced by cross-references. Consider to replace this rule by a type declaration.', {
+                        node: rule,
+                        property: 'name'
+                    });
+                } else {
+                    accept('hint', 'This rule is declared but never referenced.', {
+                        node: rule,
+                        property: 'name',
+                        tags: [DiagnosticTag.Unnecessary]
+                    });
+                }
             }
         }
     }

--- a/packages/langium/src/grammar/validation/validator.ts
+++ b/packages/langium/src/grammar/validation/validator.ts
@@ -104,6 +104,7 @@ export namespace IssueCodes {
     export const UseRegexTokens = 'use-regex-tokens';
     export const EntryRuleTokenSyntax = 'entry-rule-token-syntax';
     export const CrossRefTokenSyntax = 'cross-ref-token-syntax';
+    export const ParserRuleToTypeDecl = 'parser-rule-to-type-decl';
     export const UnnecessaryFileExtension = 'unnecessary-file-extension';
     export const InvalidReturns = 'invalid-returns';
     export const InvalidInfers = 'invalid-infers';
@@ -565,7 +566,8 @@ export class LangiumGrammarValidator {
                 if (ast.isParserRule(rule) && parserRulesUsedByCrossReferences.has(rule)) {
                     accept('hint', 'This parser rule is not used for parsing, but referenced by cross-references. Consider to replace this rule by a type declaration.', {
                         node: rule,
-                        property: 'name'
+                        // property: 'name',
+                        data: diagnosticData(IssueCodes.ParserRuleToTypeDecl)
                     });
                 } else {
                     accept('hint', 'This rule is declared but never referenced.', {

--- a/packages/langium/src/grammar/validation/validator.ts
+++ b/packages/langium/src/grammar/validation/validator.ts
@@ -566,7 +566,6 @@ export class LangiumGrammarValidator {
                 if (ast.isParserRule(rule) && parserRulesUsedByCrossReferences.has(rule)) {
                     accept('hint', 'This parser rule is not used for parsing, but referenced by cross-references. Consider to replace this rule by a type declaration.', {
                         node: rule,
-                        // property: 'name',
                         data: diagnosticData(IssueCodes.ParserRuleToTypeDecl)
                     });
                 } else {

--- a/packages/langium/src/test/langium-test.ts
+++ b/packages/langium/src/test/langium-test.ts
@@ -4,22 +4,23 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import type { CompletionItem, CompletionList, Diagnostic, DocumentSymbol, FoldingRange, FormattingOptions, Range, ReferenceParams, SemanticTokensParams, SemanticTokenTypes, TextDocumentIdentifier, TextDocumentPositionParams, WorkspaceSymbol } from 'vscode-languageserver-protocol';
-import type { LangiumCoreServices, LangiumSharedCoreServices } from '../services.js';
-import type { AstNode, CstNode, Properties } from '../syntax-tree.js';
-import { type LangiumDocument, TextDocument } from '../workspace/documents.js';
-import type { BuildOptions } from '../workspace/document-builder.js';
-import { DiagnosticSeverity, MarkupContent } from 'vscode-languageserver-types';
-import { escapeRegExp } from '../utils/regexp-utils.js';
-import { URI } from '../utils/uri-utils.js';
-import { findNodeForProperty } from '../utils/grammar-utils.js';
-import { SemanticTokensDecoder } from '../lsp/semantic-token-provider.js';
 import * as assert from 'node:assert';
-import { stream } from '../utils/stream.js';
-import type { AsyncDisposable } from '../utils/disposable.js';
-import { Disposable } from '../utils/disposable.js';
+import { CodeAction } from 'vscode-languageserver';
+import type { CompletionItem, CompletionList, Diagnostic, DocumentSymbol, FoldingRange, FormattingOptions, Range, ReferenceParams, SemanticTokensParams, SemanticTokenTypes, TextDocumentIdentifier, TextDocumentPositionParams, WorkspaceSymbol } from 'vscode-languageserver-protocol';
+import { DiagnosticSeverity, MarkupContent } from 'vscode-languageserver-types';
 import { normalizeEOL } from '../generate/template-string.js';
 import type { LangiumServices, LangiumSharedLSPServices } from '../lsp/lsp-services.js';
+import { SemanticTokensDecoder } from '../lsp/semantic-token-provider.js';
+import type { LangiumCoreServices, LangiumSharedCoreServices } from '../services.js';
+import type { AstNode, CstNode, Properties } from '../syntax-tree.js';
+import type { AsyncDisposable } from '../utils/disposable.js';
+import { Disposable } from '../utils/disposable.js';
+import { findNodeForProperty } from '../utils/grammar-utils.js';
+import { escapeRegExp } from '../utils/regexp-utils.js';
+import { stream } from '../utils/stream.js';
+import { URI } from '../utils/uri-utils.js';
+import type { BuildOptions } from '../workspace/document-builder.js';
+import { TextDocument, type LangiumDocument } from '../workspace/documents.js';
 
 export interface ParseHelperOptions extends BuildOptions {
     /**
@@ -746,4 +747,105 @@ export function expectSemanticToken(tokensWithRanges: DecodedSemanticTokensWithR
         return t.tokenType === options.tokenType && t.offset === range[0] && t.offset + t.text.length === range[1];
     });
     expectedFunction(result.length, 1, `Expected one token with the specified options but found ${result.length}`);
+}
+
+export interface QuickFixResult<T extends AstNode = AstNode> extends AsyncDisposable {
+    /** the document containing the AST */
+    document: LangiumDocument<T>;
+    /** all diagnostics of the validation */
+    diagnosticsAll: Diagnostic[];
+    /** the relevant Diagnostic with the given diagnosticCode, it is expected that the given input has exactly one such diagnostic */
+    diagnosticRelevant: Diagnostic;
+    /** the CodeAction to fix the found relevant problem, it is possible, that there is no such code action */
+    action?: CodeAction;
+}
+
+/**
+ * This is a helper function to easily test quick-fixes for validation problems.
+ * @param services the Langium services for the language with quick fixes
+ * @returns A function to easily test a single quick-fix on the given invalid 'input'.
+ * This function expects, that 'input' contains exactly one validation problem with the given 'diagnosticCode'.
+ * If 'outputAfterFix' is specified, this functions checks, that the diagnostic comes with a single quick-fix for this validation problem.
+ * After applying this quick-fix, 'input' is transformed to 'outputAfterFix'.
+ */
+export function testQuickFix<T extends AstNode = AstNode>(services: LangiumServices):
+        (input: string, diagnosticCode: string, outputAfterFix: string | undefined, options?: ParseHelperOptions) => Promise<QuickFixResult<T>> {
+    const validateHelper = validationHelper<T>(services);
+    return async (input, diagnosticCode, outputAfterFix, options) => {
+        // parse + validate
+        const validationBefore = await validateHelper(input, options);
+        const document = validationBefore.document;
+        const diagnosticsAll = document.diagnostics ?? [];
+        // use only the diagnostics with the given validation code
+        const diagnosticsRelevant = diagnosticsAll.filter(d => d.data && 'code' in d.data && d.data.code === diagnosticCode);
+        // expect exactly one validation with the given code
+        expectedFunction(diagnosticsRelevant.length, 1);
+        const diagnosticRelevant = diagnosticsRelevant[0];
+
+        // check, that the quick-fixes are generated for the selected validation:
+        // prepare the action provider
+        const actionProvider = expectTruthy(services.lsp.CodeActionProvider);
+        // request the actions for this diagnostic
+        const currentActions = await actionProvider!.getCodeActions(document, {
+            ...textDocumentParams(document),
+            range: diagnosticRelevant.range,
+            context: {
+                diagnostics: diagnosticsRelevant,
+                triggerKind: 1 // explicitly triggered by users (or extensions)
+            }
+        });
+
+        // evaluate the resulting actions
+        let action: CodeAction | undefined;
+        let validationAfter: ValidationResult | undefined;
+        if (outputAfterFix) {
+            // exactly one quick-fix is expected
+            expectTruthy(currentActions);
+            expectTruthy(Array.isArray(currentActions));
+            expectedFunction(currentActions!.length, 1);
+            expectTruthy(CodeAction.is(currentActions![0]));
+            action = currentActions![0] as CodeAction;
+
+            // execute the found quick-fix
+            const edits = expectTruthy(action.edit?.changes![document.textDocument.uri]);
+            const updatedText = TextDocument.applyEdits(document.textDocument, edits!);
+
+            // check the result after applying the quick-fix:
+            // 1st text is updated as expected
+            expectedFunction(updatedText, outputAfterFix);
+            // 2nd the validation diagnostic is gone after the fix
+            validationAfter = await validateHelper(updatedText, options);
+            const diagnosticsUpdated = validationAfter.diagnostics.filter(d => d.data && 'code' in d.data && d.data.code === diagnosticCode);
+            expectedFunction(diagnosticsUpdated.length, 0);
+        } else {
+            // no quick-fix is expected
+            expectFalsy(currentActions);
+        }
+
+        // collect the data to return
+        async function dispose(): Promise<void> {
+            validationBefore.dispose();
+            validationAfter?.dispose();
+        }
+        return {
+            document,
+            diagnosticsAll,
+            diagnosticRelevant: diagnosticRelevant,
+            action,
+            dispose: () => dispose()
+        };
+    };
+}
+
+function expectTruthy<T>(value: T): NonNullable<T> {
+    if (value) {
+        return value;
+    } else {
+        throw new Error();
+    }
+}
+function expectFalsy(value: unknown) {
+    if (value) {
+        throw new Error();
+    }
 }

--- a/packages/langium/src/test/langium-test.ts
+++ b/packages/langium/src/test/langium-test.ts
@@ -769,7 +769,7 @@ export interface QuickFixResult<T extends AstNode = AstNode> extends AsyncDispos
  * After applying this quick-fix, 'input' is transformed to 'outputAfterFix'.
  */
 export function testQuickFix<T extends AstNode = AstNode>(services: LangiumServices):
-        (input: string, diagnosticCode: string, outputAfterFix: string | undefined, options?: ParseHelperOptions) => Promise<QuickFixResult<T>> {
+(input: string, diagnosticCode: string, outputAfterFix: string | undefined, options?: ParseHelperOptions) => Promise<QuickFixResult<T>> {
     const validateHelper = validationHelper<T>(services);
     return async (input, diagnosticCode, outputAfterFix, options) => {
         // parse + validate

--- a/packages/langium/src/utils/grammar-utils.ts
+++ b/packages/langium/src/utils/grammar-utils.ts
@@ -69,6 +69,28 @@ function ruleDfs(rule: ast.AbstractRule, visitedSet: Set<string>, allTerminals: 
 }
 
 /**
+ * Returns all parser rules which are used in the grammar as type in cross-references.
+ * @param grammar the grammar to investigate
+ * @returns the set of parser rules used as type in cross-references
+ */
+export function getAllRulesUsedForCrossReferences(grammar: ast.Grammar): Set<ast.ParserRule> {
+    const result = new Set<ast.ParserRule>();
+    streamAllContents(grammar).forEach(node => {
+        if (ast.isCrossReference(node)) {
+            // the cross-reference refers directly to a parser rule
+            if (ast.isParserRule(node.type.ref)) {
+                result.add(node.type.ref);
+            }
+            // the cross-reference refers to the explicitly inferred type of a parser rule
+            if (ast.isInferredType(node.type.ref) && ast.isParserRule(node.type.ref.$container)) {
+                result.add(node.type.ref.$container);
+            }
+        }
+    });
+    return result;
+}
+
+/**
  * Determines the grammar expression used to parse a cross-reference (usually a reference to a terminal rule).
  * A cross-reference can declare this expression explicitly in the form `[Type : Terminal]`, but if `Terminal`
  * is omitted, this function attempts to infer it from the name of the referenced `Type` (using `findNameAssignment`).

--- a/packages/langium/src/utils/grammar-utils.ts
+++ b/packages/langium/src/utils/grammar-utils.ts
@@ -69,15 +69,15 @@ function ruleDfs(rule: ast.AbstractRule, visitedSet: Set<string>, allTerminals: 
 }
 
 /**
- * Returns all parser rules which are used in the grammar as type in cross-references.
+ * Returns all parser rules which provide types which are used in the grammar as type in cross-references.
  * @param grammar the grammar to investigate
- * @returns the set of parser rules used as type in cross-references
+ * @returns the set of parser rules whose contributed types are used as type in cross-references
  */
 export function getAllRulesUsedForCrossReferences(grammar: ast.Grammar): Set<ast.ParserRule> {
     const result = new Set<ast.ParserRule>();
     streamAllContents(grammar).forEach(node => {
         if (ast.isCrossReference(node)) {
-            // the cross-reference refers directly to a parser rule
+            // the cross-reference refers directly to a parser rule (without "returns", without "infers")
             if (ast.isParserRule(node.type.ref)) {
                 result.add(node.type.ref);
             }

--- a/packages/langium/test/grammar/grammar-validator.test.ts
+++ b/packages/langium/test/grammar/grammar-validator.test.ts
@@ -4,16 +4,14 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import type { AstNode, Properties } from 'langium';
-import type { GrammarAST as GrammarTypes } from 'langium';
-import type { ValidationResult } from 'langium/test';
-import { afterEach, beforeAll, describe, expect, test } from 'vitest';
-import { CodeAction, DiagnosticSeverity } from 'vscode-languageserver';
+import type { AstNode, GrammarAST as GrammarTypes, Properties } from 'langium';
 import { AstUtils, EmptyFileSystem, GrammarAST } from 'langium';
 import { IssueCodes, createLangiumGrammarServices } from 'langium/grammar';
-import { clearDocuments, expectError, expectIssue, expectNoIssues, expectWarning, parseHelper, textDocumentParams, validationHelper } from 'langium/test';
-import { TextDocument } from 'vscode-languageserver-textdocument';
-import { textBeforeParserRuleCrossReferences, textExpectedParserRuleCrossReferences } from './lsp/grammar-code-actions.test.js';
+import type { ValidationResult } from 'langium/test';
+import { clearDocuments, expectError, expectIssue, expectNoIssues, expectWarning, parseHelper, validationHelper } from 'langium/test';
+import { afterEach, beforeAll, describe, expect, test } from 'vitest';
+import { DiagnosticSeverity } from 'vscode-languageserver';
+import { textBeforeParserRuleCrossReferences, textBeforeParserRuleCrossReferencesWithInfers } from './lsp/grammar-code-actions.test.js';
 
 const services = createLangiumGrammarServices(EmptyFileSystem);
 const parse = parseHelper(services.grammar);
@@ -431,8 +429,12 @@ describe('Unused rules validation', () => {
         });
     });
 
-    test('Parser rules used only as type in cross-references are not marked as unused, but with a hint suggesting a type declaration', async () => {
-        // this test case targets https://github.com/eclipse-langium/langium/issues/1309
+});
+
+describe('Parser rules used only as type in cross-references are not marked as unused, but with a hint suggesting a type declaration', () => {
+    // these test cases target https://github.com/eclipse-langium/langium/issues/1309
+
+    test('union of two types', async () => {
         const validation = await validate(textBeforeParserRuleCrossReferences);
         expect(validation.diagnostics).toHaveLength(1);
         const ruleWithHint = validation.document.parseResult.value.rules.find(e => e.name === 'Person')!;
@@ -442,6 +444,15 @@ describe('Unused rules validation', () => {
         });
     });
 
+    test('union of two types, with infers', async () => {
+        const validation = await validate(textBeforeParserRuleCrossReferencesWithInfers);
+        expect(validation.diagnostics).toHaveLength(1);
+        const ruleWithHint = validation.document.parseResult.value.rules.find(e => e.name === 'Person')!;
+        expectIssue(validation, {
+            node: ruleWithHint,
+            severity: DiagnosticSeverity.Hint
+        });
+    });
 });
 
 describe('Reserved names', () => {

--- a/packages/langium/test/grammar/grammar-validator.test.ts
+++ b/packages/langium/test/grammar/grammar-validator.test.ts
@@ -431,7 +431,8 @@ describe('Unused rules validation', () => {
 
 });
 
-describe('Parser rules used only as type in cross-references are not marked as unused, but with a hint suggesting a type declaration', () => {
+describe('Parser rules used only as type in cross-references are not marked as unused, but with a hint suggesting to use a type declaration instead', () => {
+    // The used test data are defined at the test cases for possible quick-fixes for these validation problems.
     // these test cases target https://github.com/eclipse-langium/langium/issues/1309
 
     test('union of two types', async () => {

--- a/packages/langium/test/grammar/grammar-validator.test.ts
+++ b/packages/langium/test/grammar/grammar-validator.test.ts
@@ -13,6 +13,7 @@ import { AstUtils, EmptyFileSystem, GrammarAST } from 'langium';
 import { IssueCodes, createLangiumGrammarServices } from 'langium/grammar';
 import { clearDocuments, expectError, expectIssue, expectNoIssues, expectWarning, parseHelper, textDocumentParams, validationHelper } from 'langium/test';
 import { TextDocument } from 'vscode-languageserver-textdocument';
+import { textBeforeParserRuleCrossReferences, textExpectedParserRuleCrossReferences } from './lsp/grammar-code-actions.test.js';
 
 const services = createLangiumGrammarServices(EmptyFileSystem);
 const parse = parseHelper(services.grammar);
@@ -430,80 +431,15 @@ describe('Unused rules validation', () => {
         });
     });
 
-    test('Parser rules used only as type in cross-references are correctly identified as used', async () => {
+    test('Parser rules used only as type in cross-references are not marked as unused, but with a hint suggesting a type declaration', async () => {
         // this test case targets https://github.com/eclipse-langium/langium/issues/1309
-        const text = `
-        grammar ParserRulesOnlyForCrossReferences
-
-        entry Model:
-            (persons+=Neighbor | friends+=Friend | greetings+=Greeting)*;
-
-        Neighbor:
-            'neighbor' name=ID;
-        Friend:
-            'friend' name=ID;
-
-        Person: Neighbor | Friend; // 'Person' is used only for cross-references, not as parser rule
-
-        Greeting:
-            'Hello' person=[Person:ID] '!';
-
-        hidden terminal WS: /\\s+/;
-        terminal ID: /[_a-zA-Z][\\w_]*/;
-        `;
-        // check, that the expected validation hint is available
-        const validation = await validate(text);
+        const validation = await validate(textBeforeParserRuleCrossReferences);
         expect(validation.diagnostics).toHaveLength(1);
         const ruleWithHint = validation.document.parseResult.value.rules.find(e => e.name === 'Person')!;
         expectIssue(validation, {
             node: ruleWithHint,
-            // property: 'name',
             severity: DiagnosticSeverity.Hint
         });
-        // check, that the quick-fix is generated
-        const actionProvider = services.grammar.lsp.CodeActionProvider;
-        expect(actionProvider).toBeTruthy();
-        const currentAcctions = await actionProvider!.getCodeActions(validation.document, {
-            ...textDocumentParams(validation.document),
-            range: validation.diagnostics[0].range,
-            context: {
-                diagnostics: validation.diagnostics,
-                triggerKind: 1 // explicitly triggered by users (or extensions)
-            }
-        });
-        // there is one quick-fix
-        expect(currentAcctions).toBeTruthy();
-        expect(Array.isArray(currentAcctions)).toBeTruthy();
-        expect(currentAcctions!.length).toBe(1);
-        expect(CodeAction.is(currentAcctions![0])).toBeTruthy();
-        const action: CodeAction = currentAcctions![0] as CodeAction;
-        // execute the found quick-fix
-        expect(action.title).toBe('Replace parser rule by type declaration');
-        const edits = action.edit?.changes![validation.document.textDocument.uri];
-        expect(edits).toBeTruthy();
-        const updatedText = TextDocument.applyEdits(validation.document.textDocument, edits!);
-
-        // check the result
-        const textExpected = `
-        grammar ParserRulesOnlyForCrossReferences
-
-        entry Model:
-            (persons+=Neighbor | friends+=Friend | greetings+=Greeting)*;
-
-        Neighbor:
-            'neighbor' name=ID;
-        Friend:
-            'friend' name=ID;
-
-        type Person = Neighbor | Friend; // 'Person' is used only for cross-references, not as parser rule
-
-        Greeting:
-            'Hello' person=[Person:ID] '!';
-
-        hidden terminal WS: /\\s+/;
-        terminal ID: /[_a-zA-Z][\\w_]*/;
-        `;
-        expect(updatedText).toBe(textExpected);
     });
 
 });

--- a/packages/langium/test/grammar/grammar-validator.test.ts
+++ b/packages/langium/test/grammar/grammar-validator.test.ts
@@ -11,7 +11,7 @@ import type { ValidationResult } from 'langium/test';
 import { clearDocuments, expectError, expectIssue, expectNoIssues, expectWarning, parseHelper, validationHelper } from 'langium/test';
 import { afterEach, beforeAll, describe, expect, test } from 'vitest';
 import { DiagnosticSeverity } from 'vscode-languageserver';
-import { beforeTwoAlternatives, beforeWithInfers } from './lsp/grammar-code-actions.test.js';
+import { beforeAnotherRule, beforeSinglelternative, beforeTwoAlternatives, beforeWithInfers } from './lsp/grammar-code-actions.test.js';
 
 const services = createLangiumGrammarServices(EmptyFileSystem);
 const parse = parseHelper(services.grammar);
@@ -436,24 +436,31 @@ describe('Parser rules used only as type in cross-references are not marked as u
     // these test cases target https://github.com/eclipse-langium/langium/issues/1309
 
     test('union of two types', async () => {
-        const validation = await validate(beforeTwoAlternatives);
-        expect(validation.diagnostics).toHaveLength(1);
-        const ruleWithHint = validation.document.parseResult.value.rules.find(e => e.name === 'Person')!;
-        expectIssue(validation, {
-            node: ruleWithHint,
-            severity: DiagnosticSeverity.Hint
-        });
+        await validateRule(beforeTwoAlternatives);
     });
 
-    test('union of two types, with infers', async () => {
-        const validation = await validate(beforeWithInfers);
-        expect(validation.diagnostics).toHaveLength(1);
+    test('only a single type', async () => {
+        await validateRule(beforeSinglelternative);
+    });
+
+    test('rule using a nested rule', async () => {
+        await validateRule(beforeAnotherRule, 2); // 2 hints, since there is another "unused" rule (which is out-of-scope here)
+    });
+
+    test('union of two types, with "infers" keyword', async () => {
+        await validateRule(beforeWithInfers);
+    });
+
+    async function validateRule(grammar: string, foundDiagnostics: number = 1) {
+        const validation = await validate(grammar);
+        expect(validation.diagnostics).toHaveLength(foundDiagnostics);
         const ruleWithHint = validation.document.parseResult.value.rules.find(e => e.name === 'Person')!;
         expectIssue(validation, {
             node: ruleWithHint,
             severity: DiagnosticSeverity.Hint
         });
-    });
+        return ruleWithHint;
+    }
 });
 
 describe('Reserved names', () => {

--- a/packages/langium/test/grammar/grammar-validator.test.ts
+++ b/packages/langium/test/grammar/grammar-validator.test.ts
@@ -8,10 +8,11 @@ import type { AstNode, Properties } from 'langium';
 import type { GrammarAST as GrammarTypes } from 'langium';
 import type { ValidationResult } from 'langium/test';
 import { afterEach, beforeAll, describe, expect, test } from 'vitest';
-import { DiagnosticSeverity } from 'vscode-languageserver';
+import { CodeAction, DiagnosticSeverity } from 'vscode-languageserver';
 import { AstUtils, EmptyFileSystem, GrammarAST } from 'langium';
 import { IssueCodes, createLangiumGrammarServices } from 'langium/grammar';
-import { clearDocuments, expectError, expectIssue, expectNoIssues, expectWarning, parseHelper, validationHelper } from 'langium/test';
+import { clearDocuments, expectError, expectIssue, expectNoIssues, expectWarning, parseHelper, textDocumentParams, validationHelper } from 'langium/test';
+import { TextDocument } from 'vscode-languageserver-textdocument';
 
 const services = createLangiumGrammarServices(EmptyFileSystem);
 const parse = parseHelper(services.grammar);
@@ -432,7 +433,7 @@ describe('Unused rules validation', () => {
     test('Parser rules used only as type in cross-references are correctly identified as used', async () => {
         // this test case targets https://github.com/eclipse-langium/langium/issues/1309
         const text = `
-        grammar HelloWorld
+        grammar ParserRulesOnlyForCrossReferences
 
         entry Model:
             (persons+=Neighbor | friends+=Friend | greetings+=Greeting)*;
@@ -450,14 +451,59 @@ describe('Unused rules validation', () => {
         hidden terminal WS: /\\s+/;
         terminal ID: /[_a-zA-Z][\\w_]*/;
         `;
+        // check, that the expected validation hint is available
         const validation = await validate(text);
         expect(validation.diagnostics).toHaveLength(1);
         const ruleWithHint = validation.document.parseResult.value.rules.find(e => e.name === 'Person')!;
         expectIssue(validation, {
             node: ruleWithHint,
-            property: 'name',
+            // property: 'name',
             severity: DiagnosticSeverity.Hint
         });
+        // check, that the quick-fix is generated
+        const actionProvider = services.grammar.lsp.CodeActionProvider;
+        expect(actionProvider).toBeTruthy();
+        const currentAcctions = await actionProvider!.getCodeActions(validation.document, {
+            ...textDocumentParams(validation.document),
+            range: validation.diagnostics[0].range,
+            context: {
+                diagnostics: validation.diagnostics,
+                triggerKind: 1 // explicitly triggered by users (or extensions)
+            }
+        });
+        // there is one quick-fix
+        expect(currentAcctions).toBeTruthy();
+        expect(Array.isArray(currentAcctions)).toBeTruthy();
+        expect(currentAcctions!.length).toBe(1);
+        expect(CodeAction.is(currentAcctions![0])).toBeTruthy();
+        const action: CodeAction = currentAcctions![0] as CodeAction;
+        // execute the found quick-fix
+        expect(action.title).toBe('Replace parser rule by type declaration');
+        const edits = action.edit?.changes![validation.document.textDocument.uri];
+        expect(edits).toBeTruthy();
+        const updatedText = TextDocument.applyEdits(validation.document.textDocument, edits!);
+
+        // check the result
+        const textExpected = `
+        grammar ParserRulesOnlyForCrossReferences
+
+        entry Model:
+            (persons+=Neighbor | friends+=Friend | greetings+=Greeting)*;
+
+        Neighbor:
+            'neighbor' name=ID;
+        Friend:
+            'friend' name=ID;
+
+        type Person = Neighbor | Friend; // 'Person' is used only for cross-references, not as parser rule
+
+        Greeting:
+            'Hello' person=[Person:ID] '!';
+
+        hidden terminal WS: /\\s+/;
+        terminal ID: /[_a-zA-Z][\\w_]*/;
+        `;
+        expect(updatedText).toBe(textExpected);
     });
 
 });

--- a/packages/langium/test/grammar/grammar-validator.test.ts
+++ b/packages/langium/test/grammar/grammar-validator.test.ts
@@ -429,6 +429,37 @@ describe('Unused rules validation', () => {
         });
     });
 
+    test('Parser rules used only as type in cross-references are correctly identified as used', async () => {
+        // this test case targets https://github.com/eclipse-langium/langium/issues/1309
+        const text = `
+        grammar HelloWorld
+
+        entry Model:
+            (persons+=Neighbor | friends+=Friend | greetings+=Greeting)*;
+
+        Neighbor:
+            'neighbor' name=ID;
+        Friend:
+            'friend' name=ID;
+
+        Person: Neighbor | Friend; // 'Person' is used only for cross-references, not as parser rule
+
+        Greeting:
+            'Hello' person=[Person:ID] '!';
+
+        hidden terminal WS: /\\s+/;
+        terminal ID: /[_a-zA-Z][\\w_]*/;
+        `;
+        const validation = await validate(text);
+        expect(validation.diagnostics).toHaveLength(1);
+        const ruleWithHint = validation.document.parseResult.value.rules.find(e => e.name === 'Person')!;
+        expectIssue(validation, {
+            node: ruleWithHint,
+            property: 'name',
+            severity: DiagnosticSeverity.Hint
+        });
+    });
+
 });
 
 describe('Reserved names', () => {

--- a/packages/langium/test/grammar/grammar-validator.test.ts
+++ b/packages/langium/test/grammar/grammar-validator.test.ts
@@ -11,7 +11,7 @@ import type { ValidationResult } from 'langium/test';
 import { clearDocuments, expectError, expectIssue, expectNoIssues, expectWarning, parseHelper, validationHelper } from 'langium/test';
 import { afterEach, beforeAll, describe, expect, test } from 'vitest';
 import { DiagnosticSeverity } from 'vscode-languageserver';
-import { textBeforeParserRuleCrossReferences, textBeforeParserRuleCrossReferencesWithInfers } from './lsp/grammar-code-actions.test.js';
+import { beforeTwoAlternatives, beforeWithInfers } from './lsp/grammar-code-actions.test.js';
 
 const services = createLangiumGrammarServices(EmptyFileSystem);
 const parse = parseHelper(services.grammar);
@@ -436,7 +436,7 @@ describe('Parser rules used only as type in cross-references are not marked as u
     // these test cases target https://github.com/eclipse-langium/langium/issues/1309
 
     test('union of two types', async () => {
-        const validation = await validate(textBeforeParserRuleCrossReferences);
+        const validation = await validate(beforeTwoAlternatives);
         expect(validation.diagnostics).toHaveLength(1);
         const ruleWithHint = validation.document.parseResult.value.rules.find(e => e.name === 'Person')!;
         expectIssue(validation, {
@@ -446,7 +446,7 @@ describe('Parser rules used only as type in cross-references are not marked as u
     });
 
     test('union of two types, with infers', async () => {
-        const validation = await validate(textBeforeParserRuleCrossReferencesWithInfers);
+        const validation = await validate(beforeWithInfers);
         expect(validation.diagnostics).toHaveLength(1);
         const ruleWithHint = validation.document.parseResult.value.rules.find(e => e.name === 'Person')!;
         expectIssue(validation, {

--- a/packages/langium/test/grammar/lsp/grammar-code-actions.test.ts
+++ b/packages/langium/test/grammar/lsp/grammar-code-actions.test.ts
@@ -1,0 +1,78 @@
+/******************************************************************************
+ * Copyright 2023 TypeFox GmbH
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License, which is available in the project root.
+ ******************************************************************************/
+
+import type { GrammarAST } from 'langium';
+import { EmptyFileSystem, createLangiumGrammarServices } from 'langium';
+import { textDocumentParams, validationHelper } from 'langium/test';
+import { describe, expect, test } from 'vitest';
+import { CodeAction } from 'vscode-languageserver';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+
+const services = createLangiumGrammarServices(EmptyFileSystem);
+const validate = validationHelper<GrammarAST.Grammar>(services.grammar);
+
+export const textBeforeParserRuleCrossReferences = `
+    grammar ParserRulesOnlyForCrossReferences
+    entry Model: (persons+=Neighbor | friends+=Friend | greetings+=Greeting)*;
+    Neighbor:   'neighbor'  name=ID;
+    Friend:     'friend'    name=ID;
+
+    Person: Neighbor | Friend; // 'Person' is used only for cross-references, not as parser rule
+    Greeting: 'Hello' person=[Person:ID] '!';
+
+    hidden terminal WS: /\\s+/;
+    terminal ID: /[_a-zA-Z][\\w_]*/;
+`;
+
+export const textExpectedParserRuleCrossReferences = `
+    grammar ParserRulesOnlyForCrossReferences
+    entry Model: (persons+=Neighbor | friends+=Friend | greetings+=Greeting)*;
+    Neighbor:   'neighbor'  name=ID;
+    Friend:     'friend'    name=ID;
+
+    type Person = Neighbor | Friend; // 'Person' is used only for cross-references, not as parser rule
+    Greeting: 'Hello' person=[Person:ID] '!';
+
+    hidden terminal WS: /\\s+/;
+    terminal ID: /[_a-zA-Z][\\w_]*/;
+`;
+
+describe('Langium grammar quick-fixes for validations', () => {
+    test('Parser rules used only as type in cross-references are correctly identified as used', async () => {
+        // this test case targets https://github.com/eclipse-langium/langium/issues/1309
+        // check, that the expected validation hint is available
+        const validation = await validate(textBeforeParserRuleCrossReferences);
+        expect(validation.diagnostics).toHaveLength(1);
+        // check, that the quick-fix is generated
+        const actionProvider = services.grammar.lsp.CodeActionProvider;
+        expect(actionProvider).toBeTruthy();
+        const currentAcctions = await actionProvider!.getCodeActions(validation.document, {
+            ...textDocumentParams(validation.document),
+            range: validation.diagnostics[0].range,
+            context: {
+                diagnostics: validation.diagnostics,
+                triggerKind: 1 // explicitly triggered by users (or extensions)
+            }
+        });
+        // there is one quick-fix
+        expect(currentAcctions).toBeTruthy();
+        expect(Array.isArray(currentAcctions)).toBeTruthy();
+        expect(currentAcctions!.length).toBe(1);
+        expect(CodeAction.is(currentAcctions![0])).toBeTruthy();
+        const action: CodeAction = currentAcctions![0] as CodeAction;
+        // execute the found quick-fix
+        expect(action.title).toBe('Replace parser rule by type declaration');
+        const edits = action.edit?.changes![validation.document.textDocument.uri];
+        expect(edits).toBeTruthy();
+        const updatedText = TextDocument.applyEdits(validation.document.textDocument, edits!);
+
+        // check the result after applying the quick-fix
+        expect(updatedText).toBe(textExpectedParserRuleCrossReferences);
+        const validationUpdated = await validate(updatedText);
+        expect(validationUpdated.diagnostics).toHaveLength(0);
+    });
+
+});

--- a/packages/langium/test/grammar/lsp/grammar-code-actions.test.ts
+++ b/packages/langium/test/grammar/lsp/grammar-code-actions.test.ts
@@ -4,20 +4,16 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import { AstNode, AsyncDisposable, EmptyFileSystem, LangiumDocument } from 'langium';
-import { ParseHelperOptions, ValidationResult, textDocumentParams, validationHelper } from 'langium/test';
+import { EmptyFileSystem } from 'langium';
 import { describe, expect, test } from 'vitest';
-import type { Diagnostic } from 'vscode-languageserver';
-import { CodeAction } from 'vscode-languageserver';
-import { TextDocument } from 'vscode-languageserver-textdocument';
-import { createLangiumGrammarServices } from '../../../src/grammar/langium-grammar-module.js';
 import { IssueCodes } from '../../../src/grammar/index.js';
-import { LangiumServices } from '../../../lib/lsp/lsp-services.js';
+import { createLangiumGrammarServices } from '../../../src/grammar/langium-grammar-module.js';
+import { testQuickFix } from '../../../src/test/langium-test.js';
 
 const services = createLangiumGrammarServices(EmptyFileSystem);
 const testQuickFixes = testQuickFix(services.grammar);
 
-// Some of these test data are exported, since they are reused for corresponding test cases 
+// Some of these test data are exported, since they are reused for corresponding test cases for the grammar validation itself
 
 export const textBeforeParserRuleCrossReferences = `
     grammar ParserRulesOnlyForCrossReferences
@@ -87,91 +83,3 @@ describe('Langium grammar quick-fixes for validations: Parser rules used only as
 
     // TODO test cases, where no quick-fix action is provided
 });
-
-export interface QuickFixResult<T extends AstNode = AstNode> extends AsyncDisposable {
-    /** the document containing the AST */
-    document: LangiumDocument<T>;
-    /** all diagnostics of the validation */
-    diagnosticsAll: Diagnostic[];
-    /** the relevant Diagnostic with the given diagnosticCode, it is expected that the given input has exactly one such diagnostic */
-    diagnosticRelevant: Diagnostic;
-    /** the CodeAction to fix the found relevant problem, it is possible, that there is no such code action */
-    action?: CodeAction;
-}
-/**
- * This is a helper function to easily test quick-fixes for validation problems.
- * @param services the Langium services for the language with quick fixes
- * @returns A function to easily test a single quick-fix on the given invalid 'input'.
- * This function expects, that 'input' contains exactly one validation problem with the given 'diagnosticCode'.
- * If 'outputAfterFix' is specified, this functions checks, that the diagnostic comes with a single quick-fix for this validation problem.
- * After applying this quick-fix, 'input' is transformed to 'outputAfterFix'.
- */
-export function testQuickFix<T extends AstNode = AstNode>(services: LangiumServices):
-        (input: string, diagnosticCode: string, outputAfterFix: string | undefined, options?: ParseHelperOptions) => Promise<QuickFixResult<T>> {
-    const validateHelper = validationHelper<T>(services);
-    return async (input, diagnosticCode, outputAfterFix, options) => {
-        // parse + validate
-        const validationBefore = await validateHelper(input, options);
-        const document = validationBefore.document;
-        const diagnosticsAll = document.diagnostics ?? [];
-        // use only the diagnostics with the given validation code
-        const diagnosticsRelevant = diagnosticsAll.filter(d => d.data && 'code' in d.data && d.data.code === diagnosticCode);
-        // expect exactly one validation with the given code
-        expect(diagnosticsRelevant.length).toBe(1);
-        const diagnosticRelevant = diagnosticsRelevant[0];
-
-        // check, that the quick-fixes are generated for the selected validation:
-        // prepare the action provider
-        const actionProvider = services.lsp.CodeActionProvider;
-        expect(actionProvider).toBeTruthy();
-        // request the actions for this diagnostic
-        const currentActions = await actionProvider!.getCodeActions(document, {
-            ...textDocumentParams(document),
-            range: diagnosticRelevant.range,
-            context: {
-                diagnostics: diagnosticsRelevant,
-                triggerKind: 1 // explicitly triggered by users (or extensions)
-            }
-        });
-
-        // evaluate the resulting actions
-        let action: CodeAction | undefined;
-        let validationAfter: ValidationResult | undefined;
-        if (outputAfterFix) {
-            // exactly one quick-fix is expected
-            expect(currentActions).toBeTruthy();
-            expect(Array.isArray(currentActions)).toBeTruthy();
-            expect(currentActions!).toHaveLength(1);
-            expect(CodeAction.is(currentActions![0])).toBeTruthy();
-            action = currentActions![0] as CodeAction;
-
-            // execute the found quick-fix
-            const edits = action.edit?.changes![document.textDocument.uri];
-            expect(edits).toBeTruthy();
-            const updatedText = TextDocument.applyEdits(document.textDocument, edits!);
-
-            // check the result after applying the quick-fix:
-            // 1st text is updated as expected
-            expect(updatedText).toBe(outputAfterFix);
-            // 2nd the validation diagnostic is gone after the fix
-            validationAfter = await validateHelper(updatedText, options);
-            const diagnosticsUpdated = validationAfter.diagnostics.filter(d => d.data && 'code' in d.data && d.data.code === diagnosticCode);
-            expect(diagnosticsUpdated).toHaveLength(0);
-        } else {
-            // no quick-fix is expected
-            expect(currentActions).toBeFalsy();
-        }
-
-        async function dispose(): Promise<void> {
-            validationBefore.dispose();
-            validationAfter?.dispose();
-        }
-        return {
-            document,
-            diagnosticsAll,
-            diagnosticRelevant: diagnosticRelevant,
-            action,
-            dispose: () => dispose()
-        };
-    };
-}

--- a/packages/langium/test/grammar/lsp/grammar-code-actions.test.ts
+++ b/packages/langium/test/grammar/lsp/grammar-code-actions.test.ts
@@ -4,16 +4,20 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import type { GrammarAST } from 'langium';
-import { EmptyFileSystem } from 'langium';
-import { textDocumentParams, validationHelper } from 'langium/test';
+import { AstNode, AsyncDisposable, EmptyFileSystem, LangiumDocument } from 'langium';
+import { ParseHelperOptions, ValidationResult, textDocumentParams, validationHelper } from 'langium/test';
 import { describe, expect, test } from 'vitest';
+import type { Diagnostic } from 'vscode-languageserver';
 import { CodeAction } from 'vscode-languageserver';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { createLangiumGrammarServices } from '../../../src/grammar/langium-grammar-module.js';
+import { IssueCodes } from '../../../src/grammar/index.js';
+import { LangiumServices } from '../../../lib/lsp/lsp-services.js';
 
 const services = createLangiumGrammarServices(EmptyFileSystem);
-const validate = validationHelper<GrammarAST.Grammar>(services.grammar);
+const testQuickFixes = testQuickFix(services.grammar);
+
+// Some of these test data are exported, since they are reused for corresponding test cases 
 
 export const textBeforeParserRuleCrossReferences = `
     grammar ParserRulesOnlyForCrossReferences
@@ -67,40 +71,107 @@ export const textExpectedParserRuleCrossReferencesWithInfers = `
     terminal ID: /[_a-zA-Z][\\w_]*/;
 `;
 
-
 describe('Langium grammar quick-fixes for validations: Parser rules used only as type in cross-references are not marked as unused, but with a hint suggesting a type declaration', () => {
     // these test cases target https://github.com/eclipse-langium/langium/issues/1309
 
-    test('union of two types', async () => {
-        // check, that the expected validation hint is available
-        const validation = await validate(textBeforeParserRuleCrossReferences);
-        expect(validation.diagnostics).toHaveLength(1);
-        // check, that the quick-fix is generated
-        const actionProvider = services.grammar.lsp.CodeActionProvider;
+    test('The parser rule has an implicitly inferred type', async () => {
+        const result = await testQuickFixes(textBeforeParserRuleCrossReferences, IssueCodes.ParserRuleToTypeDecl, textExpectedParserRuleCrossReferences);
+        const action = result.action;
+        expect(action).toBeTruthy();
+        expect(action!.title).toBe('Replace parser rule by type declaration');
+    });
+
+    test('The parser rule has an explicitly inferred type', async () => {
+        await testQuickFixes(textBeforeParserRuleCrossReferencesWithInfers, IssueCodes.ParserRuleToTypeDecl, textExpectedParserRuleCrossReferencesWithInfers);
+    });
+
+    // TODO test cases, where no quick-fix action is provided
+});
+
+export interface QuickFixResult<T extends AstNode = AstNode> extends AsyncDisposable {
+    /** the document containing the AST */
+    document: LangiumDocument<T>;
+    /** all diagnostics of the validation */
+    diagnosticsAll: Diagnostic[];
+    /** the relevant Diagnostic with the given diagnosticCode, it is expected that the given input has exactly one such diagnostic */
+    diagnosticRelevant: Diagnostic;
+    /** the CodeAction to fix the found relevant problem, it is possible, that there is no such code action */
+    action?: CodeAction;
+}
+/**
+ * This is a helper function to easily test quick-fixes for validation problems.
+ * @param services the Langium services for the language with quick fixes
+ * @returns A function to easily test a single quick-fix on the given invalid 'input'.
+ * This function expects, that 'input' contains exactly one validation problem with the given 'diagnosticCode'.
+ * If 'outputAfterFix' is specified, this functions checks, that the diagnostic comes with a single quick-fix for this validation problem.
+ * After applying this quick-fix, 'input' is transformed to 'outputAfterFix'.
+ */
+export function testQuickFix<T extends AstNode = AstNode>(services: LangiumServices):
+        (input: string, diagnosticCode: string, outputAfterFix: string | undefined, options?: ParseHelperOptions) => Promise<QuickFixResult<T>> {
+    const validateHelper = validationHelper<T>(services);
+    return async (input, diagnosticCode, outputAfterFix, options) => {
+        // parse + validate
+        const validationBefore = await validateHelper(input, options);
+        const document = validationBefore.document;
+        const diagnosticsAll = document.diagnostics ?? [];
+        // use only the diagnostics with the given validation code
+        const diagnosticsRelevant = diagnosticsAll.filter(d => d.data && 'code' in d.data && d.data.code === diagnosticCode);
+        // expect exactly one validation with the given code
+        expect(diagnosticsRelevant.length).toBe(1);
+        const diagnosticRelevant = diagnosticsRelevant[0];
+
+        // check, that the quick-fixes are generated for the selected validation:
+        // prepare the action provider
+        const actionProvider = services.lsp.CodeActionProvider;
         expect(actionProvider).toBeTruthy();
-        const currentAcctions = await actionProvider!.getCodeActions(validation.document, {
-            ...textDocumentParams(validation.document),
-            range: validation.diagnostics[0].range,
+        // request the actions for this diagnostic
+        const currentActions = await actionProvider!.getCodeActions(document, {
+            ...textDocumentParams(document),
+            range: diagnosticRelevant.range,
             context: {
-                diagnostics: validation.diagnostics,
+                diagnostics: diagnosticsRelevant,
                 triggerKind: 1 // explicitly triggered by users (or extensions)
             }
         });
-        // there is one quick-fix
-        expect(currentAcctions).toBeTruthy();
-        expect(Array.isArray(currentAcctions)).toBeTruthy();
-        expect(currentAcctions!.length).toBe(1);
-        expect(CodeAction.is(currentAcctions![0])).toBeTruthy();
-        const action: CodeAction = currentAcctions![0] as CodeAction;
-        // execute the found quick-fix
-        expect(action.title).toBe('Replace parser rule by type declaration');
-        const edits = action.edit?.changes![validation.document.textDocument.uri];
-        expect(edits).toBeTruthy();
-        const updatedText = TextDocument.applyEdits(validation.document.textDocument, edits!);
 
-        // check the result after applying the quick-fix
-        expect(updatedText).toBe(textExpectedParserRuleCrossReferences);
-        const validationUpdated = await validate(updatedText);
-        expect(validationUpdated.diagnostics).toHaveLength(0);
-    });
-});
+        // evaluate the resulting actions
+        let action: CodeAction | undefined;
+        let validationAfter: ValidationResult | undefined;
+        if (outputAfterFix) {
+            // exactly one quick-fix is expected
+            expect(currentActions).toBeTruthy();
+            expect(Array.isArray(currentActions)).toBeTruthy();
+            expect(currentActions!).toHaveLength(1);
+            expect(CodeAction.is(currentActions![0])).toBeTruthy();
+            action = currentActions![0] as CodeAction;
+
+            // execute the found quick-fix
+            const edits = action.edit?.changes![document.textDocument.uri];
+            expect(edits).toBeTruthy();
+            const updatedText = TextDocument.applyEdits(document.textDocument, edits!);
+
+            // check the result after applying the quick-fix:
+            // 1st text is updated as expected
+            expect(updatedText).toBe(outputAfterFix);
+            // 2nd the validation diagnostic is gone after the fix
+            validationAfter = await validateHelper(updatedText, options);
+            const diagnosticsUpdated = validationAfter.diagnostics.filter(d => d.data && 'code' in d.data && d.data.code === diagnosticCode);
+            expect(diagnosticsUpdated).toHaveLength(0);
+        } else {
+            // no quick-fix is expected
+            expect(currentActions).toBeFalsy();
+        }
+
+        async function dispose(): Promise<void> {
+            validationBefore.dispose();
+            validationAfter?.dispose();
+        }
+        return {
+            document,
+            diagnosticsAll,
+            diagnosticRelevant: diagnosticRelevant,
+            action,
+            dispose: () => dispose()
+        };
+    };
+}

--- a/packages/langium/test/grammar/lsp/grammar-code-actions.test.ts
+++ b/packages/langium/test/grammar/lsp/grammar-code-actions.test.ts
@@ -40,9 +40,37 @@ export const textExpectedParserRuleCrossReferences = `
     terminal ID: /[_a-zA-Z][\\w_]*/;
 `;
 
-describe('Langium grammar quick-fixes for validations', () => {
-    test('Parser rules used only as type in cross-references are correctly identified as used', async () => {
-        // this test case targets https://github.com/eclipse-langium/langium/issues/1309
+export const textBeforeParserRuleCrossReferencesWithInfers = `
+    grammar ParserRulesOnlyForCrossReferences
+    entry Model: (persons+=Neighbor | friends+=Friend | greetings+=Greeting)*;
+    Neighbor:   'neighbor'  name=ID;
+    Friend:     'friend'    name=ID;
+
+    Person infers PersonType: Neighbor | Friend; // 'Person' is used only for cross-references, not as parser rule
+    Greeting: 'Hello' person=[PersonType:ID] '!';
+
+    hidden terminal WS: /\\s+/;
+    terminal ID: /[_a-zA-Z][\\w_]*/;
+`;
+
+export const textExpectedParserRuleCrossReferencesWithInfers = `
+    grammar ParserRulesOnlyForCrossReferences
+    entry Model: (persons+=Neighbor | friends+=Friend | greetings+=Greeting)*;
+    Neighbor:   'neighbor'  name=ID;
+    Friend:     'friend'    name=ID;
+
+    type PersonType = Neighbor | Friend; // 'Person' is used only for cross-references, not as parser rule
+    Greeting: 'Hello' person=[PersonType:ID] '!';
+
+    hidden terminal WS: /\\s+/;
+    terminal ID: /[_a-zA-Z][\\w_]*/;
+`;
+
+
+describe('Langium grammar quick-fixes for validations: Parser rules used only as type in cross-references are not marked as unused, but with a hint suggesting a type declaration', () => {
+    // these test cases target https://github.com/eclipse-langium/langium/issues/1309
+
+    test('union of two types', async () => {
         // check, that the expected validation hint is available
         const validation = await validate(textBeforeParserRuleCrossReferences);
         expect(validation.diagnostics).toHaveLength(1);
@@ -74,5 +102,4 @@ describe('Langium grammar quick-fixes for validations', () => {
         const validationUpdated = await validate(updatedText);
         expect(validationUpdated.diagnostics).toHaveLength(0);
     });
-
 });

--- a/packages/langium/test/grammar/lsp/grammar-code-actions.test.ts
+++ b/packages/langium/test/grammar/lsp/grammar-code-actions.test.ts
@@ -5,11 +5,12 @@
  ******************************************************************************/
 
 import type { GrammarAST } from 'langium';
-import { EmptyFileSystem, createLangiumGrammarServices } from 'langium';
+import { EmptyFileSystem } from 'langium';
 import { textDocumentParams, validationHelper } from 'langium/test';
 import { describe, expect, test } from 'vitest';
 import { CodeAction } from 'vscode-languageserver';
 import { TextDocument } from 'vscode-languageserver-textdocument';
+import { createLangiumGrammarServices } from '../../../src/grammar/langium-grammar-module.js';
 
 const services = createLangiumGrammarServices(EmptyFileSystem);
 const validate = validationHelper<GrammarAST.Grammar>(services.grammar);

--- a/packages/langium/test/grammar/lsp/grammar-code-actions.test.ts
+++ b/packages/langium/test/grammar/lsp/grammar-code-actions.test.ts
@@ -15,83 +15,47 @@ const testQuickFixes = testQuickFix(services.grammar);
 
 // Some of these test data are exported, since they are reused for corresponding test cases for the grammar validation itself
 
-export const beforeTwoAlternatives = `
-    grammar ParserRulesOnlyForCrossReferences
-    entry Model: (persons+=Neighbor | friends+=Friend | greetings+=Greeting)*;
-    Neighbor:   'neighbor'  name=ID;
-    Friend:     'friend'    name=ID;
-
-    Person: (Neighbor | Friend); // 'Person' is used only for cross-references, not as parser rule
+export const beforeTwoAlternatives = grammarRuleVsType(`
+    Person: Neighbor | Friend;
     Greeting: 'Hello' person=[Person:ID] '!';
+`);
 
-    hidden terminal WS: /\\s+/;
-    terminal ID: /[_a-zA-Z][\\w_]*/;
-`;
-
-export const expectedTwoAlternatives = `
-    grammar ParserRulesOnlyForCrossReferences
-    entry Model: (persons+=Neighbor | friends+=Friend | greetings+=Greeting)*;
-    Neighbor:   'neighbor'  name=ID;
-    Friend:     'friend'    name=ID;
-
-    type Person = Neighbor | Friend; // 'Person' is used only for cross-references, not as parser rule
+export const expectedTwoAlternatives = grammarRuleVsType(`
+    type Person = Neighbor | Friend;
     Greeting: 'Hello' person=[Person:ID] '!';
+`);
 
-    hidden terminal WS: /\\s+/;
-    terminal ID: /[_a-zA-Z][\\w_]*/;
-`;
-
-export const beforeSinglelternative = `
-    grammar ParserRulesOnlyForCrossReferences
-    entry Model: (persons+=Neighbor | friends+=Friend | greetings+=Greeting)*;
-    Neighbor:   'neighbor'  name=ID;
-    Friend:     'friend'    name=ID;
-
-    Person: Neighbor; // 'Person' is used only for cross-references, not as parser rule
+export const beforeSinglelternative = grammarRuleVsType(`
+    Person: Neighbor;
     Greeting: 'Hello' person=[Person:ID] '!';
+`);
 
-    hidden terminal WS: /\\s+/;
-    terminal ID: /[_a-zA-Z][\\w_]*/;
-`;
-
-export const expectedSingleAlternative = `
-    grammar ParserRulesOnlyForCrossReferences
-    entry Model: (persons+=Neighbor | friends+=Friend | greetings+=Greeting)*;
-    Neighbor:   'neighbor'  name=ID;
-    Friend:     'friend'    name=ID;
-
-    type Person = Neighbor; // 'Person' is used only for cross-references, not as parser rule
+export const expectedSingleAlternative = grammarRuleVsType(`
+    type Person = Neighbor;
     Greeting: 'Hello' person=[Person:ID] '!';
+`);
 
-    hidden terminal WS: /\\s+/;
-    terminal ID: /[_a-zA-Z][\\w_]*/;
-`;
-
-export const beforeWithInfers = `
-    grammar ParserRulesOnlyForCrossReferences
-    entry Model: (persons+=Neighbor | friends+=Friend | greetings+=Greeting)*;
-    Neighbor:   'neighbor'  name=ID;
-    Friend:     'friend'    name=ID;
-
-    Person infers PersonType: Neighbor | Friend; // 'Person' is used only for cross-references, not as parser rule
+export const beforeWithInfers = grammarRuleVsType(`
+    Person infers PersonType: Neighbor | Friend;
     Greeting: 'Hello' person=[PersonType:ID] '!';
+`);
 
-    hidden terminal WS: /\\s+/;
-    terminal ID: /[_a-zA-Z][\\w_]*/;
-`;
-
-export const expectedWithInfers = `
-    grammar ParserRulesOnlyForCrossReferences
-    entry Model: (persons+=Neighbor | friends+=Friend | greetings+=Greeting)*;
-    Neighbor:   'neighbor'  name=ID;
-    Friend:     'friend'    name=ID;
-
-    type PersonType = Neighbor | Friend; // 'Person' is used only for cross-references, not as parser rule
+export const expectedWithInfers = grammarRuleVsType(`
+    type PersonType = Neighbor | Friend;
     Greeting: 'Hello' person=[PersonType:ID] '!';
+`);
 
-    hidden terminal WS: /\\s+/;
-    terminal ID: /[_a-zA-Z][\\w_]*/;
-`;
+function grammarRuleVsType(body: string): string {
+    return `
+        grammar ParserRuleUsedOnlyForCrossReference
+        entry Model: (persons+=Neighbor | friends+=Friend | greetings+=Greeting)*;
+        Neighbor:   'neighbor'  name=ID;
+        Friend:     'friend'    name=ID;
+        ${body}
+        hidden terminal WS: /\\s+/;
+        terminal ID: /[_a-zA-Z][\\w_]*/;
+    `;
+}
 
 describe('Langium grammar quick-fixes for validations: Parser rules used only as type in cross-references are not marked as unused, but with a hint suggesting a type declaration', () => {
     // these test cases target https://github.com/eclipse-langium/langium/issues/1309


### PR DESCRIPTION
This PR contributes the following things:
- At the moment parser rules which are used not for parsing but whose type is used in cross-references are marked as "unused" for users. This message is not accurate and could confuse inexperienced users. Therefore, the message of the validation is improved to "This parser rule is not used for parsing, but referenced by cross-references. Consider to replace this rule by a type declaration.". See #1309 for details.
- Additionally, a quick-fix is provided for users to replace such a parser rule by a type declaration.
- While the two contributions above target a quite special case, this PR contributes also a generic helper functionality to check quick-fixes (`testQuickFix` in `packages/langium/src/test/langium-test.ts`). This function is tested by applying it to the mentioned new quick-fix for the Langium grammar.