### PR TITLE
Use correct module type for generated module

### DIFF
--- a/examples/arithmetics/src/language-server/generated/module.ts
+++ b/examples/arithmetics/src/language-server/generated/module.ts
@@ -3,8 +3,7 @@
  * DO NOT EDIT MANUALLY!
  ******************************************************************************/
 
-import type { LangiumGeneratedCoreServices, LangiumGeneratedSharedCoreServices, LanguageMetaData, Module } from 'langium';
-import type { LangiumSharedServices, LangiumServices } from 'langium/lsp';
+import type { LangiumSharedCoreServices, LangiumCoreServices, LangiumGeneratedCoreServices, LangiumGeneratedSharedCoreServices, LanguageMetaData, Module } from 'langium';
 import { ArithmeticsAstReflection } from './ast.js';
 import { ArithmeticsGrammar } from './grammar.js';
 
@@ -14,11 +13,11 @@ export const ArithmeticsLanguageMetaData = {
     caseInsensitive: true
 } as const satisfies LanguageMetaData;
 
-export const ArithmeticsGeneratedSharedModule: Module<LangiumSharedServices, LangiumGeneratedSharedCoreServices> = {
+export const ArithmeticsGeneratedSharedModule: Module<LangiumSharedCoreServices, LangiumGeneratedSharedCoreServices> = {
     AstReflection: () => new ArithmeticsAstReflection()
 };
 
-export const ArithmeticsGeneratedModule: Module<LangiumServices, LangiumGeneratedCoreServices> = {
+export const ArithmeticsGeneratedModule: Module<LangiumCoreServices, LangiumGeneratedCoreServices> = {
     Grammar: () => ArithmeticsGrammar(),
     LanguageMetaData: () => ArithmeticsLanguageMetaData,
     parser: {}

--- a/examples/domainmodel/src/language-server/generated/module.ts
+++ b/examples/domainmodel/src/language-server/generated/module.ts
@@ -3,8 +3,7 @@
  * DO NOT EDIT MANUALLY!
  ******************************************************************************/
 
-import type { LangiumGeneratedCoreServices, LangiumGeneratedSharedCoreServices, LanguageMetaData, Module, IParserConfig } from 'langium';
-import type { LangiumSharedServices, LangiumServices } from 'langium/lsp';
+import type { LangiumSharedCoreServices, LangiumCoreServices, LangiumGeneratedCoreServices, LangiumGeneratedSharedCoreServices, LanguageMetaData, Module, IParserConfig } from 'langium';
 import { DomainModelAstReflection } from './ast.js';
 import { DomainModelGrammar } from './grammar.js';
 
@@ -20,11 +19,11 @@ export const parserConfig: IParserConfig = {
     maxLookahead: 3,
 };
 
-export const DomainModelGeneratedSharedModule: Module<LangiumSharedServices, LangiumGeneratedSharedCoreServices> = {
+export const DomainModelGeneratedSharedModule: Module<LangiumSharedCoreServices, LangiumGeneratedSharedCoreServices> = {
     AstReflection: () => new DomainModelAstReflection()
 };
 
-export const DomainModelGeneratedModule: Module<LangiumServices, LangiumGeneratedCoreServices> = {
+export const DomainModelGeneratedModule: Module<LangiumCoreServices, LangiumGeneratedCoreServices> = {
     Grammar: () => DomainModelGrammar(),
     LanguageMetaData: () => DomainModelLanguageMetaData,
     parser: {

--- a/examples/requirements/src/language-server/generated/module.ts
+++ b/examples/requirements/src/language-server/generated/module.ts
@@ -3,8 +3,7 @@
  * DO NOT EDIT MANUALLY!
  ******************************************************************************/
 
-import type { LangiumGeneratedCoreServices, LangiumGeneratedSharedCoreServices, LanguageMetaData, Module } from 'langium';
-import type { LangiumSharedServices, LangiumServices } from 'langium/lsp';
+import type { LangiumSharedCoreServices, LangiumCoreServices, LangiumGeneratedCoreServices, LangiumGeneratedSharedCoreServices, LanguageMetaData, Module } from 'langium';
 import { RequirementsAndTestsAstReflection } from './ast.js';
 import { RequirementsGrammar, TestsGrammar } from './grammar.js';
 
@@ -20,17 +19,17 @@ export const TestsLanguageMetaData = {
     caseInsensitive: false
 } as const satisfies LanguageMetaData;
 
-export const RequirementsAndTestsGeneratedSharedModule: Module<LangiumSharedServices, LangiumGeneratedSharedCoreServices> = {
+export const RequirementsAndTestsGeneratedSharedModule: Module<LangiumSharedCoreServices, LangiumGeneratedSharedCoreServices> = {
     AstReflection: () => new RequirementsAndTestsAstReflection()
 };
 
-export const RequirementsGeneratedModule: Module<LangiumServices, LangiumGeneratedCoreServices> = {
+export const RequirementsGeneratedModule: Module<LangiumCoreServices, LangiumGeneratedCoreServices> = {
     Grammar: () => RequirementsGrammar(),
     LanguageMetaData: () => RequirementsLanguageMetaData,
     parser: {}
 };
 
-export const TestsGeneratedModule: Module<LangiumServices, LangiumGeneratedCoreServices> = {
+export const TestsGeneratedModule: Module<LangiumCoreServices, LangiumGeneratedCoreServices> = {
     Grammar: () => TestsGrammar(),
     LanguageMetaData: () => TestsLanguageMetaData,
     parser: {}

--- a/examples/statemachine/src/language-server/generated/module.ts
+++ b/examples/statemachine/src/language-server/generated/module.ts
@@ -3,8 +3,7 @@
  * DO NOT EDIT MANUALLY!
  ******************************************************************************/
 
-import type { LangiumGeneratedCoreServices, LangiumGeneratedSharedCoreServices, LanguageMetaData, Module } from 'langium';
-import type { LangiumSharedServices, LangiumServices } from 'langium/lsp';
+import type { LangiumSharedCoreServices, LangiumCoreServices, LangiumGeneratedCoreServices, LangiumGeneratedSharedCoreServices, LanguageMetaData, Module } from 'langium';
 import { StatemachineAstReflection } from './ast.js';
 import { StatemachineGrammar } from './grammar.js';
 
@@ -14,11 +13,11 @@ export const StatemachineLanguageMetaData = {
     caseInsensitive: false
 } as const satisfies LanguageMetaData;
 
-export const StatemachineGeneratedSharedModule: Module<LangiumSharedServices, LangiumGeneratedSharedCoreServices> = {
+export const StatemachineGeneratedSharedModule: Module<LangiumSharedCoreServices, LangiumGeneratedSharedCoreServices> = {
     AstReflection: () => new StatemachineAstReflection()
 };
 
-export const StatemachineGeneratedModule: Module<LangiumServices, LangiumGeneratedCoreServices> = {
+export const StatemachineGeneratedModule: Module<LangiumCoreServices, LangiumGeneratedCoreServices> = {
     Grammar: () => StatemachineGrammar(),
     LanguageMetaData: () => StatemachineLanguageMetaData,
     parser: {}

--- a/packages/langium-cli/CHANGELOG.md
+++ b/packages/langium-cli/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log of `langium-cli`
 
+## v3.0.1 (Feb. 2024)
+
+Fixed a minor issue related to generated code for projects that don't use the `langium/lsp` import ([#1393](https://github.com/eclipse-langium/langium/pull/1393)).
+
+## v3.0.0 (Feb. 2024)
+
+Some adjustments of the generated code due to the LSP bundling changes in Langium. For further information, see [here](https://github.com/eclipse-langium/langium/blob/main/packages/langium/CHANGELOG.md#smaller-bundles-with-exports).
+
 ## v2.0.1 (Aug. 2023)
 
 Fix a bug that prevented usage of the JS API of the CLI package ([#1160](https://github.com/eclipse-langium/langium/pull/1160)).

--- a/packages/langium-cli/src/generator/module-generator.ts
+++ b/packages/langium-cli/src/generator/module-generator.ts
@@ -25,16 +25,14 @@ export function generateModule(grammars: Grammar[], config: LangiumConfig, gramm
             import type { LanguageMetaData } from '../../languages/language-meta-data${config.importExtension}';
             import { ${config.projectName}AstReflection } from '../../languages/generated/ast${config.importExtension}';
             import type { Module } from '../../dependency-injection${config.importExtension}';
-            import type { LangiumGeneratedCoreServices, LangiumGeneratedSharedCoreServices } from '../../services${config.importExtension}';
-            import type { LangiumSharedServices, LangiumServices } from '../../lsp/lsp-services${config.importExtension}';
+            import type { LangiumSharedCoreServices, LangiumCoreServices, LangiumGeneratedCoreServices, LangiumGeneratedSharedCoreServices } from '../../services${config.importExtension}';
         `.appendTemplateIf(hasIParserConfigImport)`
 
             import type { IParserConfig } from '../../parser/parser-config${config.importExtension}';
         `
     ).appendTemplateIf(!config.langiumInternal)`
 
-        import type { LangiumGeneratedCoreServices, LangiumGeneratedSharedCoreServices, LanguageMetaData, Module${hasIParserConfigImport ? ', IParserConfig' : ''} } from 'langium';
-        import type { LangiumSharedServices, LangiumServices } from 'langium/lsp';
+        import type { LangiumSharedCoreServices, LangiumCoreServices, LangiumGeneratedCoreServices, LangiumGeneratedSharedCoreServices, LanguageMetaData, Module${hasIParserConfigImport ? ', IParserConfig' : ''} } from 'langium';
         import { ${config.projectName}AstReflection } from './ast${config.importExtension}';
     `.appendTemplate`
 
@@ -79,7 +77,7 @@ export function generateModule(grammars: Grammar[], config: LangiumConfig, gramm
             };
         `}
 
-        export const ${config.projectName}GeneratedSharedModule: Module<LangiumSharedServices, LangiumGeneratedSharedCoreServices> = {
+        export const ${config.projectName}GeneratedSharedModule: Module<LangiumSharedCoreServices, LangiumGeneratedSharedCoreServices> = {
             AstReflection: () => new ${config.projectName}AstReflection()
         };
         ${joinToNode(
@@ -88,7 +86,7 @@ export function generateModule(grammars: Grammar[], config: LangiumConfig, gramm
                 const grammarConfig = grammarConfigMap.get(grammar)!;
                 return expandToNode`
 
-                    export const ${grammar.name}GeneratedModule: Module<LangiumServices, LangiumGeneratedCoreServices> = {
+                    export const ${grammar.name}GeneratedModule: Module<LangiumCoreServices, LangiumGeneratedCoreServices> = {
                         Grammar: () => ${grammar.name}Grammar(),
                         LanguageMetaData: () => ${grammar.name}LanguageMetaData,
                         parser: {${(grammarConfig.chevrotainParserConfig || parserConfig) && expandToNode`

--- a/packages/langium/src/grammar/generated/module.ts
+++ b/packages/langium/src/grammar/generated/module.ts
@@ -6,8 +6,7 @@
 import type { LanguageMetaData } from '../../languages/language-meta-data.js';
 import { LangiumGrammarAstReflection } from '../../languages/generated/ast.js';
 import type { Module } from '../../dependency-injection.js';
-import type { LangiumGeneratedCoreServices, LangiumGeneratedSharedCoreServices } from '../../services.js';
-import type { LangiumSharedServices, LangiumServices } from '../../lsp/lsp-services.js';
+import type { LangiumSharedCoreServices, LangiumCoreServices, LangiumGeneratedCoreServices, LangiumGeneratedSharedCoreServices } from '../../services.js';
 import type { IParserConfig } from '../../parser/parser-config.js';
 import { LangiumGrammarGrammar } from './grammar.js';
 
@@ -21,11 +20,11 @@ export const LangiumGrammarParserConfig: IParserConfig = {
     maxLookahead: 3,
 };
 
-export const LangiumGrammarGeneratedSharedModule: Module<LangiumSharedServices, LangiumGeneratedSharedCoreServices> = {
+export const LangiumGrammarGeneratedSharedModule: Module<LangiumSharedCoreServices, LangiumGeneratedSharedCoreServices> = {
     AstReflection: () => new LangiumGrammarAstReflection()
 };
 
-export const LangiumGrammarGeneratedModule: Module<LangiumServices, LangiumGeneratedCoreServices> = {
+export const LangiumGrammarGeneratedModule: Module<LangiumCoreServices, LangiumGeneratedCoreServices> = {
     Grammar: () => LangiumGrammarGrammar(),
     LanguageMetaData: () => LangiumGrammarLanguageMetaData,
     parser: {


### PR DESCRIPTION
Related to https://github.com/eclipse-langium/langium/issues/1392

Instead of being part of `LangiumServices`, the module should instead be part of `LangiumCoreServices`. Afaik, the current solution is working fine, but using `LangiumCoreServices` is more appropriate.