### PR TITLE
Correctly pass parser error message

### DIFF
--- a/packages/langium/src/serializer/hydrator.ts
+++ b/packages/langium/src/serializer/hydrator.ts
@@ -63,8 +63,8 @@ export class DefaultHydrator implements Hydrator {
         return {
             // We need to create shallow copies of the errors
             // The original errors inherit from the `Error` class, which is not transferable across worker threads
-            lexerErrors: result.lexerErrors.map(e => ({ ...e })),
-            parserErrors: result.parserErrors.map(e => ({ ...e })),
+            lexerErrors: result.lexerErrors.map(e => ({ ...e, message: e.message })),
+            parserErrors: result.parserErrors.map(e => ({ ...e, message: e.message })),
             value: this.dehydrateAstNode(result.value, this.createDehyrationContext(result.value))
         };
     }

--- a/packages/langium/test/parser/worker-thread-async-parser.test.ts
+++ b/packages/langium/test/parser/worker-thread-async-parser.test.ts
@@ -108,6 +108,7 @@ describe('WorkerThreadAsyncParser', () => {
         expect(result.parserErrors).toHaveLength(1);
         expect(result.parserErrors[0].name).toBe('MismatchedTokenException');
         expect(result.parserErrors[0]).toHaveProperty('previousToken');
+        expect(result.parserErrors[0]).toHaveProperty('message', "Expecting token of type ';' but found ``.");
     });
 
     function createLargeFile(size: number): string {


### PR DESCRIPTION
For some reason, copying an error via the spread operator doesn't copy its `message` property. This change ensures that the message property is being copied.