### PR TITLE
feat: validate assignments when calling rules with multiplicity

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5132,9 +5132,9 @@
       }
     },
     "node_modules/ip": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
-      "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.1.tgz",
+      "integrity": "sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ==",
       "optional": true,
       "peer": true
     },
@@ -6260,9 +6260,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.32",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.32.tgz",
-      "integrity": "sha512-D/kj5JNu6oo2EIy+XL/26JEDTlIbB8hw85G8StOE6L74RQAVVP5rej6wxCNqyMbR4RkPfqvezVbPw81Ngd6Kcw==",
+      "version": "8.4.35",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.35.tgz",
+      "integrity": "sha512-u5U8qYpBCpN13BsiEB0CbR1Hhh4Gc0zLFuedrHJKMctHCHAGrMdG0PRM/KErzAL3CU6/eckEtmHNB3x6e3c0vA==",
       "dev": true,
       "funding": [
         {
@@ -7406,13 +7406,13 @@
       }
     },
     "node_modules/vite": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.0.8.tgz",
-      "integrity": "sha512-jYMALd8aeqR3yS9xlHd0OzQJndS9fH5ylVgWdB+pxTwxLKdO1pgC5Dlb398BUxpfaBxa4M9oT7j1g503Gaj5IQ==",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.1.4.tgz",
+      "integrity": "sha512-n+MPqzq+d9nMVTKyewqw6kSt+R3CkvF9QAKY8obiQn8g1fwTscKxyfaYnC632HtBXAQGc1Yjomphwn1dtwGAHg==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.19.3",
-        "postcss": "^8.4.32",
+        "postcss": "^8.4.35",
         "rollup": "^4.2.0"
       },
       "bin": {

--- a/packages/langium/src/grammar/validation/validator.ts
+++ b/packages/langium/src/grammar/validation/validator.ts
@@ -687,10 +687,11 @@ export class LangiumGrammarValidator {
             }
             return result;
         };
+        const isNotAFragment = call.rule.ref !== undefined && !call.rule.ref.fragment;
         const appearsMultipleTimes = findContainerWithCardinality(call) !== undefined;
         const hasAssignment = call.$container && call.$container.$type === ast.Assignment;
 
-        if (appearsMultipleTimes && !hasAssignment) {
+        if (appearsMultipleTimes && !hasAssignment && isNotAFragment) {
             accept('error', `Rule call ${call.rule.$refText} requires assignment when used with multiplicity.`, {
                 node: call,
                 property: 'cardinality'

--- a/packages/langium/test/grammar/grammar-validator.test.ts
+++ b/packages/langium/test/grammar/grammar-validator.test.ts
@@ -145,6 +145,29 @@ describe('Langium grammar validation', () => {
         expect(validationResult.diagnostics).toHaveLength(1);
         expect(validationResult.diagnostics[0].data?.code).toBe(IssueCodes.InvalidInfers);
     });
+
+    test('Rule calls with multiplicity have assignment', async () => {
+        const grammar = `
+            grammar RuleCallMult
+
+            entry List1:
+                '(' Mult (',' Mult)* ')';
+            List2:
+                Plus+;
+    
+            Mult: content=ID;
+            Plus: content=ID;
+            terminal ID: /[_a-zA-Z][\\w_]*/;
+        `.trim();
+
+        const validationResult = await validate(grammar);
+        expectError(validationResult, 'Rule call Mult requires assignment when used with multiplicity.', {
+            property: 'cardinality'
+        });
+        expectError(validationResult, 'Rule call Plus requires assignment when used with multiplicity.', {
+            property: 'cardinality'
+        });
+    });
 });
 
 describe('Data type rule return type', () => {
@@ -315,7 +338,9 @@ describe('Check grammar with primitives', () => {
     const grammar = `
     grammar PrimGrammar
     entry Expr:
-        (Word | Bool | Num | LargeInt | DateObj)*;
+        primitives=Primitive*;
+    Primitive:
+        (Word | Bool | Num | LargeInt | DateObj);
     Word:
         'Word' val=STR;
     Bool:

--- a/packages/langium/test/grammar/grammar-validator.test.ts
+++ b/packages/langium/test/grammar/grammar-validator.test.ts
@@ -148,19 +148,24 @@ describe('Langium grammar validation', () => {
 
     test('Rule calls with multiplicity have assignment', async () => {
         const grammar = `
-            grammar RuleCallMult
+        grammar RuleCallMult
 
-            entry List1:
-                '(' Mult (',' Mult)* ')';
-            List2:
-                Plus+;
-    
-            Mult: content=ID;
-            Plus: content=ID;
-            terminal ID: /[_a-zA-Z][\\w_]*/;
+        entry List1:
+            '(' Mult (',' Mult)* ')' '/' List2 '/' List3;
+        List2:
+            Plus+;
+        List3:
+            Exp+;
+        
+        Mult: content=ID;
+        Plus: content=ID;
+        fragment Exp: content+=ID;
+        
+        terminal ID: /[_a-zA-Z][\\w_]*/;
         `.trim();
 
         const validationResult = await validate(grammar);
+        expect(validationResult.diagnostics).to.have.length(2);
         expectError(validationResult, 'Rule call Mult requires assignment when used with multiplicity.', {
             property: 'cardinality'
         });


### PR DESCRIPTION
Closes #1246:

Adds a new validation rule for rule calls. It looks up an enclosing container with multiplicity, and then demands that an assignment occurs for said call.