### PR TITLE
Initialize configuration provider when creating services outside a language server

### DIFF
--- a/examples/arithmetics/src/language-server/arithmetics-module.ts
+++ b/examples/arithmetics/src/language-server/arithmetics-module.ts
@@ -69,5 +69,10 @@ export function createArithmeticsServices(context: DefaultSharedModuleContext): 
     );
     shared.ServiceRegistry.register(arithmetics);
     registerValidationChecks(arithmetics);
+    if (!context.connection) {
+        // We don't run inside a language server
+        // Therefore, initialize the configuration provider instantly
+        shared.workspace.ConfigurationProvider.initialized({});
+    }
     return { shared, arithmetics };
 }

--- a/examples/domainmodel/src/language-server/domain-model-module.ts
+++ b/examples/domainmodel/src/language-server/domain-model-module.ts
@@ -54,5 +54,10 @@ export function createDomainModelServices(context: DefaultSharedModuleContext): 
     );
     shared.ServiceRegistry.register(domainmodel);
     registerValidationChecks(domainmodel);
+    if (!context.connection) {
+        // We don't run inside a language server
+        // Therefore, initialize the configuration provider instantly
+        shared.workspace.ConfigurationProvider.initialized({});
+    }
     return { shared, domainmodel };
 }

--- a/examples/requirements/src/language-server/requirements-and-tests-lang-module.ts
+++ b/examples/requirements/src/language-server/requirements-and-tests-lang-module.ts
@@ -52,5 +52,10 @@ export function createRequirementsAndTestsLangServices(context: DefaultSharedMod
     shared.ServiceRegistry.register(tests);
     registerRequirementsValidationChecks(requirements);
     registerTestsValidationChecks(tests);
+    if (!context.connection) {
+        // We don't run inside a language server
+        // Therefore, initialize the configuration provider instantly
+        shared.workspace.ConfigurationProvider.initialized({});
+    }
     return { shared, requirements, tests };
 }

--- a/examples/statemachine/src/language-server/statemachine-module.ts
+++ b/examples/statemachine/src/language-server/statemachine-module.ts
@@ -66,5 +66,10 @@ export function createStatemachineServices(context: DefaultSharedModuleContext):
     );
     shared.ServiceRegistry.register(statemachine);
     registerValidationChecks(statemachine);
+    if (!context.connection) {
+        // We don't run inside a language server
+        // Therefore, initialize the configuration provider instantly
+        shared.workspace.ConfigurationProvider.initialized({});
+    }
     return { shared, statemachine };
 }

--- a/packages/generator-langium/templates/core/src/language/language-id-module.ts
+++ b/packages/generator-langium/templates/core/src/language/language-id-module.ts
@@ -59,5 +59,10 @@ export function create<%= LanguageName %>Services(context: DefaultSharedModuleCo
     );
     shared.ServiceRegistry.register(<%= LanguageName %>);
     registerValidationChecks(<%= LanguageName %>);
+    if (!context.connection) {
+        // We don't run inside a language server
+        // Therefore, initialize the configuration provider instantly
+        shared.workspace.ConfigurationProvider.initialized({});
+    }
     return { shared, <%= LanguageName %> };
 }

--- a/packages/langium/src/grammar/langium-grammar-module.ts
+++ b/packages/langium/src/grammar/langium-grammar-module.ts
@@ -93,6 +93,12 @@ export function createLangiumGrammarServices(context: DefaultSharedModuleContext
     registerValidationChecks(grammar);
     registerTypeValidationChecks(grammar);
 
+    if (!context.connection) {
+        // We don't run inside a language server
+        // Therefore, initialize the configuration provider instantly
+        shared.workspace.ConfigurationProvider.initialized({});
+    }
+
     return { shared, grammar };
 }
 

--- a/packages/langium/test/workspace/configuration.test.ts
+++ b/packages/langium/test/workspace/configuration.test.ts
@@ -14,7 +14,6 @@ describe('ConfigurationProvider', () => {
     const grammarServices = createLangiumGrammarServices(EmptyFileSystem).grammar;
     const langId = grammarServices.LanguageMetaData.languageId;
     const configs = grammarServices.shared.workspace.ConfigurationProvider;
-    configs.initialized({});
     beforeEach(() => {
         (configs as any).settings = {};
     });


### PR DESCRIPTION
Closes #1397 

The function `create<Language>Services` that gets created from the Yeoman template now initializes the configuration provider immediately if called outside a language server. Previously, each caller (CLI/tests) had to take care of this before working with the configuration provider.

Existing projects must be updated manually.