### PR TITLE
Implemented option for parsing text with an alternative entry rule

### DIFF
--- a/packages/langium/src/parser/langium-parser.ts
+++ b/packages/langium/src/parser/langium-parser.ts
@@ -131,6 +131,10 @@ export abstract class AbstractLangiumParser implements BaseParser {
     }
 }
 
+export interface ParserOptions {
+    rule?: string
+}
+
 export class LangiumParser extends AbstractLangiumParser {
     private readonly linker: Linker;
     private readonly converter: ValueConverter;
@@ -160,7 +164,7 @@ export class LangiumParser extends AbstractLangiumParser {
         return ruleMethod;
     }
 
-    parse<T extends AstNode = AstNode>(input: string, options: { rule?: string } = {}): ParseResult<T> {
+    parse<T extends AstNode = AstNode>(input: string, options: ParserOptions = {}): ParseResult<T> {
         this.nodeBuilder.buildRootNode(input);
         const lexerResult = this.lexer.tokenize(input);
         this.wrapper.input = lexerResult.tokens;

--- a/packages/langium/src/parser/parser-builder-base.ts
+++ b/packages/langium/src/parser/parser-builder-base.ts
@@ -26,7 +26,6 @@ type RuleContext = {
 type ParserContext = {
     parser: BaseParser
     tokens: TokenTypeDictionary
-    rules: Map<string, Rule>
     ruleNames: Map<AstNode, string>
 }
 
@@ -39,11 +38,9 @@ type Predicate = (args: Args) => boolean;
 type Method = (args: Args) => void;
 
 export function createParser<T extends BaseParser>(grammar: Grammar, parser: T, tokens: TokenTypeDictionary): T {
-    const rules = new Map<string, Rule>();
     const parserContext: ParserContext = {
         parser,
         tokens,
-        rules,
         ruleNames: new Map()
     };
     buildRules(parserContext, grammar);
@@ -62,10 +59,7 @@ function buildRules(parserContext: ParserContext, grammar: Grammar): void {
             many: 1,
             or: 1
         };
-        ctx.rules.set(
-            rule.name,
-            parserContext.parser.rule(rule, buildElement(ctx, rule.definition))
-        );
+        parserContext.parser.rule(rule, buildElement(ctx, rule.definition));
     }
 }
 
@@ -369,7 +363,7 @@ function wrap(ctx: RuleContext, guard: Condition | undefined, method: Method, ca
 
 function getRule(ctx: ParserContext, element: ParserRule | AbstractElement): Rule {
     const name = getRuleName(ctx, element);
-    const rule = ctx.rules.get(name);
+    const rule = ctx.parser.getRule(name);
     if (!rule) throw new Error(`Rule "${name}" not found."`);
     return rule;
 }

--- a/packages/langium/test/parser/langium-parser.test.ts
+++ b/packages/langium/test/parser/langium-parser.test.ts
@@ -4,40 +4,41 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import type { LangiumParser } from 'langium';
+import type { AstNode, LangiumCoreServices } from 'langium';
 import { describe, expect, test, beforeEach } from 'vitest';
-import { createServicesForGrammar } from 'langium/grammar';
+import { createServicesForGrammar  } from 'langium/grammar';
+import { parseHelper  } from 'langium/test';
 
 describe('Partial parsing', () => {
     const content = `
     grammar Test
-    entry Model: (a+=A | b+=B)*;
+    entry Model: 'model' (a+=A | b+=B)*;
     A: 'a' name=ID;
     B: 'b' name=ID;
     terminal ID: /[_a-zA-Z][\\w_]*/;
     hidden terminal WS: /\\s+/;
     `;
 
-    let parser: LangiumParser;
+    let services: LangiumCoreServices;
 
     beforeEach(async () => {
-        parser = await parserFromGrammar(content);
+        services = await createServicesForGrammar({ grammar: content });
     });
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     function expectCorrectParse(text: string, rule?: string): any {
-        const result = parser.parse(text, { rule });
+        const result = services.parser.LangiumParser.parse(text, { rule });
         expect(result.parserErrors.length).toBe(0);
         return result.value;
     }
 
     function expectErrorneousParse(text: string, rule?: string): void {
-        const result = parser.parse(text, { rule });
+        const result = services.parser.LangiumParser.parse(text, { rule });
         expect(result.parserErrors.length).toBeGreaterThan(0);
     }
 
     test('Should parse correctly with normal entry rule', () => {
-        const result = expectCorrectParse('a Foo b Bar');
+        const result = expectCorrectParse('model a Foo b Bar');
         expect(result.a[0].name).toEqual('Foo');
         expect(result.b[0].name).toEqual('Bar');
     });
@@ -45,16 +46,26 @@ describe('Partial parsing', () => {
     test('Should parse correctly with alternative entry rule A', () => {
         const result = expectCorrectParse('a Foo', 'A');
         expect(result.name).toEqual('Foo');
+        expectErrorneousParse('model a Foo', 'A');
         expectErrorneousParse('b Bar', 'A');
     });
 
     test('Should parse correctly with alternative entry rule B', () => {
         const result = expectCorrectParse('b Foo', 'B');
         expect(result.name).toEqual('Foo');
+        expectErrorneousParse('model b Foo', 'B');
         expectErrorneousParse('a Foo', 'B');
     });
+
+    test('Parse helper supports using alternative entry rule A', async () => {
+        const parse = parseHelper<A>(services);
+        const document = await parse('a Foo', { parserOptions: { rule: 'A' } });
+        expect(document.parseResult.parserErrors.length).toBe(0);
+        expect(document.parseResult.value.name).toEqual('Foo');
+    });
+
 });
 
-async function parserFromGrammar(grammar: string): Promise<LangiumParser> {
-    return (await createServicesForGrammar({ grammar })).parser.LangiumParser;
+interface A extends AstNode {
+    name: string
 }

--- a/packages/langium/test/parser/langium-parser.test.ts
+++ b/packages/langium/test/parser/langium-parser.test.ts
@@ -1,0 +1,60 @@
+/******************************************************************************
+ * Copyright 2024 TypeFox GmbH
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License, which is available in the project root.
+ ******************************************************************************/
+
+import type { LangiumParser } from 'langium';
+import { describe, expect, test, beforeEach } from 'vitest';
+import { createServicesForGrammar } from 'langium/grammar';
+
+describe('Partial parsing', () => {
+    const content = `
+    grammar Test
+    entry Model: (a+=A | b+=B)*;
+    A: 'a' name=ID;
+    B: 'b' name=ID;
+    terminal ID: /[_a-zA-Z][\\w_]*/;
+    hidden terminal WS: /\\s+/;
+    `;
+
+    let parser: LangiumParser;
+
+    beforeEach(async () => {
+        parser = await parserFromGrammar(content);
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    function expectCorrectParse(text: string, rule?: string): any {
+        const result = parser.parse(text, { rule });
+        expect(result.parserErrors.length).toBe(0);
+        return result.value;
+    }
+
+    function expectErrorneousParse(text: string, rule?: string): void {
+        const result = parser.parse(text, { rule });
+        expect(result.parserErrors.length).toBeGreaterThan(0);
+    }
+
+    test('Should parse correctly with normal entry rule', () => {
+        const result = expectCorrectParse('a Foo b Bar');
+        expect(result.a[0].name).toEqual('Foo');
+        expect(result.b[0].name).toEqual('Bar');
+    });
+
+    test('Should parse correctly with alternative entry rule A', () => {
+        const result = expectCorrectParse('a Foo', 'A');
+        expect(result.name).toEqual('Foo');
+        expectErrorneousParse('b Bar', 'A');
+    });
+
+    test('Should parse correctly with alternative entry rule B', () => {
+        const result = expectCorrectParse('b Foo', 'B');
+        expect(result.name).toEqual('Foo');
+        expectErrorneousParse('a Foo', 'B');
+    });
+});
+
+async function parserFromGrammar(grammar: string): Promise<LangiumParser> {
+    return (await createServicesForGrammar({ grammar })).parser.LangiumParser;
+}


### PR DESCRIPTION
See discussion #1404. This PR adds an option to `LangiumParser` so one can change the entry rule used for parsing a given text.