### PR TITLE
Validation for assignments with `=` instead of `+=`

### DIFF
--- a/packages/langium/src/grammar/validation/validator.ts
+++ b/packages/langium/src/grammar/validation/validator.ts
@@ -856,10 +856,11 @@ export class LangiumGrammarValidator {
         }
 
         // look for assignments to the same feature within groups
-        if (ast.isGroup(currentContainer) || ast.isUnorderedGroup(currentContainer)) {
+        if (ast.isGroup(currentContainer) || ast.isUnorderedGroup(currentContainer) || ast.isAlternatives(currentContainer)) {
             let countGroup = 0;
             let foundRelevantChild = false;
             for (const child of currentContainer.elements) {
+                // special case: Actions
                 if (child === relevantChild) {
                     foundRelevantChild = true;
                 }
@@ -878,37 +879,18 @@ export class LangiumGrammarValidator {
                         break;
                     }
                 }
-                countGroup += this.searchAssignmentsRecursivelyDown(child, undefined, featureName);
+
+                // count the relevant child assignments
+                const countCurrent = this.searchAssignmentsRecursivelyDown(child, undefined, featureName);
+                if (ast.isAlternatives(currentContainer)) {
+                    // for alternatives, only a single alternative is used => assume the worst case and take the maximum number of assignments
+                    countGroup = Math.max(countGroup, countCurrent);
+                } else {
+                    // all members of the group are relavant => count them all
+                    countGroup += countCurrent;
+                }
             }
             countResult += countGroup;
-        }
-        // look for assignments to the same feature within alternatives
-        if (ast.isAlternatives(currentContainer)) {
-            // TODO 2x if vereinheitlichen!
-            let countAlternatives = 0;
-            let foundRelevantChild = false;
-            for (const child of currentContainer.elements) {
-                if (child === relevantChild) {
-                    foundRelevantChild = true;
-                }
-                if (ast.isAction(child)) {
-                    // a new object is created => following assignments are put into the new object
-                    if (relevantChild) {
-                        if (foundRelevantChild) {
-                            // the assignment to check
-                            break; //  => break the for-loop here, since all following assignments are put into the new object
-                        } else {
-                            containerMultiplicityMatters = false;
-                            countAlternatives = 0;
-                        }
-                    } else {
-                        // 
-                        break;
-                    }
-                }
-                countAlternatives = Math.max(countAlternatives, this.searchAssignmentsRecursivelyDown(child, undefined, featureName));
-            }
-            countResult += countAlternatives;
         }
 
         // the current element can occur multiple times => its assignments occur multiple times as well

--- a/packages/langium/src/grammar/validation/validator.ts
+++ b/packages/langium/src/grammar/validation/validator.ts
@@ -816,10 +816,11 @@ export class LangiumGrammarValidator {
     }
 
     private searchAssignmentsRecursivelyUp(node: AstNode, assignment: ast.Assignment, accept: ValidationAcceptor): boolean {
-        let currentElement: AstNode | undefined = node;
-        while (currentElement) {
+        let currentContainer: AstNode | undefined = node;
+        let previousChild: AstNode | undefined = undefined;
+        while (currentContainer) {
             // check neighbored and nested assignments
-            const countAssignments = this.searchAssignmentsRecursivelyDown(currentElement, assignment.feature);
+            const countAssignments = this.searchAssignmentsRecursivelyDown(currentContainer, previousChild, assignment.feature);
             if (countAssignments >= 2) {
                 accept(
                     'warning',
@@ -830,38 +831,88 @@ export class LangiumGrammarValidator {
             }
 
             // check the next container
-            currentElement = currentElement.$container;
+            previousChild = currentContainer;
+            currentContainer = currentContainer.$container;
         }
         return false;
     }
 
-    private searchAssignmentsRecursivelyDown(node: AstNode, featureName: string): number {
+    private searchAssignmentsRecursivelyDown(currentContainer: AstNode, relevantChild: AstNode | undefined, featureName: string): number {
         let countResult = 0;
+        let containerMultiplicityMatters = true;
+
         // assignment
-        if (ast.isAssignment(node) && node.feature === featureName) {
+        if (ast.isAssignment(currentContainer) && currentContainer.feature === featureName) {
             countResult += 1;
         }
         // search for assignments in used fragments as well, since their property values are stored in the current object,
         // but not in calls of regular parser rules, since they create new objects
-        if (ast.isRuleCall(node) && ast.isParserRule(node.rule.ref) && node.rule.ref.fragment) {
-            countResult += this.searchAssignmentsRecursivelyDown(node.rule.ref.definition, featureName);
+        if (ast.isRuleCall(currentContainer) && ast.isParserRule(currentContainer.rule.ref) && currentContainer.rule.ref.fragment) {
+            countResult += this.searchAssignmentsRecursivelyDown(currentContainer.rule.ref.definition, undefined, featureName);
         }
+        // TODO test this special assignment!
+        if (ast.isAction(currentContainer) && currentContainer.feature === featureName) {
+            countResult++;
+        }
+
         // look for assignments to the same feature within groups
-        if (ast.isGroup(node) || ast.isUnorderedGroup(node)) {
-            for (const child of node.elements) {
-                countResult += this.searchAssignmentsRecursivelyDown(child, featureName);
+        if (ast.isGroup(currentContainer) || ast.isUnorderedGroup(currentContainer)) {
+            let countGroup = 0;
+            let foundRelevantChild = false;
+            for (const child of currentContainer.elements) {
+                if (child === relevantChild) {
+                    foundRelevantChild = true;
+                }
+                if (ast.isAction(child)) {
+                    // a new object is created => following assignments are put into the new object
+                    if (relevantChild) {
+                        if (foundRelevantChild) {
+                            // the previous assignments are put into the same object as the given relevant child => ignore the following assignments to the new object
+                            break;
+                        } else {
+                            // 
+                            containerMultiplicityMatters = false; // since an additional object is created for each time, */+ around the current group don't matter!
+                            countGroup = 0;
+                        }
+                    } else {
+                        break;
+                    }
+                }
+                countGroup += this.searchAssignmentsRecursivelyDown(child, undefined, featureName);
             }
+            countResult += countGroup;
         }
         // look for assignments to the same feature within alternatives
-        if (ast.isAlternatives(node)) {
-            let alternativeCount = 0;
-            for (const child of node.elements) {
-                alternativeCount = Math.max(alternativeCount, this.searchAssignmentsRecursivelyDown(child, featureName));
+        if (ast.isAlternatives(currentContainer)) {
+            // TODO 2x if vereinheitlichen!
+            let countAlternatives = 0;
+            let foundRelevantChild = false;
+            for (const child of currentContainer.elements) {
+                if (child === relevantChild) {
+                    foundRelevantChild = true;
+                }
+                if (ast.isAction(child)) {
+                    // a new object is created => following assignments are put into the new object
+                    if (relevantChild) {
+                        if (foundRelevantChild) {
+                            // the assignment to check
+                            break; //  => break the for-loop here, since all following assignments are put into the new object
+                        } else {
+                            containerMultiplicityMatters = false;
+                            countAlternatives = 0;
+                        }
+                    } else {
+                        // 
+                        break;
+                    }
+                }
+                countAlternatives = Math.max(countAlternatives, this.searchAssignmentsRecursivelyDown(child, undefined, featureName));
             }
-            countResult += alternativeCount;
+            countResult += countAlternatives;
         }
+
         // the current element can occur multiple times => its assignments occur multiple times as well
-        if (ast.isAbstractElement(node) && isArrayCardinality(node.cardinality)) {
+        if (containerMultiplicityMatters && ast.isAbstractElement(currentContainer) && isArrayCardinality(currentContainer.cardinality)) {
             countResult *= 2; // note, that the result is not exact (but it is sufficient for the current case)!
         }
         return countResult;

--- a/packages/langium/src/grammar/validation/validator.ts
+++ b/packages/langium/src/grammar/validation/validator.ts
@@ -4,23 +4,23 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
+import type { Range } from 'vscode-languageserver-types';
+import { DiagnosticTag } from 'vscode-languageserver-types';
+import * as ast from '../../languages/generated/ast.js';
 import type { NamedAstNode } from '../../references/name-provider.js';
 import type { References } from '../../references/references.js';
 import type { AstNode, Properties, Reference } from '../../syntax-tree.js';
-import type { Stream } from '../../utils/stream.js';
-import type { DiagnosticData, ValidationAcceptor, ValidationChecks } from '../../validation/validation-registry.js';
-import type { LangiumDocuments } from '../../workspace/documents.js';
-import type { LangiumGrammarServices } from '../langium-grammar-module.js';
-import type { Range } from 'vscode-languageserver-types';
-import { DiagnosticTag } from 'vscode-languageserver-types';
 import { getContainerOfType, streamAllContents } from '../../utils/ast-utils.js';
 import { MultiMap } from '../../utils/collections.js';
 import { toDocumentSegment } from '../../utils/cst-utils.js';
-import { findNameAssignment, findNodeForKeyword, findNodeForProperty, getAllReachableRules, isDataTypeRule, isOptionalCardinality, terminalRegex } from '../../utils/grammar-utils.js';
+import { findNameAssignment, findNodeForKeyword, findNodeForProperty, getAllReachableRules, isArrayCardinality, isDataTypeRule, isOptionalCardinality, terminalRegex } from '../../utils/grammar-utils.js';
+import type { Stream } from '../../utils/stream.js';
 import { stream } from '../../utils/stream.js';
+import type { DiagnosticData, ValidationAcceptor, ValidationChecks } from '../../validation/validation-registry.js';
 import { diagnosticData } from '../../validation/validation-registry.js';
-import * as ast from '../../languages/generated/ast.js';
+import type { LangiumDocuments } from '../../workspace/documents.js';
 import { getTypeNameWithoutError, hasDataTypeReturn, isPrimitiveGrammarType, isStringGrammarType, resolveImport, resolveTransitiveImports } from '../internal-grammar-util.js';
+import type { LangiumGrammarServices } from '../langium-grammar-module.js';
 import { typeDefinitionToPropertyType } from '../type-system/type-collector/declared-types.js';
 import { flattenPlainType, isPlainReferenceType } from '../type-system/type-collector/plain-types.js';
 
@@ -788,38 +788,55 @@ export class LangiumGrammarValidator {
 
     checkAssignmentOperator(assignment: ast.Assignment, accept: ValidationAcceptor): void {
         // this validation is specific for assignments with '=' as assignment operator
-        if (assignment.operator !== '=') {
-            return;
-        }
-        // the assignment has a multi-value cardinality itself
-        if (this.isMany(assignment)) {
-            this.markAssignment(assignment, accept);
-            return;
-        }
-        // check the container group of the assignment
-        if (ast.isGroup(assignment.$container) || ast.isUnorderedGroup(assignment.$container)) {
-            // the group can occur multiple times
-            if (this.isMany(assignment.$container)) {
-                this.markAssignment(assignment, accept);
-                return;
-            }
-            // look for at least a second assignments to the same feature within the container group, the cardinality does not matter
-            if (assignment.$container.elements.filter(child => ast.isAssignment(child) && child.feature === assignment.feature).length >= 2) {
-                this.markAssignment(assignment, accept);
-                return;
+        if (assignment.operator === '=') {
+            // check the initial assignment and all of its containers
+            let currentElement: AstNode | undefined = assignment;
+            while (currentElement) {
+                const countAssignments = this.searchAssignmentsRecursively(currentElement, assignment.feature);
+                if (countAssignments >= 2) {
+                    accept(
+                        'warning',
+                        `It seems, that you assign multiple values to the feature '${assignment.feature}', while you are using '=' as assignment operator. Consider to use '+=' instead in order not to loose some of the assigned value.`,
+                        { node: assignment, property: 'operator' }
+                    );
+                    return;
+                }
+                // check the next container
+                currentElement = currentElement.$container;
             }
         }
-        // TODO more cases
     }
-    private isMany(node: AstNode): boolean {
-        return ast.isAbstractElement(node) && (node.cardinality === '*' || node.cardinality === '+');
-    }
-    private markAssignment(assignment: ast.Assignment, accept: ValidationAcceptor): void {
-        accept(
-            'warning',
-            `It seems, that you assign multiple values to the feature '${assignment.feature}', while you are using '=' as assignment operator. Consider to use '+=' instead in order not to loose some of the assigned value.`,
-            { node: assignment, property: 'operator' }
-        );
+
+    private searchAssignmentsRecursively(node: AstNode, featureName: string): number {
+        let countResult = 0;
+        // assignment
+        if (ast.isAssignment(node) && node.feature === featureName) {
+            countResult += 1;
+        }
+        // search for assignments in used fragments as well, since their property values are stored in the current object,
+        // but not in calls of regular parser rules, since they create new objects
+        if (ast.isRuleCall(node) && ast.isParserRule(node.rule.ref) && node.rule.ref.fragment) {
+            countResult += this.searchAssignmentsRecursively(node.rule.ref.definition, featureName);
+        }
+        // look for assignments to the same feature within groups
+        if (ast.isGroup(node) || ast.isUnorderedGroup(node)) {
+            for (const child of node.elements) {
+                countResult += this.searchAssignmentsRecursively(child, featureName);
+            }
+        }
+        // look for assignments to the same feature within alternatives
+        if (ast.isAlternatives(node)) {
+            let alternativeCount = 0;
+            for (const child of node.elements) {
+                alternativeCount = Math.max(alternativeCount, this.searchAssignmentsRecursively(child, featureName));
+            }
+            countResult += alternativeCount;
+        }
+        // the current element can occur multiple times => its assignments occur multiple times as well
+        if (ast.isAbstractElement(node) && isArrayCardinality(node.cardinality)) {
+            countResult *= 2; // note, that the result is not exact (but it is sufficient for the current case)!
+        }
+        return countResult;
     }
 
     checkInterfacePropertyTypes(interfaceDecl: ast.Interface, accept: ValidationAcceptor): void {

--- a/packages/langium/src/grammar/validation/validator.ts
+++ b/packages/langium/src/grammar/validation/validator.ts
@@ -36,6 +36,7 @@ export function registerValidationChecks(services: LangiumGrammarServices): void
             validator.checkAssignmentWithFeatureName,
             validator.checkAssignmentToFragmentRule,
             validator.checkAssignmentTypes,
+            validator.checkAssignmentOperator,
             validator.checkAssignmentReservedName
         ],
         ParserRule: [
@@ -782,6 +783,20 @@ export class LangiumGrammarValidator {
                     property: 'terminal'
                 }
             );
+        }
+    }
+
+    checkAssignmentOperator(assignment: ast.Assignment, accept: ValidationAcceptor): void {
+        if (assignment.operator === '=') {
+            // the assignment has a multi-value cardinality
+            if (assignment.cardinality === '*' || assignment.cardinality === '+') {
+                accept(
+                    'warning',
+                    `It seems, that you assign multiple values to the feature '${assignment.feature}', while you are using '=' as assignment operator. Consider to use '+=' instead in order not to loose some of the assigned value.`,
+                    { node: assignment, property: 'operator' }
+                );
+            }
+            // TODO more cases
         }
     }
 

--- a/packages/langium/src/grammar/validation/validator.ts
+++ b/packages/langium/src/grammar/validation/validator.ts
@@ -31,6 +31,7 @@ export function registerValidationChecks(services: LangiumGrammarServices): void
     const checks: ValidationChecks<ast.LangiumGrammarAstType> = {
         Action: [
             validator.checkAssignmentReservedName,
+            validator.checkActionOperator,
         ],
         AbstractRule: validator.checkRuleName,
         Assignment: [
@@ -789,25 +790,39 @@ export class LangiumGrammarValidator {
         }
     }
 
+    /** This validation is specific for assignments with '=' as assignment operator and checks,
+     * whether the operator should be '+=' instead. */
     checkAssignmentOperator(assignment: ast.Assignment, accept: ValidationAcceptor): void {
-        // this validation is specific for assignments with '=' as assignment operator
         if (assignment.operator === '=') {
-            // check the initial assignment and all of its containers
-            const reportedProblem = this.searchAssignmentsRecursivelyUp(assignment, assignment, accept);
+            this.checkAssignable(assignment, accept);
+        }
+    }
 
-            // check a special case: the current assignment is located within a fragment => check, whether the fragment is called multiple times
-            if (!reportedProblem) {
-                const containerFragment = getContainerOfType(assignment, ast.isParserRule);
-                if (containerFragment && containerFragment.fragment) {
-                    // for all calls of the fragment ...
-                    for (const ref of this.references.findReferences(containerFragment, {})) {
-                        const doc = this.documents.getDocument(ref.sourceUri);
-                        const call = doc ? this.nodeLocator.getAstNode(doc.parseResult.value, ref.sourcePath) : undefined;
-                        if (call) {
-                            // ... check whether there are multiple assignments to the same feature
-                            if (this.searchAssignmentsRecursivelyUp(call, assignment, accept)) {
-                                return;
-                            }
+    /** This validation is specific for rewriting actions with '=' as assignment operator and checks,
+     * whether the operator of the (rewriting) assignment should be '+=' instead. */
+    checkActionOperator(action: ast.Action, accept: ValidationAcceptor): void {
+        if (action.operator === '=' && action.feature) {
+            this.checkAssignable(action, accept);
+        }
+    }
+
+    private checkAssignable(assignment: ast.Assignment | ast.Action, accept: ValidationAcceptor): void {
+        // check the initial assignment and all of its containers
+        const reportedProblem = this.searchRecursivelyUpForAssignments(assignment, assignment, accept);
+
+        // check a special case: the current assignment is located within a fragment
+        // => check, whether the fragment is called multiple times by parser rules
+        if (!reportedProblem) {
+            const containerFragment = getContainerOfType(assignment, ast.isParserRule);
+            if (containerFragment && containerFragment.fragment) {
+                // for all callers of the fragment ...
+                for (const callerReference of this.references.findReferences(containerFragment, {})) {
+                    const document = this.documents.getDocument(callerReference.sourceUri);
+                    const callingNode = document ? this.nodeLocator.getAstNode(document.parseResult.value, callerReference.sourcePath) : undefined;
+                    if (callingNode) {
+                        // ... check whether there are multiple assignments to the same feature
+                        if (this.searchRecursivelyUpForAssignments(callingNode, assignment, accept)) {
+                            return;
                         }
                     }
                 }
@@ -815,12 +830,19 @@ export class LangiumGrammarValidator {
         }
     }
 
-    private searchAssignmentsRecursivelyUp(node: AstNode, assignment: ast.Assignment, accept: ValidationAcceptor): boolean {
-        let currentContainer: AstNode | undefined = node;
-        let previousChild: AstNode | undefined = undefined;
+    /**
+     * Searches in the given start node and its containers for assignments to the same feature as the given assignment xor action.
+     * @param startNode the node to start the search
+     * @param assignment the assignment for which "conflicting" assigments shall be searched
+     * @param accept acceptor for warnings
+     * @returns true, if the given assignment got a warning, false otherwise
+     */
+    private searchRecursivelyUpForAssignments(startNode: AstNode, assignment: ast.Assignment | ast.Action, accept: ValidationAcceptor): boolean {
+        let currentContainer: AstNode | undefined = startNode; // the current node to search in
+        let previousChild: AstNode | undefined = undefined; // remember the previous node, which is now a direct child of the current container
         while (currentContainer) {
             // check neighbored and nested assignments
-            const countAssignments = this.searchAssignmentsRecursivelyDown(currentContainer, previousChild, assignment.feature);
+            const countAssignments = this.searchRecursivelyDownForAssignments(currentContainer, previousChild, assignment.feature!);
             if (countAssignments >= 2) {
                 accept(
                     'warning',
@@ -837,52 +859,73 @@ export class LangiumGrammarValidator {
         return false;
     }
 
-    private searchAssignmentsRecursivelyDown(currentContainer: AstNode, relevantChild: AstNode | undefined, featureName: string): number {
+    /**
+     * Searches in the given current node and its contained nodes for assignments with the given feature name.
+     * @param currentNode the element whose assignments should be (recursively) counted
+     * @param relevantChild if given, this node is a direct child of the given 'currentNode'
+     * and is required in case of Actions contained in the 'currentNode' to identify which assignments are relevant and which not,
+     * depending on the positions of the Action and the 'relevantChild',
+     * i.e. only assignments to the same object which contains the given 'relevantChild' matter.
+     * @param featureName the feature name of assignments to search for
+     * @returns the number of found assignments with the given name,
+     * note, that the returned number is not exact and "estimates the potential number",
+     * i.e. multiplicities like + and * are counted as 2x/twice,
+     * and for alternatives, the worst case is assumed.
+     * In other words, here it is enough to know, whether there are two or more assignments possible to the same feature.
+     */
+    private searchRecursivelyDownForAssignments(currentNode: AstNode, relevantChild: AstNode | undefined, featureName: string): number {
         let countResult = 0;
         let containerMultiplicityMatters = true;
 
         // assignment
-        if (ast.isAssignment(currentContainer) && currentContainer.feature === featureName) {
+        if (ast.isAssignment(currentNode) && currentNode.feature === featureName) {
             countResult += 1;
         }
-        // search for assignments in used fragments as well, since their property values are stored in the current object,
-        // but not in calls of regular parser rules, since they create new objects
-        if (ast.isRuleCall(currentContainer) && ast.isParserRule(currentContainer.rule.ref) && currentContainer.rule.ref.fragment) {
-            countResult += this.searchAssignmentsRecursivelyDown(currentContainer.rule.ref.definition, undefined, featureName);
-        }
-        // TODO test this special assignment!
-        if (ast.isAction(currentContainer) && currentContainer.feature === featureName) {
-            countResult++;
+
+        // Search for assignments in used fragments as well, since their property values are stored in the current object.
+        // But do not search in calls of regular parser rules, since parser rules create new objects.
+        if (ast.isRuleCall(currentNode) && ast.isParserRule(currentNode.rule.ref) && currentNode.rule.ref.fragment) {
+            countResult += this.searchRecursivelyDownForAssignments(currentNode.rule.ref.definition, undefined, featureName);
         }
 
-        // look for assignments to the same feature within groups
-        if (ast.isGroup(currentContainer) || ast.isUnorderedGroup(currentContainer) || ast.isAlternatives(currentContainer)) {
+        // rewriting actions are a special case for assignments
+        if (ast.isAction(currentNode) && currentNode.feature === featureName) {
+            countResult += 1;
+        }
+
+        // look for assignments to the same feature nested within groups
+        if (ast.isGroup(currentNode) || ast.isUnorderedGroup(currentNode) || ast.isAlternatives(currentNode)) {
             let countGroup = 0;
             let foundRelevantChild = false;
-            for (const child of currentContainer.elements) {
-                // special case: Actions
-                if (child === relevantChild) {
-                    foundRelevantChild = true;
-                }
+            for (const child of currentNode.elements) {
+                // Actions are a special case: a new object is created => following assignments are put into the new object
+                // (This counts for rewriting actions as well as for unassigned actions, i.e. actions without feature name)
                 if (ast.isAction(child)) {
-                    // a new object is created => following assignments are put into the new object
                     if (relevantChild) {
+                        // there is a child given => ensure, that only assignments to the same object which contains this child are counted
                         if (foundRelevantChild) {
                             // the previous assignments are put into the same object as the given relevant child => ignore the following assignments to the new object
                             break;
                         } else {
-                            // 
-                            containerMultiplicityMatters = false; // since an additional object is created for each time, */+ around the current group don't matter!
+                            // the previous assignments are stored in a different object than the given relevant child => ignore those assignments
                             countGroup = 0;
+                            // since an additional object is created for each time, */+ around the current group don't matter!
+                            containerMultiplicityMatters = false;
                         }
                     } else {
+                        // all following assignments are put into the new object => ignore following assignments, but count previous assignments
                         break;
                     }
                 }
 
+                // remember, whether the given child is already found in the current group
+                if (child === relevantChild) {
+                    foundRelevantChild = true;
+                }
+
                 // count the relevant child assignments
-                const countCurrent = this.searchAssignmentsRecursivelyDown(child, undefined, featureName);
-                if (ast.isAlternatives(currentContainer)) {
+                const countCurrent = this.searchRecursivelyDownForAssignments(child, undefined, featureName);
+                if (ast.isAlternatives(currentNode)) {
                     // for alternatives, only a single alternative is used => assume the worst case and take the maximum number of assignments
                     countGroup = Math.max(countGroup, countCurrent);
                 } else {
@@ -893,10 +936,11 @@ export class LangiumGrammarValidator {
             countResult += countGroup;
         }
 
-        // the current element can occur multiple times => its assignments occur multiple times as well
-        if (containerMultiplicityMatters && ast.isAbstractElement(currentContainer) && isArrayCardinality(currentContainer.cardinality)) {
+        // the current element can occur multiple times => its assignments can occur multiple times as well
+        if (containerMultiplicityMatters && ast.isAbstractElement(currentNode) && isArrayCardinality(currentNode.cardinality)) {
             countResult *= 2; // note, that the result is not exact (but it is sufficient for the current case)!
         }
+
         return countResult;
     }
 

--- a/packages/langium/src/grammar/validation/validator.ts
+++ b/packages/langium/src/grammar/validation/validator.ts
@@ -787,17 +787,39 @@ export class LangiumGrammarValidator {
     }
 
     checkAssignmentOperator(assignment: ast.Assignment, accept: ValidationAcceptor): void {
-        if (assignment.operator === '=') {
-            // the assignment has a multi-value cardinality
-            if (assignment.cardinality === '*' || assignment.cardinality === '+') {
-                accept(
-                    'warning',
-                    `It seems, that you assign multiple values to the feature '${assignment.feature}', while you are using '=' as assignment operator. Consider to use '+=' instead in order not to loose some of the assigned value.`,
-                    { node: assignment, property: 'operator' }
-                );
-            }
-            // TODO more cases
+        // this validation is specific for assignments with '=' as assignment operator
+        if (assignment.operator !== '=') {
+            return;
         }
+        // the assignment has a multi-value cardinality itself
+        if (this.isMany(assignment)) {
+            this.markAssignment(assignment, accept);
+            return;
+        }
+        // check the container group of the assignment
+        if (ast.isGroup(assignment.$container) || ast.isUnorderedGroup(assignment.$container)) {
+            // the group can occur multiple times
+            if (this.isMany(assignment.$container)) {
+                this.markAssignment(assignment, accept);
+                return;
+            }
+            // look for at least a second assignments to the same feature within the container group, the cardinality does not matter
+            if (assignment.$container.elements.filter(child => ast.isAssignment(child) && child.feature === assignment.feature).length >= 2) {
+                this.markAssignment(assignment, accept);
+                return;
+            }
+        }
+        // TODO more cases
+    }
+    private isMany(node: AstNode): boolean {
+        return ast.isAbstractElement(node) && (node.cardinality === '*' || node.cardinality === '+');
+    }
+    private markAssignment(assignment: ast.Assignment, accept: ValidationAcceptor): void {
+        accept(
+            'warning',
+            `It seems, that you assign multiple values to the feature '${assignment.feature}', while you are using '=' as assignment operator. Consider to use '+=' instead in order not to loose some of the assigned value.`,
+            { node: assignment, property: 'operator' }
+        );
     }
 
     checkInterfacePropertyTypes(interfaceDecl: ast.Interface, accept: ValidationAcceptor): void {

--- a/packages/langium/src/grammar/validation/validator.ts
+++ b/packages/langium/src/grammar/validation/validator.ts
@@ -23,6 +23,7 @@ import { getTypeNameWithoutError, hasDataTypeReturn, isPrimitiveGrammarType, isS
 import type { LangiumGrammarServices } from '../langium-grammar-module.js';
 import { typeDefinitionToPropertyType } from '../type-system/type-collector/declared-types.js';
 import { flattenPlainType, isPlainReferenceType } from '../type-system/type-collector/plain-types.js';
+import type { AstNodeLocator } from '../../workspace/ast-node-locator.js';
 
 export function registerValidationChecks(services: LangiumGrammarServices): void {
     const registry = services.validation.ValidationRegistry;
@@ -116,10 +117,12 @@ export namespace IssueCodes {
 export class LangiumGrammarValidator {
 
     protected readonly references: References;
+    protected readonly nodeLocator: AstNodeLocator;
     protected readonly documents: LangiumDocuments;
 
     constructor(services: LangiumGrammarServices) {
         this.references = services.references.References;
+        this.nodeLocator = services.workspace.AstNodeLocator;
         this.documents = services.shared.workspace.LangiumDocuments;
     }
 
@@ -790,24 +793,49 @@ export class LangiumGrammarValidator {
         // this validation is specific for assignments with '=' as assignment operator
         if (assignment.operator === '=') {
             // check the initial assignment and all of its containers
-            let currentElement: AstNode | undefined = assignment;
-            while (currentElement) {
-                const countAssignments = this.searchAssignmentsRecursively(currentElement, assignment.feature);
-                if (countAssignments >= 2) {
-                    accept(
-                        'warning',
-                        `It seems, that you assign multiple values to the feature '${assignment.feature}', while you are using '=' as assignment operator. Consider to use '+=' instead in order not to loose some of the assigned value.`,
-                        { node: assignment, property: 'operator' }
-                    );
-                    return;
+            const reportedProblem = this.searchAssignmentsRecursivelyUp(assignment, assignment, accept);
+
+            // check a special case: the current assignment is located within a fragment => check, whether the fragment is called multiple times
+            if (!reportedProblem) {
+                const containerFragment = getContainerOfType(assignment, ast.isParserRule);
+                if (containerFragment && containerFragment.fragment) {
+                    // for all calls of the fragment ...
+                    for (const ref of this.references.findReferences(containerFragment, {})) {
+                        const doc = this.documents.getDocument(ref.sourceUri);
+                        const call = doc ? this.nodeLocator.getAstNode(doc.parseResult.value, ref.sourcePath) : undefined;
+                        if (call) {
+                            // ... check whether there are multiple assignments to the same feature
+                            if (this.searchAssignmentsRecursivelyUp(call, assignment, accept)) {
+                                return;
+                            }
+                        }
+                    }
                 }
-                // check the next container
-                currentElement = currentElement.$container;
             }
         }
     }
 
-    private searchAssignmentsRecursively(node: AstNode, featureName: string): number {
+    private searchAssignmentsRecursivelyUp(node: AstNode, assignment: ast.Assignment, accept: ValidationAcceptor): boolean {
+        let currentElement: AstNode | undefined = node;
+        while (currentElement) {
+            // check neighbored and nested assignments
+            const countAssignments = this.searchAssignmentsRecursivelyDown(currentElement, assignment.feature);
+            if (countAssignments >= 2) {
+                accept(
+                    'warning',
+                    `It seems, that you are assigning multiple values to the feature '${assignment.feature}', while you are using '=' as assignment operator. Consider to use '+=' instead in order not to loose some of the assigned value.`,
+                    { node: assignment, property: 'operator' }
+                );
+                return true;
+            }
+
+            // check the next container
+            currentElement = currentElement.$container;
+        }
+        return false;
+    }
+
+    private searchAssignmentsRecursivelyDown(node: AstNode, featureName: string): number {
         let countResult = 0;
         // assignment
         if (ast.isAssignment(node) && node.feature === featureName) {
@@ -816,19 +844,19 @@ export class LangiumGrammarValidator {
         // search for assignments in used fragments as well, since their property values are stored in the current object,
         // but not in calls of regular parser rules, since they create new objects
         if (ast.isRuleCall(node) && ast.isParserRule(node.rule.ref) && node.rule.ref.fragment) {
-            countResult += this.searchAssignmentsRecursively(node.rule.ref.definition, featureName);
+            countResult += this.searchAssignmentsRecursivelyDown(node.rule.ref.definition, featureName);
         }
         // look for assignments to the same feature within groups
         if (ast.isGroup(node) || ast.isUnorderedGroup(node)) {
             for (const child of node.elements) {
-                countResult += this.searchAssignmentsRecursively(child, featureName);
+                countResult += this.searchAssignmentsRecursivelyDown(child, featureName);
             }
         }
         // look for assignments to the same feature within alternatives
         if (ast.isAlternatives(node)) {
             let alternativeCount = 0;
             for (const child of node.elements) {
-                alternativeCount = Math.max(alternativeCount, this.searchAssignmentsRecursively(child, featureName));
+                alternativeCount = Math.max(alternativeCount, this.searchAssignmentsRecursivelyDown(child, featureName));
             }
             countResult += alternativeCount;
         }

--- a/packages/langium/test/grammar/grammar-validator.test.ts
+++ b/packages/langium/test/grammar/grammar-validator.test.ts
@@ -891,6 +891,28 @@ describe('Assignments with = instead of +=', () => {
         `));
         expect(validation.diagnostics.length).toBe(0);
     });
+
+    test('no problem with action: assignment is looped, but stored in a new object each time', async () => {
+        const validation = await validate(getGrammar(`
+            entry Model infers Expression:
+                Person ({infer Model.left=current} operator=('+' | '-') right=Person)*;
+            Person infers Expression:
+                {infer Person} 'person' name=ID ;
+        `));
+        expect(validation.diagnostics.length).toBe(0);
+    });
+
+    test('actions: the rewrite part is a special assignment, which needs to be checked as well!', async () => {
+        const validation = await validate(getGrammar(`
+            entry Model infers Expression:
+                Person ({infer Model.left=current} operator=('+' | '-') right=Person left=Model)*;
+            Person infers Expression:
+                {infer Person} 'person' name=ID ;
+        `));
+        expect(validation.diagnostics.length).toBe(2);
+        expect(validation.diagnostics[0].message).toBe(getMessage('left'));
+        expect(validation.diagnostics[1].message).toBe(getMessage('left'));
+    });
 });
 
 describe('Missing required properties are not arrays or booleans', () => {

--- a/packages/langium/test/grammar/grammar-validator.test.ts
+++ b/packages/langium/test/grammar/grammar-validator.test.ts
@@ -698,6 +698,71 @@ describe('Property type is not a mix of cross-ref and non-cross-ref types.', () 
 
 });
 
+describe('Assignments with = instead of +=', () => {
+    function getMessage(featureName: string): string {
+        return `It seems, that you assign multiple values to the feature '${featureName}', while you are using '=' as assignment operator. Consider to use '+=' instead in order not to loose some of the assigned value.`;
+    }
+    function getGrammar(content: string): string {
+        return `
+            grammar HelloWorld
+            ${content}
+            hidden terminal WS: /\\s+/;
+            terminal ID: /[_a-zA-Z][\\w_]*/;
+        `;
+    }
+
+    test('assignment with * cardinality', async () => {
+        const validation = await validate(getGrammar(`
+            entry Model:
+                persons = Person* ;
+            Person:
+                'person' name=ID ;
+        `));
+        expect(validation.diagnostics.length).toBe(1);
+        expect(validation.diagnostics[0].message).toBe(getMessage('persons'));
+    });
+    test('assignment with + cardinality', async () => {
+        const validation = await validate(getGrammar(`
+            entry Model:
+                persons = Person+ ;
+            Person:
+                'person' name=ID ;
+        `));
+        expect(validation.diagnostics.length).toBe(1);
+        expect(validation.diagnostics[0].message).toBe(getMessage('persons'));
+    });
+
+    test.only('two assignments with single cardinality', async () => {
+        const validation = await validate(getGrammar(`
+            entry Model:
+                persons = Person ',' persons = Person;
+            Person:
+                'person' name=ID ;
+        `));
+        expect(validation.diagnostics.length).toBe(2);
+        expect(validation.diagnostics[0].message).toBe(getMessage('persons'));
+    });
+
+    test('Simple case', async () => {
+        const validation = await validate(getGrammar(`
+            entry Model:
+                persons += Person*
+                greetings = Greeting*;
+
+            Person:
+                'person' name=ID;
+
+            Greeting:
+                'Hello' person=[Person:ID] '!';
+        `));
+
+        expect(validation.diagnostics.length).toBe(1);
+        expect(validation.diagnostics[0].message).toBe(getMessage('greetings'));
+        // expectError(validation, /Mixing a cross-reference with other types is not supported. Consider splitting property /);
+    });
+
+});
+
 describe('Missing required properties are not arrays or booleans', () => {
 
     test('No missing properties', async () => {

--- a/packages/langium/test/grammar/grammar-validator.test.ts
+++ b/packages/langium/test/grammar/grammar-validator.test.ts
@@ -715,8 +715,7 @@ describe('Assignments with = instead of +=', () => {
         const validation = await validate(getGrammar(`
             entry Model:
                 persons = Person* ;
-            Person:
-                'person' name=ID ;
+            Person: 'person' name=ID ;
         `));
         expect(validation.diagnostics.length).toBe(1);
         expect(validation.diagnostics[0].message).toBe(getMessage('persons'));
@@ -725,21 +724,29 @@ describe('Assignments with = instead of +=', () => {
         const validation = await validate(getGrammar(`
             entry Model:
                 persons = Person+ ;
-            Person:
-                'person' name=ID ;
+            Person: 'person' name=ID ;
         `));
         expect(validation.diagnostics.length).toBe(1);
         expect(validation.diagnostics[0].message).toBe(getMessage('persons'));
     });
 
-    test.only('two assignments with single cardinality', async () => {
+    test('two assignments with single cardinality', async () => {
         const validation = await validate(getGrammar(`
             entry Model:
                 persons = Person ',' persons = Person;
-            Person:
-                'person' name=ID ;
+            Person: 'person' name=ID ;
         `));
         expect(validation.diagnostics.length).toBe(2);
+        expect(validation.diagnostics[0].message).toBe(getMessage('persons'));
+    });
+
+    test('single assignment with outer * cardinality', async () => {
+        const validation = await validate(getGrammar(`
+            entry Model:
+                (',' persons = Person)* ;
+            Person: 'person' name=ID ;
+        `));
+        expect(validation.diagnostics.length).toBe(1);
         expect(validation.diagnostics[0].message).toBe(getMessage('persons'));
     });
 

--- a/packages/langium/test/grammar/grammar-validator.test.ts
+++ b/packages/langium/test/grammar/grammar-validator.test.ts
@@ -714,7 +714,7 @@ describe('Assignments with = instead of +=', () => {
     test('assignment with * cardinality', async () => {
         const validation = await validate(getGrammar(`
             entry Model:
-                persons = Person* ;
+                persons=Person* ;
             Person: 'person' name=ID ;
         `));
         expect(validation.diagnostics.length).toBe(1);
@@ -723,7 +723,7 @@ describe('Assignments with = instead of +=', () => {
     test('assignment with + cardinality', async () => {
         const validation = await validate(getGrammar(`
             entry Model:
-                persons = Person+ ;
+                persons=Person+ ;
             Person: 'person' name=ID ;
         `));
         expect(validation.diagnostics.length).toBe(1);
@@ -733,7 +733,7 @@ describe('Assignments with = instead of +=', () => {
     test('two assignments with single cardinality', async () => {
         const validation = await validate(getGrammar(`
             entry Model:
-                persons = Person ',' persons = Person;
+                persons=Person ',' persons=Person;
             Person: 'person' name=ID ;
         `));
         expect(validation.diagnostics.length).toBe(2);
@@ -743,7 +743,7 @@ describe('Assignments with = instead of +=', () => {
     test('single assignment with outer * cardinality', async () => {
         const validation = await validate(getGrammar(`
             entry Model:
-                (',' persons = Person)* ;
+                (',' persons=Person)* ;
             Person: 'person' name=ID ;
         `));
         expect(validation.diagnostics.length).toBe(1);
@@ -765,9 +765,109 @@ describe('Assignments with = instead of +=', () => {
 
         expect(validation.diagnostics.length).toBe(1);
         expect(validation.diagnostics[0].message).toBe(getMessage('greetings'));
-        // expectError(validation, /Mixing a cross-reference with other types is not supported. Consider splitting property /);
     });
 
+    test('no problem: assignments in different alternatives', async () => {
+        const validation = await validate(getGrammar(`
+            entry Model:
+                (persons=Person) | (persons=Person);
+            Person: 'person' name=ID ;
+        `));
+        expect(validation.diagnostics.length).toBe(0);
+        // TODO more "no problem" cases!
+    });
+
+    test('assignments in different alternatives, but looped', async () => {
+        const validation = await validate(getGrammar(`
+            entry Model:
+                ((persons=Person) | (persons=Person))*;
+            Person: 'person' name=ID ;
+        `));
+        expect(validation.diagnostics.length).toBe(2);
+        expect(validation.diagnostics[0].message).toBe(getMessage('persons'));
+        expect(validation.diagnostics[1].message).toBe(getMessage('persons'));
+    });
+
+    test('assignments in different alternatives, written twice', async () => {
+        const validation = await validate(getGrammar(`
+            entry Model:
+                ((persons=Person) | (persons=Person)) ',' ((persons=Person) | (persons=Person));
+            Person: 'person' name=ID ;
+        `));
+        expect(validation.diagnostics.length).toBe(4);
+        expect(validation.diagnostics[0].message).toBe(getMessage('persons'));
+        expect(validation.diagnostics[1].message).toBe(getMessage('persons'));
+        expect(validation.diagnostics[2].message).toBe(getMessage('persons'));
+        expect(validation.diagnostics[3].message).toBe(getMessage('persons'));
+    });
+
+    test('multiple optional assignments', async () => {
+        const validation = await validate(getGrammar(`
+            entry Model:
+                persons=Person (',' persons=Person (',' persons=Person )?)?;
+            Person: 'person' name=ID ;
+        `));
+        expect(validation.diagnostics.length).toBe(3);
+        expect(validation.diagnostics[0].message).toBe(getMessage('persons'));
+        expect(validation.diagnostics[1].message).toBe(getMessage('persons'));
+        expect(validation.diagnostics[2].message).toBe(getMessage('persons'));
+    });
+
+    test('multiple assignments on different nesting levels', async () => {
+        const validation = await validate(getGrammar(`
+            entry Model:
+                persons=Person (',' persons=Person (',' persons=Person ));
+            Person: 'person' name=ID ;
+        `));
+        expect(validation.diagnostics.length).toBe(3);
+        expect(validation.diagnostics[0].message).toBe(getMessage('persons'));
+        expect(validation.diagnostics[1].message).toBe(getMessage('persons'));
+        expect(validation.diagnostics[2].message).toBe(getMessage('persons'));
+    });
+
+    test('fragments: 2nd assignment is in fragment', async () => {
+        const validation = await validate(getGrammar(`
+            entry Model:
+                persons=Person ';' Assign;
+            fragment Assign:
+                ',' persons=Person;
+            Person: 'person' name=ID ;
+        `));
+        expect(validation.diagnostics.length).toBe(1);
+        expect(validation.diagnostics[0].message).toBe(getMessage('persons'));
+    });
+
+    test('fragments: assignments only in fragment', async () => {
+        const validation = await validate(getGrammar(`
+            entry Model:
+                Assign ';' Assign;
+            fragment Assign:
+                ',' persons=Person;
+            Person: 'person' name=ID ;
+        `));
+        expect(validation.diagnostics.length).toBe(1);
+        expect(validation.diagnostics[0].message).toBe(getMessage('persons'));
+    });
+
+    test('fragments: alternatives with no problems', async () => {
+        const validation = await validate(getGrammar(`
+            entry Model:
+                Assign | (';' Assign);
+            fragment Assign:
+                ',' persons=Person;
+            Person: 'person' name=ID ;
+        `));
+        expect(validation.diagnostics.length).toBe(0);
+    });
+
+    test('no problem: assignments in different parser rules', async () => {
+        const validation = await validate(getGrammar(`
+            entry Model:
+                persons=Person;
+            Person: 'person' name=ID persons=Person;
+        `));
+        expect(validation.diagnostics.length).toBe(0);
+    });
 });
 
 describe('Missing required properties are not arrays or booleans', () => {

--- a/packages/langium/test/grammar/grammar-validator.test.ts
+++ b/packages/langium/test/grammar/grammar-validator.test.ts
@@ -892,10 +892,20 @@ describe('Assignments with = instead of +=', () => {
         expect(validation.diagnostics.length).toBe(0);
     });
 
-    test('no problem with action: assignment is looped, but stored in a new object each time', async () => {
+    test('no problem with actions: assignment is looped, but stored in a new object each time', async () => {
         const validation = await validate(getGrammar(`
             entry Model infers Expression:
                 Person ({infer Model.left=current} operator=('+' | '-') right=Person)*;
+            Person infers Expression:
+                {infer Person} 'person' name=ID ;
+        `));
+        expect(validation.diagnostics.length).toBe(0);
+    });
+
+    test('no problem with actions: second assignment is stored in a new object', async () => {
+        const validation = await validate(getGrammar(`
+            entry Model infers Expression:
+                Person (operator=('+' | '-') right=Person {infer Model.left=current} right=Person)?;
             Person infers Expression:
                 {infer Person} 'person' name=ID ;
         `));

--- a/packages/langium/test/grammar/grammar-validator.test.ts
+++ b/packages/langium/test/grammar/grammar-validator.test.ts
@@ -700,7 +700,7 @@ describe('Property type is not a mix of cross-ref and non-cross-ref types.', () 
 
 describe('Assignments with = instead of +=', () => {
     function getMessage(featureName: string): string {
-        return `It seems, that you assign multiple values to the feature '${featureName}', while you are using '=' as assignment operator. Consider to use '+=' instead in order not to loose some of the assigned value.`;
+        return `It seems, that you are assigning multiple values to the feature '${featureName}', while you are using '=' as assignment operator. Consider to use '+=' instead in order not to loose some of the assigned value.`;
     }
     function getGrammar(content: string): string {
         return `
@@ -750,7 +750,7 @@ describe('Assignments with = instead of +=', () => {
         expect(validation.diagnostics[0].message).toBe(getMessage('persons'));
     });
 
-    test('Simple case', async () => {
+    test('correct and wrong assignments next to each other', async () => {
         const validation = await validate(getGrammar(`
             entry Model:
                 persons += Person*
@@ -774,7 +774,6 @@ describe('Assignments with = instead of +=', () => {
             Person: 'person' name=ID ;
         `));
         expect(validation.diagnostics.length).toBe(0);
-        // TODO more "no problem" cases!
     });
 
     test('assignments in different alternatives, but looped', async () => {
@@ -801,7 +800,18 @@ describe('Assignments with = instead of +=', () => {
         expect(validation.diagnostics[3].message).toBe(getMessage('persons'));
     });
 
-    test('multiple optional assignments', async () => {
+    test('assignments only in some alternatives, assume the worst case', async () => {
+        const validation = await validate(getGrammar(`
+            entry Model:
+                ((persons=Person) | (';')) ',' ((persons=Person) | (';'));
+            Person: 'person' name=ID ;
+        `));
+        expect(validation.diagnostics.length).toBe(2);
+        expect(validation.diagnostics[0].message).toBe(getMessage('persons'));
+        expect(validation.diagnostics[1].message).toBe(getMessage('persons'));
+    });
+
+    test('multiple, nested optional assignments', async () => {
         const validation = await validate(getGrammar(`
             entry Model:
                 persons=Person (',' persons=Person (',' persons=Person )?)?;
@@ -813,7 +823,7 @@ describe('Assignments with = instead of +=', () => {
         expect(validation.diagnostics[2].message).toBe(getMessage('persons'));
     });
 
-    test('multiple assignments on different nesting levels', async () => {
+    test('multiple, nested mandatory assignments', async () => {
         const validation = await validate(getGrammar(`
             entry Model:
                 persons=Person (',' persons=Person (',' persons=Person ));
@@ -825,7 +835,7 @@ describe('Assignments with = instead of +=', () => {
         expect(validation.diagnostics[2].message).toBe(getMessage('persons'));
     });
 
-    test('fragments: 2nd assignment is in fragment', async () => {
+    test('fragments: 2nd critical assignment is located in a fragment', async () => {
         const validation = await validate(getGrammar(`
             entry Model:
                 persons=Person ';' Assign;
@@ -833,11 +843,12 @@ describe('Assignments with = instead of +=', () => {
                 ',' persons=Person;
             Person: 'person' name=ID ;
         `));
-        expect(validation.diagnostics.length).toBe(1);
+        expect(validation.diagnostics.length).toBe(2);
         expect(validation.diagnostics[0].message).toBe(getMessage('persons'));
+        expect(validation.diagnostics[1].message).toBe(getMessage('persons'));
     });
 
-    test('fragments: assignments only in fragment', async () => {
+    test('fragments: all assignments are located in a fragment', async () => {
         const validation = await validate(getGrammar(`
             entry Model:
                 Assign ';' Assign;
@@ -849,7 +860,19 @@ describe('Assignments with = instead of +=', () => {
         expect(validation.diagnostics[0].message).toBe(getMessage('persons'));
     });
 
-    test('fragments: alternatives with no problems', async () => {
+    test('fragments: assignment in looped fragment', async () => {
+        const validation = await validate(getGrammar(`
+            entry Model:
+                Assign*;
+            fragment Assign:
+                ',' persons=Person;
+            Person: 'person' name=ID ;
+        `));
+        expect(validation.diagnostics.length).toBe(1);
+        expect(validation.diagnostics[0].message).toBe(getMessage('persons'));
+    });
+
+    test('no problem: fragments in alternatives', async () => {
         const validation = await validate(getGrammar(`
             entry Model:
                 Assign | (';' Assign);


### PR DESCRIPTION
This PR adds validations for assignments using the `=` operator, while they got multiple values assigned. This validation gives the user the hint to use `+=` as assignment operator instead.

Among others, the following details are considered during the validation and complemented with test cases:
- assignments in neighbored alternatives
- array multiplicities of outer groups
- assignments in fragments which are called multiple times
- actions creating new objects, which changes the location of stored values (that counts for looped actions as well!)
- the assignment of a rewriting action