### PR TITLE
Update diagnostics for deleted files

### DIFF
--- a/packages/langium/src/lsp/language-server.ts
+++ b/packages/langium/src/lsp/language-server.ts
@@ -298,6 +298,14 @@ export function addFileOperationHandler(connection: Connection, services: Langiu
 
 export function addDiagnosticsHandler(connection: Connection, services: LangiumSharedServices): void {
     const documentBuilder = services.workspace.DocumentBuilder;
+    documentBuilder.onUpdate(async (_, deleted) => {
+        for (const uri of deleted) {
+            connection.sendDiagnostics({
+                uri: uri.toString(),
+                diagnostics: []
+            });
+        }
+    });
     documentBuilder.onBuildPhase(DocumentState.Validated, async (documents, cancelToken) => {
         for (const document of documents) {
             if (document.diagnostics) {


### PR DESCRIPTION
Closes https://github.com/eclipse-langium/langium/issues/1440

Simply replaces the diagnostics of all deleted files with an empty array, thereby unpublishing them. This effects both deleted and renamed files.