### PR TITLE
Fix treatment of word transitions in fuzzy matcher

### DIFF
--- a/packages/langium/src/lsp/fuzzy-matcher.ts
+++ b/packages/langium/src/lsp/fuzzy-matcher.ts
@@ -28,7 +28,6 @@ export class DefaultFuzzyMatcher implements FuzzyMatcher {
             return true;
         }
 
-        text = text.toLowerCase();
         let matchedFirstCharacter = false;
         let previous: number | undefined;
         let character = 0;

--- a/packages/langium/test/lsp/fuzzy-matcher.test.ts
+++ b/packages/langium/test/lsp/fuzzy-matcher.test.ts
@@ -19,6 +19,14 @@ describe('Fuzzy Matcher', () => {
         expect(matcher.match('He', 'Hello')).toBeTruthy();
     });
 
+    test('Matches first few characters (word transition, camel case)', () => {
+        expect(matcher.match('la', 'helloLangium')).toBeTruthy();
+    });
+
+    test('Matches first few characters (word transition, snake case)', () => {
+        expect(matcher.match('la', 'hello_langium')).toBeTruthy();
+    });
+
     test('Matches first few characters - negative', () => {
         expect(matcher.match('ell', 'Hello')).toBeFalsy();
     });
@@ -27,8 +35,15 @@ describe('Fuzzy Matcher', () => {
         expect(matcher.match('Ho', 'Hello')).toBeTruthy();
     });
 
+    test('Matches omitted characters (word transition, camel case)', () => {
+        expect(matcher.match('lm', 'helloLangium')).toBeTruthy();
+    });
+
+    test('Matches omitted characters (word transition, snake case)', () => {
+        expect(matcher.match('lm', 'hello_langium')).toBeTruthy();
+    });
+
     test('Matches omitted characters - negative', () => {
         expect(matcher.match('Hi', 'Hello')).toBeFalsy();
     });
-
 });


### PR DESCRIPTION
Previously, the first character of a query had to match the first character of some `camelCase` text in the fuzzy matcher. 

Now, it has to match either the first character of the text or the first character after a word transition.