### PR TITLE
Fix langium-railroad as part of the npm workspace

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
       "name": "langium-workspaces",
       "workspaces": [
         "packages/langium",
-        "packages/langium-railrod",
+        "packages/langium-railroad",
         "packages/langium-cli",
         "packages/langium-sprotty",
         "packages/langium-vscode",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   },
   "workspaces": [
     "packages/langium",
-    "packages/langium-railrod",
+    "packages/langium-railroad",
     "packages/langium-cli",
     "packages/langium-sprotty",
     "packages/langium-vscode",


### PR DESCRIPTION
Fixes the issue encountered during the last release attempt, see [here](https://github.com/eclipse-langium/langium/actions/runs/8096211170/job/22124537555). This was effectively just a typo.

You can confirm that this works as expected by running `npm run lint --workspace=langium-railroad`.