### PR TITLE
Respect declared type of data type rules

### DIFF
--- a/packages/langium/src/grammar/type-system/type-collector/types.ts
+++ b/packages/langium/src/grammar/type-system/type-collector/types.ts
@@ -304,7 +304,18 @@ function isTypeAssignableInternal(from: PropertyType | undefined, to: PropertyTy
         result = isArrayType(to) && isTypeAssignableInternal(from.elementType, to.elementType, visited);
     } else if (isValueType(from)) {
         if (isUnionType(from.value)) {
-            result = isTypeAssignableInternal(from.value.type, to, visited);
+            if (from.value.dataType) {
+                // We can test the primitive data type directly
+                // This potentially skips a expensive recursive call
+                // This also helps in case the computed internal data type does not fit the declared data type
+                const primitiveType: PrimitiveType = {
+                    primitive: from.value.dataType
+                };
+                result = isTypeAssignableInternal(primitiveType, to, visited);
+            }
+            if (!result) {
+                result = isTypeAssignableInternal(from.value.type, to, visited);
+            }
         } else if (!isValueType(to)) {
             result = false;
         } else if (isUnionType(to.value)) {

--- a/packages/langium/test/grammar/type-system/type-validator.test.ts
+++ b/packages/langium/test/grammar/type-system/type-validator.test.ts
@@ -281,7 +281,7 @@ describe('validate declared types', () => {
         });
     });
 
-    test('Can assign a data type rule to a property with its base type', async () => {
+    test('Can assign a data type rule to a property with its base type #1', async () => {
         const validationResult = await validate(`
             interface RuleType { prop : string };
             Rule returns RuleType: prop = MyDataType;
@@ -289,6 +289,18 @@ describe('validate declared types', () => {
             // The type system should respect the declared type
             MyDataType returns string: INT;
             terminal INT returns number: /[0-9]+/;
+        `);
+        expectNoIssues(validationResult);
+    });
+
+    test('Can assign a data type rule to a property with its base type #2', async () => {
+        const validationResult = await validate(`
+            interface RuleType { prop : number };
+            Rule returns RuleType: prop = MyDataType;
+            // The computed type for 'MyDataType' is INT, but its declared is number
+            // The type system should respect the declared type
+            MyDataType returns number: INT;
+            terminal INT returns string: /[0-9]+/;
         `);
         expectNoIssues(validationResult);
     });

--- a/packages/langium/test/grammar/type-system/type-validator.test.ts
+++ b/packages/langium/test/grammar/type-system/type-validator.test.ts
@@ -280,6 +280,18 @@ describe('validate declared types', () => {
             property: 'name'
         });
     });
+
+    test('Can assign a data type rule to a property with its base type', async () => {
+        const validationResult = await validate(`
+            interface RuleType { prop : string };
+            Rule returns RuleType: prop = MyDataType;
+            // The computed type for 'MyDataType' is INT, but its declared is string
+            // The type system should respect the declared type
+            MyDataType returns string: INT;
+            terminal INT returns number: /[0-9]+/;
+        `);
+        expectNoIssues(validationResult);
+    });
 });
 
 describe('validate declared default value properties', () => {

--- a/packages/langium/test/parser/worker-thread-async-parser.test.ts
+++ b/packages/langium/test/parser/worker-thread-async-parser.test.ts
@@ -39,7 +39,7 @@ describe('WorkerThreadAsyncParser', () => {
             expect(parseResult.value.name).toBe('Test');
             expect(GrammarUtils.findNodeForProperty(parseResult.value.$cstNode, 'name')!.offset).toBe(8);
         }
-    });
+    }, 20000);
 
     test('async parsing can be cancelled', async () => {
         const services = getServices();


### PR DESCRIPTION
Closes https://github.com/eclipse-langium/langium/issues/1256

In the issue, the `MyDataType` rule infers a `number` type (due to its content) instead of the declared `string` type. This change first checks whether the declared type can be assigned directly to the expected type. Only if that fails will the validation attempt to use the computed type for checking.