### PR TITLE
Track unknown documents via language id

### DIFF
--- a/packages/langium/src/default-module.ts
+++ b/packages/langium/src/default-module.ts
@@ -107,7 +107,7 @@ export interface DefaultSharedCoreModuleContext {
  */
 export function createDefaultSharedCoreModule(context: DefaultSharedCoreModuleContext): Module<LangiumSharedCoreServices, LangiumDefaultSharedCoreServices> {
     return {
-        ServiceRegistry: () => new DefaultServiceRegistry(),
+        ServiceRegistry: (services) => new DefaultServiceRegistry(services),
         workspace: {
             LangiumDocuments: (services) => new DefaultLangiumDocuments(services),
             LangiumDocumentFactory: (services) => new DefaultLangiumDocumentFactory(services),

--- a/packages/langium/src/service-registry.ts
+++ b/packages/langium/src/service-registry.ts
@@ -45,6 +45,13 @@ export class DefaultServiceRegistry implements ServiceRegistry {
     protected idMap = new Map<string, LangiumCoreServices>();
     protected extMap = new Map<string, LangiumCoreServices>();
 
+    /**
+     * @deprecated Use the new `extMap` property instead.
+     */
+    protected get map(): Map<string, LangiumCoreServices> | undefined {
+        return this.extMap;
+    }
+
     protected readonly textDocuments?: TextDocumentProvider;
 
     constructor(services?: LangiumSharedCoreServices) {
@@ -63,7 +70,6 @@ export class DefaultServiceRegistry implements ServiceRegistry {
         this.idMap.set(data.languageId, language);
         if (this.idMap.size === 1) {
             this.singleton = language;
-            return;
         } else {
             this.singleton = undefined;
         }

--- a/packages/langium/src/service-registry.ts
+++ b/packages/langium/src/service-registry.ts
@@ -4,7 +4,8 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import type { LangiumCoreServices } from './services.js';
+import type { LangiumCoreServices, LangiumSharedCoreServices } from './services.js';
+import type { TextDocumentProvider } from './workspace/documents.js';
 import { UriUtils, type URI } from './utils/uri-utils.js';
 
 /**
@@ -41,30 +42,30 @@ export interface ServiceRegistry {
 export class DefaultServiceRegistry implements ServiceRegistry {
 
     protected singleton?: LangiumCoreServices;
-    protected map?: Record<string, LangiumCoreServices>;
+    protected idMap = new Map<string, LangiumCoreServices>();
+    protected extMap = new Map<string, LangiumCoreServices>();
+
+    protected readonly textDocuments?: TextDocumentProvider;
+
+    constructor(services?: LangiumSharedCoreServices) {
+        this.textDocuments = services?.workspace.TextDocuments;
+    }
 
     register(language: LangiumCoreServices): void {
-        if (!this.singleton && !this.map) {
-            // This is the first language to be registered; store it as singleton.
+        const data = language.LanguageMetaData;
+        for (const ext of data.fileExtensions) {
+            const existing = this.extMap.get(ext);
+            if (existing) {
+                console.warn(`The file extension ${ext} is used by multiple languages. It is now assigned to '${data.languageId}'.`);
+            }
+            this.extMap.set(ext, language);
+        }
+        this.idMap.set(data.languageId, language);
+        if (this.idMap.size === 1) {
             this.singleton = language;
             return;
-        }
-        if (!this.map) {
-            this.map = {};
-            if (this.singleton) {
-                // Move the previous singleton instance to the new map.
-                for (const ext of this.singleton.LanguageMetaData.fileExtensions) {
-                    this.map[ext] = this.singleton;
-                }
-                this.singleton = undefined;
-            }
-        }
-        // Store the language services in the map.
-        for (const ext of language.LanguageMetaData.fileExtensions) {
-            if (this.map[ext] !== undefined && this.map[ext] !== language) {
-                console.warn(`The file extension ${ext} is used by multiple languages. It is now assigned to '${language.LanguageMetaData.languageId}'.`);
-            }
-            this.map[ext] = language;
+        } else {
+            this.singleton = undefined;
         }
     }
 
@@ -72,13 +73,24 @@ export class DefaultServiceRegistry implements ServiceRegistry {
         if (this.singleton !== undefined) {
             return this.singleton;
         }
-        if (this.map === undefined) {
+        if (this.idMap.size === 0) {
             throw new Error('The service registry is empty. Use `register` to register the services of a language.');
         }
+        const languageId = this.textDocuments?.get(uri.toString())?.languageId;
+        if (languageId !== undefined) {
+            const services = this.idMap.get(languageId);
+            if (services) {
+                return services;
+            }
+        }
         const ext = UriUtils.extname(uri);
-        const services = this.map[ext];
+        const services = this.extMap.get(ext);
         if (!services) {
-            throw new Error(`The service registry contains no services for the extension '${ext}'.`);
+            if (languageId) {
+                throw new Error(`The service registry contains no services for the extension '${ext}' for language '${languageId}'.`);
+            } else {
+                throw new Error(`The service registry contains no services for the extension '${ext}'.`);
+            }
         }
         return services;
     }
@@ -93,12 +105,6 @@ export class DefaultServiceRegistry implements ServiceRegistry {
     }
 
     get all(): readonly LangiumCoreServices[] {
-        if (this.singleton !== undefined) {
-            return [this.singleton];
-        }
-        if (this.map !== undefined) {
-            return Object.values(this.map);
-        }
-        return [];
+        return Array.from(this.idMap.values());
     }
 }

--- a/packages/langium/test/service-registry.test.ts
+++ b/packages/langium/test/service-registry.test.ts
@@ -6,7 +6,7 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import type { LangiumCoreServices, LangiumSharedCoreServices, TextDocumentProvider } from 'langium';
+import type { LangiumCoreServices, LangiumSharedCoreServices, Module, PartialLangiumSharedCoreServices, TextDocumentProvider } from 'langium';
 import { describe, expect, test } from 'vitest';
 import { DefaultServiceRegistry, EmptyFileSystem, URI, createDefaultSharedCoreModule, inject, TextDocument } from 'langium';
 
@@ -43,11 +43,12 @@ describe('DefaultServiceRegistry', () => {
     });
 
     function createSharedCoreServices(id?: string): LangiumSharedCoreServices {
-        return inject(createDefaultSharedCoreModule(EmptyFileSystem), {
+        const textDocumentsModule: Module<LangiumSharedCoreServices, PartialLangiumSharedCoreServices> = {
             workspace: {
                 TextDocuments: (id ? (() => createTextDocuments(id)) : undefined)
             }
-        } as any);
+        };
+        return inject(createDefaultSharedCoreModule(EmptyFileSystem), textDocumentsModule);
     }
 
     function createTextDocuments(id: string): TextDocumentProvider {

--- a/packages/langium/test/service-registry.test.ts
+++ b/packages/langium/test/service-registry.test.ts
@@ -6,29 +6,56 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import type { LangiumCoreServices } from 'langium';
+import type { LangiumCoreServices, LangiumSharedCoreServices, TextDocumentProvider } from 'langium';
 import { describe, expect, test } from 'vitest';
-import { DefaultServiceRegistry, URI } from 'langium';
+import { DefaultServiceRegistry, EmptyFileSystem, URI, createDefaultSharedCoreModule, inject, TextDocument } from 'langium';
 
 describe('DefaultServiceRegistry', () => {
 
     test('should work with a single language', () => {
-        const language: LangiumCoreServices = { foo: 'bar' } as any;
-        const registry = new DefaultServiceRegistry();
+        const language: LangiumCoreServices = { LanguageMetaData: { fileExtensions: ['.foo'], languageId: 'foo' } } as any;
+        const registry = new DefaultServiceRegistry(createSharedCoreServices());
         registry.register(language);
         expect(registry.getServices(URI.parse('file:/foo.bar'))).toBe(language);
         expect(registry.all).toHaveLength(1);
     });
 
     test('should work with two languages', () => {
-        const language1: LangiumCoreServices = { LanguageMetaData: { fileExtensions: ['.foo'] } } as any;
-        const language2: LangiumCoreServices = { LanguageMetaData: { fileExtensions: ['.bar'] } } as any;
-        const registry = new DefaultServiceRegistry();
+        const language1: LangiumCoreServices = { LanguageMetaData: { fileExtensions: ['.foo'], languageId: 'foo' } } as any;
+        const language2: LangiumCoreServices = { LanguageMetaData: { fileExtensions: ['.bar'], languageId: 'bar' } } as any;
+        const registry = new DefaultServiceRegistry(createSharedCoreServices());
         registry.register(language1);
         registry.register(language2);
         expect(registry.getServices(URI.parse('file:/test.foo'))).toBe(language1);
         expect(registry.getServices(URI.parse('file:/test.bar'))).toBe(language2);
         expect(registry.all).toHaveLength(2);
     });
+
+    test('should work based on language ids', () => {
+        const language1: LangiumCoreServices = { LanguageMetaData: { fileExtensions: [], languageId: 'foo' } } as any;
+        const language2: LangiumCoreServices = { LanguageMetaData: { fileExtensions: [], languageId: 'bar' } } as any;
+        const registry = new DefaultServiceRegistry(createSharedCoreServices('bar'));
+        registry.register(language1);
+        registry.register(language2);
+        expect(registry.getServices(URI.parse('file:/test.x'))).toBe(language2);
+        expect(registry.getServices(URI.parse('file:/test.y'))).toBe(language2);
+        expect(registry.all).toHaveLength(2);
+    });
+
+    function createSharedCoreServices(id?: string): LangiumSharedCoreServices {
+        return inject(createDefaultSharedCoreModule(EmptyFileSystem), {
+            workspace: {
+                TextDocuments: (id ? (() => createTextDocuments(id)) : undefined)
+            }
+        } as any);
+    }
+
+    function createTextDocuments(id: string): TextDocumentProvider {
+        return {
+            get(uri: string): TextDocument | undefined {
+                return TextDocument.create(uri, id, 0, '');
+            }
+        };
+    }
 
 });


### PR DESCRIPTION
This is a second iteration on the fix of https://github.com/eclipse-langium/langium/pull/1455. This idea came up while helping with https://github.com/eclipse-langium/langium/discussions/1488: The `TextDocument` is always aware of the language ID used in the language client, even if the file extension doesn't fit. We can use that info (assuming a `TextDocument` instance is available for the given URI) to make the `ServiceRegistry` more accurate.

This also fixes issues experienced when creating an untitled file and setting the language to a DSL language (in multi-language projects).