### PR TITLE
Fix intermittent testing failure

### DIFF
--- a/packages/langium/test/workspace/workspace-lock.test.ts
+++ b/packages/langium/test/workspace/workspace-lock.test.ts
@@ -61,8 +61,8 @@ describe('WorkspaceLock', () => {
         const mutex = new DefaultWorkspaceLock();
         const now = Date.now();
         const magicalNumber = await mutex.read(() => new Promise(resolve => setTimeout(() => resolve(42), 10)));
-        // Confirm that at least 10ms have elapsed
-        expect(Date.now() - now).toBeGreaterThanOrEqual(10);
+        // Confirm that at least 5ms have elapsed
+        expect(Date.now() - now).toBeGreaterThanOrEqual(5);
         // Confirm the returned value
         expect(magicalNumber).toBe(42);
     });


### PR DESCRIPTION
In some of our CI runs (see [here](https://github.com/eclipse-langium/langium/actions/runs/9081381517/job/24955100656?pr=1474)), the workspace lock test fails due to minor timing issues in the runtime. This change makes the test a bit more lenient regarding minor inaccuracies in the `setTimeout` mechanism.