### PR TITLE
Respect the declared/returned type of data type rules, which is relevant for the default value converter

### DIFF
--- a/packages/langium-cli/test/generator/ast-generator.test.ts
+++ b/packages/langium-cli/test/generator/ast-generator.test.ts
@@ -201,6 +201,60 @@ describe('Ast generator', () => {
         }
     `);
 
+    testGeneratedAst('check generated property with datatype rule of type number: single-value', `
+        grammar TestGrammar
+
+        Node: num=A;
+        A returns number: '1';
+            
+        hidden terminal WS: /\\s+/;
+        terminal ID: /[_a-zA-Z][\\w_]*/;
+    `, expandToString`
+        export type A = number;
+            
+        export function isA(item: unknown): item is A {
+            return typeof item === 'number';
+        }
+
+        export interface Node extends AstNode {
+            readonly $type: 'Node';
+            num: A;
+        }
+
+        export const Node = 'Node';
+
+        export function isNode(item: unknown): item is Node {
+            return reflection.isInstance(item, Node);
+        }
+    `);
+
+    testGeneratedAst('check generated property with datatype rule of type number: multi-value', `
+        grammar TestGrammar
+
+        Node: num+=A*;
+        A returns number: '1';
+            
+        hidden terminal WS: /\\s+/;
+        terminal ID: /[_a-zA-Z][\\w_]*/;
+    `, expandToString`
+        export type A = number;
+            
+        export function isA(item: unknown): item is A {
+            return typeof item === 'number';
+        }
+
+        export interface Node extends AstNode {
+            readonly $type: 'Node';
+            num: Array<A>;
+        }
+
+        export const Node = 'Node';
+
+        export function isNode(item: unknown): item is Node {
+            return reflection.isInstance(item, Node);
+        }
+    `);
+
     testGeneratedAst('should generate checker functions for datatype rules of type boolean', `
         grammar TestGrammar
 

--- a/packages/langium/src/grammar/type-system/type-collector/inferred-types.ts
+++ b/packages/langium/src/grammar/type-system/type-collector/inferred-types.ts
@@ -11,7 +11,7 @@ import { MultiMap } from '../../../utils/collections.js';
 import { isAlternatives, isKeyword, isParserRule, isAction, isGroup, isUnorderedGroup, isAssignment, isRuleCall, isCrossReference, isTerminalRule } from '../../../languages/generated/ast.js';
 import { getTypeNameWithoutError, isPrimitiveGrammarType } from '../../internal-grammar-util.js';
 import { mergePropertyTypes } from './plain-types.js';
-import { isOptionalCardinality, terminalRegex, getRuleType } from '../../../utils/grammar-utils.js';
+import { isOptionalCardinality, terminalRegex, getRuleTypeName } from '../../../utils/grammar-utils.js';
 
 interface TypePart {
     name?: string
@@ -470,7 +470,7 @@ function findTypes(terminal: AbstractElement, types: TypeCollection): void {
     } else if (isKeyword(terminal)) {
         types.types.add(`'${terminal.value}'`);
     } else if (isRuleCall(terminal) && terminal.rule.ref) {
-        types.types.add(getRuleType(terminal.rule.ref));
+        types.types.add(getRuleTypeName(terminal.rule.ref));
     } else if (isCrossReference(terminal) && terminal.type.ref) {
         const refTypeName = getTypeNameWithoutError(terminal.type.ref);
         if (refTypeName) {
@@ -494,7 +494,7 @@ function addRuleCall(graph: TypeGraph, current: TypePart, ruleCall: RuleCall): v
             current.properties.push(...properties);
         }
     } else if (isParserRule(rule)) {
-        current.ruleCalls.push(getRuleType(rule));
+        current.ruleCalls.push(getRuleTypeName(rule));
     }
 }
 

--- a/packages/langium/src/grammar/validation/validation-resources-collector.ts
+++ b/packages/langium/src/grammar/validation/validation-resources-collector.ts
@@ -15,7 +15,7 @@ import { stream } from '../../utils/stream.js';
 import { isAction, isAlternatives, isGroup, isUnorderedGroup } from '../../languages/generated/ast.js';
 import { mergeInterfaces, mergeTypesAndInterfaces } from '../type-system/types-util.js';
 import { collectValidationAst } from '../type-system/ast-collector.js';
-import { getActionType, getRuleType } from '../../utils/grammar-utils.js';
+import { getActionType, getRuleTypeName } from '../../utils/grammar-utils.js';
 
 export class LangiumGrammarValidationResourcesCollector {
     private readonly documents: LangiumDocuments;
@@ -94,7 +94,7 @@ function collectNameToRulesActions({ parserRules, datatypeRules }: AstResources)
     // collect rules
     stream(parserRules)
         .concat(datatypeRules)
-        .forEach(rule => acc.add(getRuleType(rule), rule));
+        .forEach(rule => acc.add(getRuleTypeName(rule), rule));
 
     // collect actions
     function collectActions(element: AbstractElement) {

--- a/packages/langium/src/utils/grammar-utils.ts
+++ b/packages/langium/src/utils/grammar-utils.ts
@@ -437,7 +437,7 @@ export function getRuleType(rule: ast.AbstractRule): string {
     if (ast.isTerminalRule(rule)) {
         return rule.type?.name ?? 'string';
     } else {
-        return isDataTypeRule(rule) ? rule.name : getExplicitRuleType(rule) ?? rule.name;
+        return getExplicitRuleType(rule) ?? rule.name;
     }
 }
 

--- a/packages/langium/src/utils/grammar-utils.ts
+++ b/packages/langium/src/utils/grammar-utils.ts
@@ -433,6 +433,28 @@ export function getActionType(action: ast.Action): string | undefined {
     return undefined; // not inferring and not referencing a valid type
 }
 
+/**
+ * This function is used at development time (for code generation and the internal type system) to get the type of the AST node produced by the given rule.
+ * For data type rules, the name of the rule is returned,
+ * e.g. "INT_value returns number: MY_INT;" returns "INT_value".
+ * @param rule the given rule
+ * @returns the name of the AST node type of the rule
+ */
+export function getRuleTypeName(rule: ast.AbstractRule): string {
+    if (ast.isTerminalRule(rule)) {
+        return rule.type?.name ?? 'string';
+    } else {
+        return isDataTypeRule(rule) ? rule.name : getExplicitRuleType(rule) ?? rule.name;
+    }
+}
+
+/**
+ * This function is used at runtime to get the actual type of the values produced by the given rule at runtime.
+ * For data type rules, the name of the declared return type of the rule is returned (if any),
+ * e.g. "INT_value returns number: MY_INT;" returns "number".
+ * @param rule the given rule
+ * @returns the name of the type of the produced values of the rule at runtime
+ */
 export function getRuleType(rule: ast.AbstractRule): string {
     if (ast.isTerminalRule(rule)) {
         return rule.type?.name ?? 'string';

--- a/packages/langium/test/grammar/type-system/type-validator.test.ts
+++ b/packages/langium/test/grammar/type-system/type-validator.test.ts
@@ -245,7 +245,7 @@ describe('validate declared types', () => {
                 propA: Mytype;
             }
             interface B {
-                propB: string;
+                propB: Mytype | string;
             }
             RuleA returns A: propA='a';
             RuleB returns B: propB=DTB;

--- a/packages/langium/test/grammar/type-system/type-validator.test.ts
+++ b/packages/langium/test/grammar/type-system/type-validator.test.ts
@@ -245,7 +245,7 @@ describe('validate declared types', () => {
                 propA: Mytype;
             }
             interface B {
-                propB: Mytype | string;
+                propB: string;
             }
             RuleA returns A: propA='a';
             RuleB returns B: propB=DTB;

--- a/packages/langium/test/parser/langium-parser-builder.test.ts
+++ b/packages/langium/test/parser/langium-parser-builder.test.ts
@@ -286,6 +286,47 @@ describe('One name for terminal and non-terminal rules', () => {
 
 });
 
+describe('check the default value converter for data type rules using terminal rules', () => {
+    const grammar = `
+    grammar Test
+
+    entry Main:
+        propInteger=INT_value
+        propBoolean=BOOLEAN_value
+        propString=STRING_value;
+
+    INT_value returns number: MY_INT;
+    BOOLEAN_value returns boolean: MY_BOOLEAN;
+    STRING_value returns string: MY_ID;
+
+    terminal MY_INT returns number: /((-|\\+)?[0-9]+)/;
+    terminal MY_BOOLEAN returns string: /(true)|(false)/;
+    terminal MY_ID returns string: /[a-zA-Z]+/;
+
+    hidden terminal WS: /\\s+/;
+    `;
+
+    let parser: LangiumParser;
+    beforeEach(async () => {
+        parser = await parserFromGrammar(grammar);
+    });
+
+    test('Should have no definition errors', () => {
+        expect(parser.definitionErrors).toHaveLength(0);
+    });
+
+    test.only('string vs number', async () => {
+        const result = parser.parse('123 true abc');
+        expect(result.lexerErrors.length).toBe(0);
+        expect(result.parserErrors.length).toBe(0);
+        const value = result.value as unknown as { propInteger: number, propBoolean: boolean, propString: string };
+        expect(value.propInteger).not.toBe('123');
+        expect(value.propInteger).toBe(123);
+        expect(value.propBoolean).toBe(true);
+        expect(value.propString).toBe('abc');
+    });
+});
+
 describe('Boolean value converter', () => {
     const content = `
     grammar G

--- a/packages/langium/test/parser/langium-parser-builder.test.ts
+++ b/packages/langium/test/parser/langium-parser-builder.test.ts
@@ -315,7 +315,7 @@ describe('check the default value converter for data type rules using terminal r
         expect(parser.definitionErrors).toHaveLength(0);
     });
 
-    test.only('string vs number', async () => {
+    test('string vs number', async () => {
         const result = parser.parse('123 true abc');
         expect(result.lexerErrors.length).toBe(0);
         expect(result.parserErrors.length).toBe(0);

--- a/packages/langium/test/parser/langium-parser-builder.test.ts
+++ b/packages/langium/test/parser/langium-parser-builder.test.ts
@@ -307,7 +307,7 @@ describe('check the default value converter for data type rules using terminal r
     `;
 
     let parser: LangiumParser;
-    beforeEach(async () => {
+    beforeAll(async () => {
         parser = await parserFromGrammar(grammar);
     });
 


### PR DESCRIPTION
This PR contributes:
- fix to respect the declared/returned type of data type rules, when (among others) checked by the default value converter
- test cases for the default value converter, when using data type rules with declared return type which use terminal rules

This issue was found in a real-world application, where a data type rule (with `returns number`) which referred to a terminal rule (with `returns number`) produced a `string` value at runtime in the AST (while the generated property in the TypeScript interface had the correct type `number`). This conforms to the "number case" in the new test case. The cases for string and boolean are added only to be more complete.

This issue is not related to https://github.com/eclipse-langium/langium/pull/1478.