### PR TITLE
Merge inferred array types

### DIFF
--- a/packages/langium/src/grammar/validation/validator.ts
+++ b/packages/langium/src/grammar/validation/validator.ts
@@ -823,7 +823,7 @@ export class LangiumGrammarValidator {
                 const flattened = flattenPlainType(plainType);
                 let hasRef = false;
                 let hasNonRef = false;
-                for (const flat of flattened) {
+                for (const flat of flattened.union.concat(flattened.array)) {
                     if (isPlainReferenceType(flat)) {
                         hasRef = true;
                     } else if (!isPlainReferenceType(flat)) {

--- a/packages/langium/test/grammar/type-system/inferred-types.test.ts
+++ b/packages/langium/test/grammar/type-system/inferred-types.test.ts
@@ -798,6 +798,30 @@ describe('types of `$container` and `$type` are correct', () => {
             }
         `);
     });
+
+    test('Should merge types of array properties', async () => {
+        const expected = expandToString`
+            export interface A extends AstNode {
+                readonly $type: 'A';
+                values: Array<number | string>;
+            }
+        `;
+        await expectTypes(`
+            A: values+=ID values+=NUMBER;
+            terminal ID returns string: /string/;
+            terminal NUMBER returns number: /number/;
+        `, expected);
+        await expectTypes(`
+            A: (values+=ID | values+=NUMBER)+;
+            terminal ID returns string: /string/;
+            terminal NUMBER returns number: /number/;
+        `, expected);
+        await expectTypes(`
+            A: values+=(ID | NUMBER)+;
+            terminal ID returns string: /string/;
+            terminal NUMBER returns number: /number/;
+        `, expected);
+    });
 });
 
 // https://github.com/eclipse-langium/langium/issues/744


### PR DESCRIPTION
Closes https://github.com/eclipse-langium/langium/issues/1505

Note that this approach has a very minor issue in regards to alternatives of lists:

```
A: (values+=ID* | values+=NUMBER*);
```

The expected type would be `values: Array<string> | Array<number>`, but this PR adjusts this to generate `values: Array<string | number>`. I think this is "good enough" as it fixes the much more common issue of `values+=ID values+=NUMBER`. See also https://github.com/eclipse-langium/langium-website/pull/132#issuecomment-2117565838.