### PR TITLE
Escape `${` in template string

### DIFF
--- a/packages/langium-cli/src/generator/grammar-serializer.ts
+++ b/packages/langium-cli/src/generator/grammar-serializer.ts
@@ -41,9 +41,13 @@ export function serializeGrammar(services: LangiumCoreServices, grammars: Gramma
                 });
                 // The json serializer returns strings with \n line delimiter by default
                 // We need to translate these line endings to the OS specific line ending
-                const json = normalizeEOL(serializedGrammar
+                let json = normalizeEOL(serializedGrammar
                     .replace(/\\/g, '\\\\')
                     .replace(new RegExp(delimiter, 'g'), '\\' + delimiter));
+                if (!production) {
+                    // Escape ${ in template strings
+                    json = json.replace(/\${/g, '\\${');
+                }
                 return expandToNode`
 
                     let loaded${grammar.name}Grammar: Grammar | undefined;


### PR DESCRIPTION
Closes https://github.com/eclipse-langium/langium/issues/1513

Whenever `${` was included in a keyword, the generated template literal expected an expression, resulting in a parser error. This change escapes the `${` as expected.