### PR TITLE
Show documentation on completion item

### DIFF
--- a/packages/langium/test/lsp/completion-provider.test.ts
+++ b/packages/langium/test/lsp/completion-provider.test.ts
@@ -12,6 +12,7 @@ import { DefaultCompletionProvider } from 'langium/lsp';
 import type { LangiumServices, PartialLangiumServices } from 'langium/lsp';
 import { clearDocuments, expectCompletion, parseHelper } from 'langium/test';
 import { MarkupContent } from 'vscode-languageserver';
+import * as assert from 'assert';
 
 describe('Langium completion provider', () => {
 
@@ -206,7 +207,7 @@ describe('Completion within alternatives', () => {
                 if (MarkupContent.is(item.documentation)) {
                     return item.documentation.value;
                 } else {
-                    return item.documentation ?? '';
+                    assert.fail('Completion item should be of type `MarkupContent`.');
                 }
             }
         });

--- a/packages/langium/test/lsp/completion-provider.test.ts
+++ b/packages/langium/test/lsp/completion-provider.test.ts
@@ -204,7 +204,7 @@ describe('Completion within alternatives', () => {
             index: 0,
             expectedItems: ['Hello this is A'],
             itemToString: item => {
-                assert(MarkupContent.is(item.documentation), 'Completion item should be of type `MarkupContent`.');
+                assert.ok(MarkupContent.is(item.documentation), 'Completion item should be of type `MarkupContent`.');
                 return item.documentation.value;
             }
         });

--- a/packages/langium/test/lsp/completion-provider.test.ts
+++ b/packages/langium/test/lsp/completion-provider.test.ts
@@ -204,11 +204,8 @@ describe('Completion within alternatives', () => {
             index: 0,
             expectedItems: ['Hello this is A'],
             itemToString: item => {
-                if (MarkupContent.is(item.documentation)) {
-                    return item.documentation.value;
-                } else {
-                    assert.fail('Completion item should be of type `MarkupContent`.');
-                }
+                assert(MarkupContent.is(item.documentation), 'Completion item should be of type `MarkupContent`.');
+                return item.documentation.value;
             }
         });
     });


### PR DESCRIPTION
See discussion in https://github.com/eclipse-langium/langium/discussions/1501#discussioncomment-9579811.

This change aligns Langium's default behavior to most programming languages, where the documentation of an element is shown on the corresponding completion item.