### PR TITLE
Update documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,15 +21,15 @@
 
 Eclipse Langium (IPA: /ˈlæŋɡiəm/, like **lang**uage and equilibr**ium**) is a language engineering tool for [TypeScript](https://www.typescriptlang.org/) with built-in support for the [Language Server Protocol](https://microsoft.github.io/language-server-protocol/). The framework is an all-in-one solution for building programming languages, domain specific languages, code generators, interpreters and compilers. It serves as a spiritual successor to the [Eclipse Xtext framework](https://www.eclipse.org/Xtext/).
 
-* **Semantics First:** Building on top of a [grammar declaration language](https://langium.org/docs/grammar-language/), Langium enables you to build the abstract model of your language in parallel to its syntax. Langium parsers are powered by [Chevrotain](https://chevrotain.io).
-* **Lean by Default, Customizable by Design:** Langium offers the infrastructure you need to build languages purely by defining their grammar. If that is not enough, you can fine tune every detail of your language using our [dependency injection system](https://langium.org/docs/configuration-services/).
+* **Semantics First:** Building on top of a [grammar declaration language](https://langium.org/docs/reference/grammar-language/), Langium enables you to build the abstract model of your language in parallel to its syntax. Langium parsers are powered by [Chevrotain](https://chevrotain.io).
+* **Lean by Default, Customizable by Design:** Langium offers the infrastructure you need to build languages purely by defining their grammar. If that is not enough, you can fine tune every detail of your language using our [dependency injection system](https://langium.org/docs/reference/configuration-services/).
 * **Write Once, Run Everywhere:** By leveraging the flexibility of JavaScript and the [Language Server Protocol](https://microsoft.github.io/language-server-protocol/), a language written using Langium can run in all kinds of IDEs and browsers or be embedded in CLIs and server applications.
 
 ## Installation
 
 Build your first language with Langium in our [online playground](https://langium.org/playground/).
 
-Once you're ready to set up a project, you can use yeoman to generate a [sample Langium project](https://langium.org/docs/getting-started/):
+Once you're ready to set up a project, you can use yeoman to generate a [sample Langium project](https://langium.org/docs/learn/workflow/):
 
 ```sh
 npm i -g yo generator-langium
@@ -40,13 +40,13 @@ yo langium
 
 You can find the Langium documentation on [the website](https://langium.org/).
 
-If you're new to building programming language, take a look at [our overview to see what Langium offers](https://langium.org/docs/langium-overview/). 
+If you're new to building programming language, take a look at [our overview to see what Langium offers](https://langium.org/docs/features/). 
 
 The documentation is divided into several sections:
 
-* [Main Concepts](https://langium.org/docs/)
-* [Tutorials](https://langium.org/tutorials/)
-* [Advanced Guides](https://langium.org/guides/)
+* [Learning Langium](https://langium.org/docs/learn/workflow/)
+* [Referece](https://langium.org/docs/reference/)
+* [Recipes](https://langium.org/docs/recipes/)
 * [Playground](https://langium.org/playground/)
 
 The documentation website is hosted in [this repository](https://github.com/langium/langium-website).

--- a/packages/generator-langium/README.md
+++ b/packages/generator-langium/README.md
@@ -2,4 +2,4 @@
 
 This [Yeoman](https://yeoman.io) generator is used to create a new [Langium](https://langium.org/) extension for VS Code.
 
-Please read the [documentation to get started](https://langium.org/docs/getting-started/).
+Please read the [documentation to get started](https://langium.org/docs/learn/workflow/).

--- a/packages/langium/src/dependency-injection.ts
+++ b/packages/langium/src/dependency-injection.ts
@@ -107,7 +107,7 @@ function _resolve<I, T>(obj: any, prop: string | symbol | number, module: Module
             throw new Error('Construction failure. Please make sure that your dependencies are constructable.', {cause: obj[prop]});
         }
         if (obj[prop] === __requested__) {
-            throw new Error('Cycle detected. Please make "' + String(prop) + '" lazy. See https://langium.org/docs/configuration-services/#resolving-cyclic-dependencies');
+            throw new Error('Cycle detected. Please make "' + String(prop) + '" lazy. Visit https://langium.org/docs/reference/configuration-services/#resolving-cyclic-dependencies');
         }
         return obj[prop];
     } else if (prop in module) {

--- a/packages/langium/test/dependency-injection.test.ts
+++ b/packages/langium/test/dependency-injection.test.ts
@@ -234,7 +234,7 @@ describe('The inject function', () => {
         }
         expect(() =>
             inject({ a: (api: API) => new A(api), b: (api: API) => new B(api) }).a
-        ).toThrowError('Cycle detected. Please make "a" lazy. See https://langium.org/docs/configuration-services/#resolving-cyclic-dependencies');
+        ).toThrowError(/Cycle detected. Please make "a" lazy/);
     });
 
     test('should throw when cyclic dependency is accessed during factory function call', () => {
@@ -243,7 +243,7 @@ describe('The inject function', () => {
         const createB = ({ a }: API) => ({ b: a.a });
         expect(() =>
             inject({ a: createA, b: createB }).a
-        ).toThrowError('Cycle detected. Please make "a" lazy. See https://langium.org/docs/configuration-services/#resolving-cyclic-dependencies');
+        ).toThrowError(/Cycle detected. Please make "a" lazy/);
     });
 
     test('should merge groups', () => {


### PR DESCRIPTION
After a recent PR in the langium website repo, we adjusted where some of the documentation can be found. This PR updates our links to the documentation to reflect those changes.