### PR TITLE
Escape strings in generated types

### DIFF
--- a/examples/arithmetics/src/language-server/generated/ast.ts
+++ b/examples/arithmetics/src/language-server/generated/ast.ts
@@ -144,7 +144,7 @@ export type ArithmeticsAstType = {
 export class ArithmeticsAstReflection extends AbstractAstReflection {
 
     getAllTypes(): string[] {
-        return ['AbstractDefinition', 'BinaryExpression', 'DeclaredParameter', 'Definition', 'Evaluation', 'Expression', 'FunctionCall', 'Module', 'NumberLiteral', 'Statement'];
+        return [AbstractDefinition, BinaryExpression, DeclaredParameter, Definition, Evaluation, Expression, FunctionCall, Module, NumberLiteral, Statement];
     }
 
     protected override computeIsSubtype(subtype: string, supertype: string): boolean {
@@ -172,7 +172,7 @@ export class ArithmeticsAstReflection extends AbstractAstReflection {
     getReferenceType(refInfo: ReferenceInfo): string {
         const referenceId = `${refInfo.container.$type}:${refInfo.property}`;
         switch (referenceId) {
-            case 'FunctionCall:func': {
+            case "FunctionCall:func": {
                 return AbstractDefinition;
             }
             default: {
@@ -183,65 +183,65 @@ export class ArithmeticsAstReflection extends AbstractAstReflection {
 
     getTypeMetaData(type: string): TypeMetaData {
         switch (type) {
-            case 'BinaryExpression': {
+            case BinaryExpression: {
                 return {
-                    name: 'BinaryExpression',
+                    name: BinaryExpression,
                     properties: [
-                        { name: 'left' },
-                        { name: 'operator' },
-                        { name: 'right' }
+                        { name: "left" },
+                        { name: "operator" },
+                        { name: "right" }
                     ]
                 };
             }
-            case 'DeclaredParameter': {
+            case DeclaredParameter: {
                 return {
-                    name: 'DeclaredParameter',
+                    name: DeclaredParameter,
                     properties: [
-                        { name: 'name' }
+                        { name: "name" }
                     ]
                 };
             }
-            case 'Definition': {
+            case Definition: {
                 return {
-                    name: 'Definition',
+                    name: Definition,
                     properties: [
-                        { name: 'args', defaultValue: [] },
-                        { name: 'expr' },
-                        { name: 'name' }
+                        { name: "args", defaultValue: [] },
+                        { name: "expr" },
+                        { name: "name" }
                     ]
                 };
             }
-            case 'Evaluation': {
+            case Evaluation: {
                 return {
-                    name: 'Evaluation',
+                    name: Evaluation,
                     properties: [
-                        { name: 'expression' }
+                        { name: "expression" }
                     ]
                 };
             }
-            case 'FunctionCall': {
+            case FunctionCall: {
                 return {
-                    name: 'FunctionCall',
+                    name: FunctionCall,
                     properties: [
-                        { name: 'args', defaultValue: [] },
-                        { name: 'func' }
+                        { name: "args", defaultValue: [] },
+                        { name: "func" }
                     ]
                 };
             }
-            case 'Module': {
+            case Module: {
                 return {
-                    name: 'Module',
+                    name: Module,
                     properties: [
-                        { name: 'name' },
-                        { name: 'statements', defaultValue: [] }
+                        { name: "name" },
+                        { name: "statements", defaultValue: [] }
                     ]
                 };
             }
-            case 'NumberLiteral': {
+            case NumberLiteral: {
                 return {
-                    name: 'NumberLiteral',
+                    name: NumberLiteral,
                     properties: [
-                        { name: 'value' }
+                        { name: "value" }
                     ]
                 };
             }

--- a/examples/domainmodel/src/language-server/generated/ast.ts
+++ b/examples/domainmodel/src/language-server/generated/ast.ts
@@ -113,7 +113,7 @@ export type DomainModelAstType = {
 export class DomainModelAstReflection extends AbstractAstReflection {
 
     getAllTypes(): string[] {
-        return ['AbstractElement', 'DataType', 'Domainmodel', 'Entity', 'Feature', 'PackageDeclaration', 'Type'];
+        return [AbstractElement, DataType, Domainmodel, Entity, Feature, PackageDeclaration, Type];
     }
 
     protected override computeIsSubtype(subtype: string, supertype: string): boolean {
@@ -135,10 +135,10 @@ export class DomainModelAstReflection extends AbstractAstReflection {
     getReferenceType(refInfo: ReferenceInfo): string {
         const referenceId = `${refInfo.container.$type}:${refInfo.property}`;
         switch (referenceId) {
-            case 'Entity:superType': {
+            case "Entity:superType": {
                 return Entity;
             }
-            case 'Feature:type': {
+            case "Feature:type": {
                 return Type;
             }
             default: {
@@ -149,48 +149,48 @@ export class DomainModelAstReflection extends AbstractAstReflection {
 
     getTypeMetaData(type: string): TypeMetaData {
         switch (type) {
-            case 'DataType': {
+            case DataType: {
                 return {
-                    name: 'DataType',
+                    name: DataType,
                     properties: [
-                        { name: 'name' }
+                        { name: "name" }
                     ]
                 };
             }
-            case 'Domainmodel': {
+            case Domainmodel: {
                 return {
-                    name: 'Domainmodel',
+                    name: Domainmodel,
                     properties: [
-                        { name: 'elements', defaultValue: [] }
+                        { name: "elements", defaultValue: [] }
                     ]
                 };
             }
-            case 'Entity': {
+            case Entity: {
                 return {
-                    name: 'Entity',
+                    name: Entity,
                     properties: [
-                        { name: 'features', defaultValue: [] },
-                        { name: 'name' },
-                        { name: 'superType' }
+                        { name: "features", defaultValue: [] },
+                        { name: "name" },
+                        { name: "superType" }
                     ]
                 };
             }
-            case 'Feature': {
+            case Feature: {
                 return {
-                    name: 'Feature',
+                    name: Feature,
                     properties: [
-                        { name: 'many', defaultValue: false },
-                        { name: 'name' },
-                        { name: 'type' }
+                        { name: "many", defaultValue: false },
+                        { name: "name" },
+                        { name: "type" }
                     ]
                 };
             }
-            case 'PackageDeclaration': {
+            case PackageDeclaration: {
                 return {
-                    name: 'PackageDeclaration',
+                    name: PackageDeclaration,
                     properties: [
-                        { name: 'elements', defaultValue: [] },
-                        { name: 'name' }
+                        { name: "elements", defaultValue: [] },
+                        { name: "name" }
                     ]
                 };
             }

--- a/examples/requirements/src/language-server/generated/ast.ts
+++ b/examples/requirements/src/language-server/generated/ast.ts
@@ -106,7 +106,7 @@ export type RequirementsAndTestsAstType = {
 export class RequirementsAndTestsAstReflection extends AbstractAstReflection {
 
     getAllTypes(): string[] {
-        return ['Contact', 'Environment', 'Requirement', 'RequirementModel', 'Test', 'TestModel'];
+        return [Contact, Environment, Requirement, RequirementModel, Test, TestModel];
     }
 
     protected override computeIsSubtype(subtype: string, supertype: string): boolean {
@@ -120,11 +120,11 @@ export class RequirementsAndTestsAstReflection extends AbstractAstReflection {
     getReferenceType(refInfo: ReferenceInfo): string {
         const referenceId = `${refInfo.container.$type}:${refInfo.property}`;
         switch (referenceId) {
-            case 'Requirement:environments':
-            case 'Test:environments': {
+            case "Requirement:environments":
+            case "Test:environments": {
                 return Environment;
             }
-            case 'Test:requirements': {
+            case "Test:requirements": {
                 return Requirement;
             }
             default: {
@@ -135,60 +135,60 @@ export class RequirementsAndTestsAstReflection extends AbstractAstReflection {
 
     getTypeMetaData(type: string): TypeMetaData {
         switch (type) {
-            case 'Contact': {
+            case Contact: {
                 return {
-                    name: 'Contact',
+                    name: Contact,
                     properties: [
-                        { name: 'user_name' }
+                        { name: "user_name" }
                     ]
                 };
             }
-            case 'Environment': {
+            case Environment: {
                 return {
-                    name: 'Environment',
+                    name: Environment,
                     properties: [
-                        { name: 'description' },
-                        { name: 'name' }
+                        { name: "description" },
+                        { name: "name" }
                     ]
                 };
             }
-            case 'Requirement': {
+            case Requirement: {
                 return {
-                    name: 'Requirement',
+                    name: Requirement,
                     properties: [
-                        { name: 'environments', defaultValue: [] },
-                        { name: 'name' },
-                        { name: 'text' }
+                        { name: "environments", defaultValue: [] },
+                        { name: "name" },
+                        { name: "text" }
                     ]
                 };
             }
-            case 'RequirementModel': {
+            case RequirementModel: {
                 return {
-                    name: 'RequirementModel',
+                    name: RequirementModel,
                     properties: [
-                        { name: 'contact' },
-                        { name: 'environments', defaultValue: [] },
-                        { name: 'requirements', defaultValue: [] }
+                        { name: "contact" },
+                        { name: "environments", defaultValue: [] },
+                        { name: "requirements", defaultValue: [] }
                     ]
                 };
             }
-            case 'Test': {
+            case Test: {
                 return {
-                    name: 'Test',
+                    name: Test,
                     properties: [
-                        { name: 'environments', defaultValue: [] },
-                        { name: 'name' },
-                        { name: 'requirements', defaultValue: [] },
-                        { name: 'testFile' }
+                        { name: "environments", defaultValue: [] },
+                        { name: "name" },
+                        { name: "requirements", defaultValue: [] },
+                        { name: "testFile" }
                     ]
                 };
             }
-            case 'TestModel': {
+            case TestModel: {
                 return {
-                    name: 'TestModel',
+                    name: TestModel,
                     properties: [
-                        { name: 'contact' },
-                        { name: 'tests', defaultValue: [] }
+                        { name: "contact" },
+                        { name: "tests", defaultValue: [] }
                     ]
                 };
             }

--- a/examples/statemachine/src/language-server/generated/ast.ts
+++ b/examples/statemachine/src/language-server/generated/ast.ts
@@ -91,7 +91,7 @@ export type StatemachineAstType = {
 export class StatemachineAstReflection extends AbstractAstReflection {
 
     getAllTypes(): string[] {
-        return ['Command', 'Event', 'State', 'Statemachine', 'Transition'];
+        return [Command, Event, State, Statemachine, Transition];
     }
 
     protected override computeIsSubtype(subtype: string, supertype: string): boolean {
@@ -105,14 +105,14 @@ export class StatemachineAstReflection extends AbstractAstReflection {
     getReferenceType(refInfo: ReferenceInfo): string {
         const referenceId = `${refInfo.container.$type}:${refInfo.property}`;
         switch (referenceId) {
-            case 'State:actions': {
+            case "State:actions": {
                 return Command;
             }
-            case 'Statemachine:init':
-            case 'Transition:state': {
+            case "Statemachine:init":
+            case "Transition:state": {
                 return State;
             }
-            case 'Transition:event': {
+            case "Transition:event": {
                 return Event;
             }
             default: {
@@ -123,50 +123,50 @@ export class StatemachineAstReflection extends AbstractAstReflection {
 
     getTypeMetaData(type: string): TypeMetaData {
         switch (type) {
-            case 'Command': {
+            case Command: {
                 return {
-                    name: 'Command',
+                    name: Command,
                     properties: [
-                        { name: 'name' }
+                        { name: "name" }
                     ]
                 };
             }
-            case 'Event': {
+            case Event: {
                 return {
-                    name: 'Event',
+                    name: Event,
                     properties: [
-                        { name: 'name' }
+                        { name: "name" }
                     ]
                 };
             }
-            case 'State': {
+            case State: {
                 return {
-                    name: 'State',
+                    name: State,
                     properties: [
-                        { name: 'actions', defaultValue: [] },
-                        { name: 'name' },
-                        { name: 'transitions', defaultValue: [] }
+                        { name: "actions", defaultValue: [] },
+                        { name: "name" },
+                        { name: "transitions", defaultValue: [] }
                     ]
                 };
             }
-            case 'Statemachine': {
+            case Statemachine: {
                 return {
-                    name: 'Statemachine',
+                    name: Statemachine,
                     properties: [
-                        { name: 'commands', defaultValue: [] },
-                        { name: 'events', defaultValue: [] },
-                        { name: 'init' },
-                        { name: 'name' },
-                        { name: 'states', defaultValue: [] }
+                        { name: "commands", defaultValue: [] },
+                        { name: "events", defaultValue: [] },
+                        { name: "init" },
+                        { name: "name" },
+                        { name: "states", defaultValue: [] }
                     ]
                 };
             }
-            case 'Transition': {
+            case Transition: {
                 return {
-                    name: 'Transition',
+                    name: Transition,
                     properties: [
-                        { name: 'event' },
-                        { name: 'state' }
+                        { name: "event" },
+                        { name: "state" }
                     ]
                 };
             }

--- a/packages/langium-cli/src/generator/ast-generator.ts
+++ b/packages/langium-cli/src/generator/ast-generator.ts
@@ -8,7 +8,7 @@ import { type Generated, expandToNode, joinToNode, toString } from 'langium/gene
 import type { AstTypes, Property, PropertyDefaultValue } from 'langium/grammar';
 import type { LangiumConfig } from '../package-types.js';
 import { AstUtils, MultiMap, GrammarAST } from 'langium';
-import { collectAst, collectTypeHierarchy, findReferenceTypes, isAstType, mergeTypesAndInterfaces } from 'langium/grammar';
+import { collectAst, collectTypeHierarchy, findReferenceTypes, isAstType, mergeTypesAndInterfaces, escapeQuotes } from 'langium/grammar';
 import { generatedHeader } from './node-util.js';
 import { collectTerminalRegexps } from './langium-util.js';
 
@@ -54,7 +54,7 @@ function generateAstReflection(config: LangiumConfig, astTypes: AstTypes): Gener
         export class ${config.projectName}AstReflection extends AbstractAstReflection {
 
             getAllTypes(): string[] {
-                return [${typeNames.map(e => `'${e}'`).join(', ')}];
+                return [${typeNames.join(', ')}];
             }
 
             protected override computeIsSubtype(subtype: string, supertype: string): boolean {
@@ -85,9 +85,9 @@ function buildTypeMetaDataMethod(astTypes: AstTypes): Generated {
                         const props = interfaceType.superProperties;
                         return (props.length > 0)
                             ? expandToNode`
-                                case '${interfaceType.name}': {
+                                case ${interfaceType.name}: {
                                     return {
-                                        name: '${interfaceType.name}',
+                                        name: ${interfaceType.name},
                                         properties: [
                                             ${buildPropertyType(props)}
                                         ]
@@ -119,7 +119,7 @@ function buildPropertyType(props: Property[]): Generated {
         all,
         property => {
             const defaultValue = stringifyDefaultValue(property.defaultValue);
-            return `{ name: '${property.name}'${defaultValue ? `, defaultValue: ${defaultValue}` : ''} }`;
+            return `{ name: "${escapeQuotes(property.name)}"${defaultValue ? `, defaultValue: ${defaultValue}` : ''} }`;
         },
         { separator: ',', appendNewLineIfNotEmpty: true}
     );
@@ -127,7 +127,8 @@ function buildPropertyType(props: Property[]): Generated {
 
 function stringifyDefaultValue(value?: PropertyDefaultValue): string | undefined {
     if (typeof value === 'string') {
-        return `"${value}"`;
+        // Escape all double quotes
+        return `"${escapeQuotes(value)}"`;
     } else if (Array.isArray(value)) {
         return `[${value.map(e => stringifyDefaultValue(e)).join(', ')}]`;
     } else if (value !== undefined) {
@@ -147,7 +148,7 @@ function buildReferenceTypeMethod(crossReferenceTypes: CrossReferenceType[]): Ge
                 joinToNode(
                     buckets.entriesGroupedByKey(),
                     ([target, refs]) => expandToNode`
-                        ${joinToNode(refs, ref => `case '${ref}':`, { appendNewLineIfNotEmpty: true, skipNewLineAfterLastItem: true})} {
+                        ${joinToNode(refs, ref => `case "${escapeQuotes(ref)}":`, { appendNewLineIfNotEmpty: true, skipNewLineAfterLastItem: true})} {
                             return ${target};
                         }
                     `,

--- a/packages/langium/src/grammar/type-system/type-collector/types.ts
+++ b/packages/langium/src/grammar/type-system/type-collector/types.ts
@@ -7,7 +7,7 @@
 import { expandToNode, expandToStringWithNL, joinToNode, toString, type Generated } from '../../../generate/index.js';
 import type { CstNode } from '../../../syntax-tree.js';
 import type { Action, Assignment, TypeAttribute } from '../../../languages/generated/ast.js';
-import { distinctAndSorted } from '../types-util.js';
+import { distinctAndSorted, escapeQuotes } from '../types-util.js';
 
 export interface Property {
     name: string;
@@ -381,7 +381,7 @@ export function propertyTypeToString(type?: PropertyType, mode: 'AstType' | 'Dec
         return type.primitive;
     } else if (isStringType(type)) {
         const delimiter = mode === 'AstType' ? "'" : '"';
-        return `${delimiter}${type.string}${delimiter}`;
+        return `${delimiter}${escapeQuotes(type.string, delimiter)}${delimiter}`;
     }
     throw new Error('Invalid type');
 }

--- a/packages/langium/src/grammar/type-system/types-util.ts
+++ b/packages/langium/src/grammar/type-system/types-util.ts
@@ -244,3 +244,11 @@ export function isAstType(type: PropertyType): boolean {
     }
     return false;
 }
+
+export function escapeQuotes(str: string, type: '"' | "'" = '"'): string {
+    if (type === '"') {
+        return str.replace(/"/g, '\\"');
+    } else {
+        return str.replace(/'/g, "\\'");
+    }
+}

--- a/packages/langium/src/languages/generated/ast.ts
+++ b/packages/langium/src/languages/generated/ast.ts
@@ -638,7 +638,7 @@ export type LangiumGrammarAstType = {
 export class LangiumGrammarAstReflection extends AbstractAstReflection {
 
     getAllTypes(): string[] {
-        return ['AbstractElement', 'AbstractRule', 'AbstractType', 'Action', 'Alternatives', 'ArrayLiteral', 'ArrayType', 'Assignment', 'BooleanLiteral', 'CharacterRange', 'Condition', 'Conjunction', 'CrossReference', 'Disjunction', 'EndOfFile', 'Grammar', 'GrammarImport', 'Group', 'InferredType', 'Interface', 'Keyword', 'NamedArgument', 'NegatedToken', 'Negation', 'NumberLiteral', 'Parameter', 'ParameterReference', 'ParserRule', 'ReferenceType', 'RegexToken', 'ReturnType', 'RuleCall', 'SimpleType', 'StringLiteral', 'TerminalAlternatives', 'TerminalGroup', 'TerminalRule', 'TerminalRuleCall', 'Type', 'TypeAttribute', 'TypeDefinition', 'UnionType', 'UnorderedGroup', 'UntilToken', 'ValueLiteral', 'Wildcard'];
+        return [AbstractElement, AbstractRule, AbstractType, Action, Alternatives, ArrayLiteral, ArrayType, Assignment, BooleanLiteral, CharacterRange, Condition, Conjunction, CrossReference, Disjunction, EndOfFile, Grammar, GrammarImport, Group, InferredType, Interface, Keyword, NamedArgument, NegatedToken, Negation, NumberLiteral, Parameter, ParameterReference, ParserRule, ReferenceType, RegexToken, ReturnType, RuleCall, SimpleType, StringLiteral, TerminalAlternatives, TerminalGroup, TerminalRule, TerminalRuleCall, Type, TypeAttribute, TypeDefinition, UnionType, UnorderedGroup, UntilToken, ValueLiteral, Wildcard];
     }
 
     protected override computeIsSubtype(subtype: string, supertype: string): boolean {
@@ -702,26 +702,26 @@ export class LangiumGrammarAstReflection extends AbstractAstReflection {
     getReferenceType(refInfo: ReferenceInfo): string {
         const referenceId = `${refInfo.container.$type}:${refInfo.property}`;
         switch (referenceId) {
-            case 'Action:type':
-            case 'CrossReference:type':
-            case 'Interface:superTypes':
-            case 'ParserRule:returnType':
-            case 'SimpleType:typeRef': {
+            case "Action:type":
+            case "CrossReference:type":
+            case "Interface:superTypes":
+            case "ParserRule:returnType":
+            case "SimpleType:typeRef": {
                 return AbstractType;
             }
-            case 'Grammar:hiddenTokens':
-            case 'ParserRule:hiddenTokens':
-            case 'RuleCall:rule': {
+            case "Grammar:hiddenTokens":
+            case "ParserRule:hiddenTokens":
+            case "RuleCall:rule": {
                 return AbstractRule;
             }
-            case 'Grammar:usedGrammars': {
+            case "Grammar:usedGrammars": {
                 return Grammar;
             }
-            case 'NamedArgument:parameter':
-            case 'ParameterReference:parameter': {
+            case "NamedArgument:parameter":
+            case "ParameterReference:parameter": {
                 return Parameter;
             }
-            case 'TerminalRuleCall:rule': {
+            case "TerminalRuleCall:rule": {
                 return TerminalRule;
             }
             default: {
@@ -732,408 +732,408 @@ export class LangiumGrammarAstReflection extends AbstractAstReflection {
 
     getTypeMetaData(type: string): TypeMetaData {
         switch (type) {
-            case 'AbstractElement': {
+            case AbstractElement: {
                 return {
-                    name: 'AbstractElement',
+                    name: AbstractElement,
                     properties: [
-                        { name: 'cardinality' },
-                        { name: 'lookahead' }
+                        { name: "cardinality" },
+                        { name: "lookahead" }
                     ]
                 };
             }
-            case 'ArrayLiteral': {
+            case ArrayLiteral: {
                 return {
-                    name: 'ArrayLiteral',
+                    name: ArrayLiteral,
                     properties: [
-                        { name: 'elements', defaultValue: [] }
+                        { name: "elements", defaultValue: [] }
                     ]
                 };
             }
-            case 'ArrayType': {
+            case ArrayType: {
                 return {
-                    name: 'ArrayType',
+                    name: ArrayType,
                     properties: [
-                        { name: 'elementType' }
+                        { name: "elementType" }
                     ]
                 };
             }
-            case 'BooleanLiteral': {
+            case BooleanLiteral: {
                 return {
-                    name: 'BooleanLiteral',
+                    name: BooleanLiteral,
                     properties: [
-                        { name: 'true', defaultValue: false }
+                        { name: "true", defaultValue: false }
                     ]
                 };
             }
-            case 'Conjunction': {
+            case Conjunction: {
                 return {
-                    name: 'Conjunction',
+                    name: Conjunction,
                     properties: [
-                        { name: 'left' },
-                        { name: 'right' }
+                        { name: "left" },
+                        { name: "right" }
                     ]
                 };
             }
-            case 'Disjunction': {
+            case Disjunction: {
                 return {
-                    name: 'Disjunction',
+                    name: Disjunction,
                     properties: [
-                        { name: 'left' },
-                        { name: 'right' }
+                        { name: "left" },
+                        { name: "right" }
                     ]
                 };
             }
-            case 'Grammar': {
+            case Grammar: {
                 return {
-                    name: 'Grammar',
+                    name: Grammar,
                     properties: [
-                        { name: 'definesHiddenTokens', defaultValue: false },
-                        { name: 'hiddenTokens', defaultValue: [] },
-                        { name: 'imports', defaultValue: [] },
-                        { name: 'interfaces', defaultValue: [] },
-                        { name: 'isDeclared', defaultValue: false },
-                        { name: 'name' },
-                        { name: 'rules', defaultValue: [] },
-                        { name: 'types', defaultValue: [] },
-                        { name: 'usedGrammars', defaultValue: [] }
+                        { name: "definesHiddenTokens", defaultValue: false },
+                        { name: "hiddenTokens", defaultValue: [] },
+                        { name: "imports", defaultValue: [] },
+                        { name: "interfaces", defaultValue: [] },
+                        { name: "isDeclared", defaultValue: false },
+                        { name: "name" },
+                        { name: "rules", defaultValue: [] },
+                        { name: "types", defaultValue: [] },
+                        { name: "usedGrammars", defaultValue: [] }
                     ]
                 };
             }
-            case 'GrammarImport': {
+            case GrammarImport: {
                 return {
-                    name: 'GrammarImport',
+                    name: GrammarImport,
                     properties: [
-                        { name: 'path' }
+                        { name: "path" }
                     ]
                 };
             }
-            case 'InferredType': {
+            case InferredType: {
                 return {
-                    name: 'InferredType',
+                    name: InferredType,
                     properties: [
-                        { name: 'name' }
+                        { name: "name" }
                     ]
                 };
             }
-            case 'Interface': {
+            case Interface: {
                 return {
-                    name: 'Interface',
+                    name: Interface,
                     properties: [
-                        { name: 'attributes', defaultValue: [] },
-                        { name: 'name' },
-                        { name: 'superTypes', defaultValue: [] }
+                        { name: "attributes", defaultValue: [] },
+                        { name: "name" },
+                        { name: "superTypes", defaultValue: [] }
                     ]
                 };
             }
-            case 'NamedArgument': {
+            case NamedArgument: {
                 return {
-                    name: 'NamedArgument',
+                    name: NamedArgument,
                     properties: [
-                        { name: 'calledByName', defaultValue: false },
-                        { name: 'parameter' },
-                        { name: 'value' }
+                        { name: "calledByName", defaultValue: false },
+                        { name: "parameter" },
+                        { name: "value" }
                     ]
                 };
             }
-            case 'Negation': {
+            case Negation: {
                 return {
-                    name: 'Negation',
+                    name: Negation,
                     properties: [
-                        { name: 'value' }
+                        { name: "value" }
                     ]
                 };
             }
-            case 'NumberLiteral': {
+            case NumberLiteral: {
                 return {
-                    name: 'NumberLiteral',
+                    name: NumberLiteral,
                     properties: [
-                        { name: 'value' }
+                        { name: "value" }
                     ]
                 };
             }
-            case 'Parameter': {
+            case Parameter: {
                 return {
-                    name: 'Parameter',
+                    name: Parameter,
                     properties: [
-                        { name: 'name' }
+                        { name: "name" }
                     ]
                 };
             }
-            case 'ParameterReference': {
+            case ParameterReference: {
                 return {
-                    name: 'ParameterReference',
+                    name: ParameterReference,
                     properties: [
-                        { name: 'parameter' }
+                        { name: "parameter" }
                     ]
                 };
             }
-            case 'ParserRule': {
+            case ParserRule: {
                 return {
-                    name: 'ParserRule',
+                    name: ParserRule,
                     properties: [
-                        { name: 'dataType' },
-                        { name: 'definesHiddenTokens', defaultValue: false },
-                        { name: 'definition' },
-                        { name: 'entry', defaultValue: false },
-                        { name: 'fragment', defaultValue: false },
-                        { name: 'hiddenTokens', defaultValue: [] },
-                        { name: 'inferredType' },
-                        { name: 'name' },
-                        { name: 'parameters', defaultValue: [] },
-                        { name: 'returnType' },
-                        { name: 'wildcard', defaultValue: false }
+                        { name: "dataType" },
+                        { name: "definesHiddenTokens", defaultValue: false },
+                        { name: "definition" },
+                        { name: "entry", defaultValue: false },
+                        { name: "fragment", defaultValue: false },
+                        { name: "hiddenTokens", defaultValue: [] },
+                        { name: "inferredType" },
+                        { name: "name" },
+                        { name: "parameters", defaultValue: [] },
+                        { name: "returnType" },
+                        { name: "wildcard", defaultValue: false }
                     ]
                 };
             }
-            case 'ReferenceType': {
+            case ReferenceType: {
                 return {
-                    name: 'ReferenceType',
+                    name: ReferenceType,
                     properties: [
-                        { name: 'referenceType' }
+                        { name: "referenceType" }
                     ]
                 };
             }
-            case 'ReturnType': {
+            case ReturnType: {
                 return {
-                    name: 'ReturnType',
+                    name: ReturnType,
                     properties: [
-                        { name: 'name' }
+                        { name: "name" }
                     ]
                 };
             }
-            case 'SimpleType': {
+            case SimpleType: {
                 return {
-                    name: 'SimpleType',
+                    name: SimpleType,
                     properties: [
-                        { name: 'primitiveType' },
-                        { name: 'stringType' },
-                        { name: 'typeRef' }
+                        { name: "primitiveType" },
+                        { name: "stringType" },
+                        { name: "typeRef" }
                     ]
                 };
             }
-            case 'StringLiteral': {
+            case StringLiteral: {
                 return {
-                    name: 'StringLiteral',
+                    name: StringLiteral,
                     properties: [
-                        { name: 'value' }
+                        { name: "value" }
                     ]
                 };
             }
-            case 'TerminalRule': {
+            case TerminalRule: {
                 return {
-                    name: 'TerminalRule',
+                    name: TerminalRule,
                     properties: [
-                        { name: 'definition' },
-                        { name: 'fragment', defaultValue: false },
-                        { name: 'hidden', defaultValue: false },
-                        { name: 'name' },
-                        { name: 'type' }
+                        { name: "definition" },
+                        { name: "fragment", defaultValue: false },
+                        { name: "hidden", defaultValue: false },
+                        { name: "name" },
+                        { name: "type" }
                     ]
                 };
             }
-            case 'Type': {
+            case Type: {
                 return {
-                    name: 'Type',
+                    name: Type,
                     properties: [
-                        { name: 'name' },
-                        { name: 'type' }
+                        { name: "name" },
+                        { name: "type" }
                     ]
                 };
             }
-            case 'TypeAttribute': {
+            case TypeAttribute: {
                 return {
-                    name: 'TypeAttribute',
+                    name: TypeAttribute,
                     properties: [
-                        { name: 'defaultValue' },
-                        { name: 'isOptional', defaultValue: false },
-                        { name: 'name' },
-                        { name: 'type' }
+                        { name: "defaultValue" },
+                        { name: "isOptional", defaultValue: false },
+                        { name: "name" },
+                        { name: "type" }
                     ]
                 };
             }
-            case 'UnionType': {
+            case UnionType: {
                 return {
-                    name: 'UnionType',
+                    name: UnionType,
                     properties: [
-                        { name: 'types', defaultValue: [] }
+                        { name: "types", defaultValue: [] }
                     ]
                 };
             }
-            case 'Action': {
+            case Action: {
                 return {
-                    name: 'Action',
+                    name: Action,
                     properties: [
-                        { name: 'cardinality' },
-                        { name: 'feature' },
-                        { name: 'inferredType' },
-                        { name: 'lookahead' },
-                        { name: 'operator' },
-                        { name: 'type' }
+                        { name: "cardinality" },
+                        { name: "feature" },
+                        { name: "inferredType" },
+                        { name: "lookahead" },
+                        { name: "operator" },
+                        { name: "type" }
                     ]
                 };
             }
-            case 'Alternatives': {
+            case Alternatives: {
                 return {
-                    name: 'Alternatives',
+                    name: Alternatives,
                     properties: [
-                        { name: 'cardinality' },
-                        { name: 'elements', defaultValue: [] },
-                        { name: 'lookahead' }
+                        { name: "cardinality" },
+                        { name: "elements", defaultValue: [] },
+                        { name: "lookahead" }
                     ]
                 };
             }
-            case 'Assignment': {
+            case Assignment: {
                 return {
-                    name: 'Assignment',
+                    name: Assignment,
                     properties: [
-                        { name: 'cardinality' },
-                        { name: 'feature' },
-                        { name: 'lookahead' },
-                        { name: 'operator' },
-                        { name: 'terminal' }
+                        { name: "cardinality" },
+                        { name: "feature" },
+                        { name: "lookahead" },
+                        { name: "operator" },
+                        { name: "terminal" }
                     ]
                 };
             }
-            case 'CharacterRange': {
+            case CharacterRange: {
                 return {
-                    name: 'CharacterRange',
+                    name: CharacterRange,
                     properties: [
-                        { name: 'cardinality' },
-                        { name: 'left' },
-                        { name: 'lookahead' },
-                        { name: 'right' }
+                        { name: "cardinality" },
+                        { name: "left" },
+                        { name: "lookahead" },
+                        { name: "right" }
                     ]
                 };
             }
-            case 'CrossReference': {
+            case CrossReference: {
                 return {
-                    name: 'CrossReference',
+                    name: CrossReference,
                     properties: [
-                        { name: 'cardinality' },
-                        { name: 'deprecatedSyntax', defaultValue: false },
-                        { name: 'lookahead' },
-                        { name: 'terminal' },
-                        { name: 'type' }
+                        { name: "cardinality" },
+                        { name: "deprecatedSyntax", defaultValue: false },
+                        { name: "lookahead" },
+                        { name: "terminal" },
+                        { name: "type" }
                     ]
                 };
             }
-            case 'EndOfFile': {
+            case EndOfFile: {
                 return {
-                    name: 'EndOfFile',
+                    name: EndOfFile,
                     properties: [
-                        { name: 'cardinality' },
-                        { name: 'lookahead' }
+                        { name: "cardinality" },
+                        { name: "lookahead" }
                     ]
                 };
             }
-            case 'Group': {
+            case Group: {
                 return {
-                    name: 'Group',
+                    name: Group,
                     properties: [
-                        { name: 'cardinality' },
-                        { name: 'elements', defaultValue: [] },
-                        { name: 'guardCondition' },
-                        { name: 'lookahead' }
+                        { name: "cardinality" },
+                        { name: "elements", defaultValue: [] },
+                        { name: "guardCondition" },
+                        { name: "lookahead" }
                     ]
                 };
             }
-            case 'Keyword': {
+            case Keyword: {
                 return {
-                    name: 'Keyword',
+                    name: Keyword,
                     properties: [
-                        { name: 'cardinality' },
-                        { name: 'lookahead' },
-                        { name: 'value' }
+                        { name: "cardinality" },
+                        { name: "lookahead" },
+                        { name: "value" }
                     ]
                 };
             }
-            case 'NegatedToken': {
+            case NegatedToken: {
                 return {
-                    name: 'NegatedToken',
+                    name: NegatedToken,
                     properties: [
-                        { name: 'cardinality' },
-                        { name: 'lookahead' },
-                        { name: 'terminal' }
+                        { name: "cardinality" },
+                        { name: "lookahead" },
+                        { name: "terminal" }
                     ]
                 };
             }
-            case 'RegexToken': {
+            case RegexToken: {
                 return {
-                    name: 'RegexToken',
+                    name: RegexToken,
                     properties: [
-                        { name: 'cardinality' },
-                        { name: 'lookahead' },
-                        { name: 'regex' }
+                        { name: "cardinality" },
+                        { name: "lookahead" },
+                        { name: "regex" }
                     ]
                 };
             }
-            case 'RuleCall': {
+            case RuleCall: {
                 return {
-                    name: 'RuleCall',
+                    name: RuleCall,
                     properties: [
-                        { name: 'arguments', defaultValue: [] },
-                        { name: 'cardinality' },
-                        { name: 'lookahead' },
-                        { name: 'rule' }
+                        { name: "arguments", defaultValue: [] },
+                        { name: "cardinality" },
+                        { name: "lookahead" },
+                        { name: "rule" }
                     ]
                 };
             }
-            case 'TerminalAlternatives': {
+            case TerminalAlternatives: {
                 return {
-                    name: 'TerminalAlternatives',
+                    name: TerminalAlternatives,
                     properties: [
-                        { name: 'cardinality' },
-                        { name: 'elements', defaultValue: [] },
-                        { name: 'lookahead' }
+                        { name: "cardinality" },
+                        { name: "elements", defaultValue: [] },
+                        { name: "lookahead" }
                     ]
                 };
             }
-            case 'TerminalGroup': {
+            case TerminalGroup: {
                 return {
-                    name: 'TerminalGroup',
+                    name: TerminalGroup,
                     properties: [
-                        { name: 'cardinality' },
-                        { name: 'elements', defaultValue: [] },
-                        { name: 'lookahead' }
+                        { name: "cardinality" },
+                        { name: "elements", defaultValue: [] },
+                        { name: "lookahead" }
                     ]
                 };
             }
-            case 'TerminalRuleCall': {
+            case TerminalRuleCall: {
                 return {
-                    name: 'TerminalRuleCall',
+                    name: TerminalRuleCall,
                     properties: [
-                        { name: 'cardinality' },
-                        { name: 'lookahead' },
-                        { name: 'rule' }
+                        { name: "cardinality" },
+                        { name: "lookahead" },
+                        { name: "rule" }
                     ]
                 };
             }
-            case 'UnorderedGroup': {
+            case UnorderedGroup: {
                 return {
-                    name: 'UnorderedGroup',
+                    name: UnorderedGroup,
                     properties: [
-                        { name: 'cardinality' },
-                        { name: 'elements', defaultValue: [] },
-                        { name: 'lookahead' }
+                        { name: "cardinality" },
+                        { name: "elements", defaultValue: [] },
+                        { name: "lookahead" }
                     ]
                 };
             }
-            case 'UntilToken': {
+            case UntilToken: {
                 return {
-                    name: 'UntilToken',
+                    name: UntilToken,
                     properties: [
-                        { name: 'cardinality' },
-                        { name: 'lookahead' },
-                        { name: 'terminal' }
+                        { name: "cardinality" },
+                        { name: "lookahead" },
+                        { name: "terminal" }
                     ]
                 };
             }
-            case 'Wildcard': {
+            case Wildcard: {
                 return {
-                    name: 'Wildcard',
+                    name: Wildcard,
                     properties: [
-                        { name: 'cardinality' },
-                        { name: 'lookahead' }
+                        { name: "cardinality" },
+                        { name: "lookahead" }
                     ]
                 };
             }


### PR DESCRIPTION
Closes https://github.com/eclipse-langium/langium/issues/1536

Correctly escapes all quotes inside of string values in the generated `ast.ts` file.

Also removes a few quotes in case they weren't needed (like for type references inside the ast reflection). This should improve bundle size.