### PR TITLE
Infer mixed type with action and rule call

### DIFF
--- a/packages/langium/src/grammar/type-system/type-collector/inferred-types.ts
+++ b/packages/langium/src/grammar/type-system/type-collector/inferred-types.ts
@@ -227,7 +227,7 @@ function copyTypePart(value: TypePart): TypePart {
         children: [],
         parents: [],
         actionWithAssignment: value.actionWithAssignment,
-        ruleCalls: [...value.ruleCalls],
+        ruleCalls: value.ruleCalls.slice(),
         properties: value.properties.map(copyProperty),
     };
 }
@@ -236,7 +236,7 @@ function copyTypeAlternative(value: TypeAlternative): TypeAlternative {
     return {
         name: value.name,
         super: value.super,
-        ruleCalls: value.ruleCalls,
+        ruleCalls: value.ruleCalls.slice(),
         properties: value.properties.map(e => copyProperty(e))
     };
 }

--- a/packages/langium/src/grammar/type-system/types-util.ts
+++ b/packages/langium/src/grammar/type-system/types-util.ts
@@ -209,7 +209,7 @@ export function findAstTypes(type: PropertyType): string[] {
     return findAstTypesInternal(type, new Set());
 }
 
-export function findAstTypesInternal(type: PropertyType, visited: Set<PropertyType>): string[] {
+function findAstTypesInternal(type: PropertyType, visited: Set<PropertyType>): string[] {
     if (visited.has(type)) {
         return [];
     } else {
@@ -231,12 +231,21 @@ export function findAstTypesInternal(type: PropertyType, visited: Set<PropertyTy
 }
 
 export function isAstType(type: PropertyType): boolean {
+    return isAstTypeInternal(type, new Set());
+}
+
+export function isAstTypeInternal(type: PropertyType, visited: Set<PropertyType>): boolean {
+    if (visited.has(type)) {
+        return false;
+    } else {
+        visited.add(type);
+    }
     if (isPropertyUnion(type)) {
-        return type.types.every(isAstType);
+        return type.types.every(e => isAstTypeInternal(e, visited));
     } else if (isValueType(type)) {
         const value = type.value;
         if ('type' in value) {
-            return isAstType(value.type);
+            return isAstTypeInternal(value.type, visited);
         } else {
             // Is definitely an interface type
             return true;

--- a/packages/langium/test/grammar/type-system/inferred-types.test.ts
+++ b/packages/langium/test/grammar/type-system/inferred-types.test.ts
@@ -340,6 +340,23 @@ describe('Inferred types', () => {
             }
         `);
     });
+
+    test('Infer mixed types with action and rule call', async () => {
+        await expectTypes(`
+            entry X: {infer Y} value='Y' | Z;
+            Z: value='Z';
+        `, expandToString`
+            export interface Y extends AstNode {
+                readonly $type: 'Y';
+                value: 'Y';
+            }
+            export interface Z extends AstNode {
+                readonly $type: 'Z';
+                value: 'Z';
+            }
+            export type X = Y | Z;
+        `);
+    });
 });
 
 describe('inferred types that are used by the grammar', () => {


### PR DESCRIPTION
Closes https://github.com/eclipse-langium/langium/issues/1540

The main issue was that the array copy call in [line 239](https://github.com/eclipse-langium/langium/blob/c8e01a29d23964f17f26afffbbec918d4407e328/packages/langium/src/grammar/type-system/type-collector/inferred-types.ts#L239) was missing. Instead, all rule calls were copied to all paths, which was pretty incorrect. I believe this accidentally worked as expected but broke with #1473.