### PR TITLE
Fix cyclic formatter behavior

### DIFF
--- a/packages/langium/src/lsp/formatter.ts
+++ b/packages/langium/src/lsp/formatter.ts
@@ -200,9 +200,11 @@ export abstract class AbstractFormatter implements Formatter {
         return false;
     }
 
-    protected isNecessary(edit: TextEdit, document: TextDocument): boolean {
-        const existing = document.getText(edit.range);
-        return existing !== edit.newText;
+    /**
+     * @deprecated This method has been deprecated with 3.1. It now always returns `true` and is no longer used by the default formatter implementation.
+     */
+    protected isNecessary(_edit: TextEdit, _document: TextDocument): boolean {
+        return true;
     }
 
     protected iterateCstFormatting(document: LangiumDocument, formattings: Map<string, FormattingAction>, options: FormattingOptions, range?: Range): TextEdit[] {
@@ -227,7 +229,7 @@ export abstract class AbstractFormatter implements Formatter {
                 if (prependFormatting) {
                     const nodeEdits = this.createTextEdit(lastNode, node, prependFormatting, context);
                     for (const edit of nodeEdits) {
-                        if (edit && this.insideRange(edit.range, range) && this.isNecessary(edit, document.textDocument)) {
+                        if (edit && this.insideRange(edit.range, range)) {
                             edits.push(edit);
                         }
                     }
@@ -240,7 +242,7 @@ export abstract class AbstractFormatter implements Formatter {
                     if (nextNode) {
                         const nodeEdits = this.createTextEdit(node, nextNode, appendFormatting, context);
                         for (const edit of nodeEdits) {
-                            if (edit && this.insideRange(edit.range, range) && this.isNecessary(edit, document.textDocument)) {
+                            if (edit && this.insideRange(edit.range, range)) {
                                 edits.push(edit);
                             }
                         }
@@ -250,7 +252,7 @@ export abstract class AbstractFormatter implements Formatter {
                 if (!prependFormatting && node.hidden) {
                     const hiddenEdits = this.createHiddenTextEdits(lastNode, node, undefined, context);
                     for (const edit of hiddenEdits) {
-                        if (edit && this.insideRange(edit.range, range) && this.isNecessary(edit, document.textDocument)) {
+                        if (edit && this.insideRange(edit.range, range)) {
                             edits.push(edit);
                         }
                     }


### PR DESCRIPTION
Closes https://github.com/eclipse-langium/langium/issues/1362

The issue was that the `isNecessary` logic is too eager in case there are conflicting formattings. To explain in short: Sometimes, this filtered the expected formatting and only left over the "unexpected" formatting. When reformatting, the expected and unexpected formatting "switched places" and this led to cyclic behavior.

Note that this issue wasn't reproducible on Windows, due to erroneous comparisons between `\n` and `\r\n`. 