### PR TITLE
Fix data type rule type computation

### DIFF
--- a/packages/langium/src/parser/langium-parser.ts
+++ b/packages/langium/src/parser/langium-parser.ts
@@ -16,7 +16,7 @@ import type { ValueConverter } from './value-converter.js';
 import { defaultParserErrorProvider, EmbeddedActionsParser, LLkLookaheadStrategy } from 'chevrotain';
 import { LLStarLookaheadStrategy } from 'chevrotain-allstar';
 import { isAssignment, isCrossReference, isKeyword } from '../languages/generated/ast.js';
-import { getExplicitRuleType } from '../utils/grammar-utils.js';
+import { getExplicitRuleType, isDataTypeRule } from '../utils/grammar-utils.js';
 import { assignMandatoryProperties, getContainerOfType, linkContentToContainer } from '../utils/ast-utils.js';
 import { CstNodeBuilder } from './cst-node-builder.js';
 
@@ -218,7 +218,7 @@ export class LangiumParser extends AbstractLangiumParser {
     private computeRuleType(rule: ParserRule): string | symbol | undefined {
         if (rule.fragment) {
             return undefined;
-        } else if (rule.dataType) {
+        } else if (isDataTypeRule(rule)) {
             return DatatypeSymbol;
         } else {
             const explicit = getExplicitRuleType(rule);

--- a/packages/langium/test/parser/langium-parser-builder.test.ts
+++ b/packages/langium/test/parser/langium-parser-builder.test.ts
@@ -508,6 +508,47 @@ describe('Parser calls value converter', () => {
         // Any value that cannot be parsed correctly is automatically false
         expectEqual('d 2022-Peach', false);
     });
+
+    test('Enums are correctly parsed with types', async () => {
+        const parser = await parserFromGrammar(`
+            grammar Test
+
+            entry Main:
+                value=Enum;
+
+            Enum returns Enum: 'A' | 'B' | 'C';
+            type Enum: 'A' | 'B' | 'C';
+
+            hidden terminal WS: /\\s+/;
+        `);
+
+        const result = parser.parse('A');
+        expect(result.lexerErrors.length).toBe(0);
+        expect(result.parserErrors.length).toBe(0);
+        const value = result.value as unknown as { value: string };
+        expect(value.value).toBeTypeOf('string');
+        expect(value.value).toBe('A');
+    });
+
+    test('Enums are correctly parsed without types', async () => {
+        const parser = await parserFromGrammar(`
+            grammar Test
+
+            entry Main:
+                value=Enum;
+
+            Enum returns string: 'A' | 'B' | 'C';
+
+            hidden terminal WS: /\\s+/;
+        `);
+
+        const result = parser.parse('A');
+        expect(result.lexerErrors.length).toBe(0);
+        expect(result.parserErrors.length).toBe(0);
+        const value = result.value as unknown as { value: string };
+        expect(value.value).toBeTypeOf('string');
+        expect(value.value).toBe('A');
+    });
 });
 
 // Constructs a grammar w/ a special token-builder to support multi-mode lexing


### PR DESCRIPTION
Fixes a regression introduced in https://github.com/eclipse-langium/langium/pull/1547 while attempting to perform a parser startup optimization. Reverts the optimization and adds regression tests for that case.