### PR TITLE
Fix false positive multiplicity validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13970,7 +13970,7 @@
       }
     },
     "packages/langium": {
-      "version": "3.1.0",
+      "version": "3.1.1",
       "license": "MIT",
       "dependencies": {
         "chevrotain": "~11.0.3",
@@ -14036,11 +14036,11 @@
       }
     },
     "packages/langium-vscode": {
-      "version": "3.1.0",
+      "version": "3.1.1",
       "license": "MIT",
       "dependencies": {
         "ignore": "~5.2.4",
-        "langium": "3.1.0",
+        "langium": "3.1.1",
         "langium-railroad": "3.1.0",
         "vscode-languageserver": "~9.0.1"
       },

--- a/packages/generator-langium/templates/core/.package.json
+++ b/packages/generator-langium/templates/core/.package.json
@@ -15,7 +15,7 @@
         "langium:watch": "langium generate --watch"
     },
     "dependencies": {
-        "langium": "~3.1.0"
+        "langium": "~3.1.1"
     },
     "devDependencies": {
         "@types/node": "^18.0.0",

--- a/packages/langium-vscode/package.json
+++ b/packages/langium-vscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "langium-vscode",
   "publisher": "langium",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "displayName": "Langium",
   "description": "Support for the Langium Grammar Language",
   "homepage": "https://langium.org",
@@ -95,7 +95,7 @@
     "lint": "eslint src --ext ts"
   },
   "dependencies": {
-    "langium": "3.1.0",
+    "langium": "3.1.1",
     "langium-railroad": "3.1.0",
     "vscode-languageserver": "~9.0.1",
     "ignore": "~5.2.4"

--- a/packages/langium/package.json
+++ b/packages/langium/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langium",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "A language engineering tool for the Language Server Protocol",
   "homepage": "https://langium.org",
   "engines": {

--- a/packages/langium/test/grammar/grammar-validator.test.ts
+++ b/packages/langium/test/grammar/grammar-validator.test.ts
@@ -156,7 +156,6 @@ describe('Langium grammar validation', () => {
             Plus+;
         List3:
             Exp+;
-        // addresses https://github.com/eclipse-langium/langium/pull/1437#pullrequestreview-1994232830
         List4:
             elems += (Minus | Div);
         
@@ -171,12 +170,30 @@ describe('Langium grammar validation', () => {
 
         const validationResult = await validate(grammar);
         expect(validationResult.diagnostics).to.have.length(2);
-        expectError(validationResult, 'Rule call Mult requires assignment when used with multiplicity.', {
-            property: 'cardinality'
+        expectError(validationResult, "Rule call 'Mult' requires assignment when parsed multiple times.", {
+            property: undefined
         });
-        expectError(validationResult, 'Rule call Plus requires assignment when used with multiplicity.', {
-            property: 'cardinality'
+        expectError(validationResult, "Rule call 'Plus' requires assignment when parsed multiple times.", {
+            property: undefined
         });
+    });
+
+    test('Rule calls with multiplicity - negative', async () => {
+        const grammar = `
+        grammar Test
+
+        entry Main:
+            Body* FQN* ID*;
+        fragment Body:
+            value+='test';
+        FQN returns string:
+            ID ('.' ID)*;
+        
+        terminal ID: /[_a-zA-Z][\\w_]*/;
+        `.trim();
+
+        const validationResult = await validate(grammar);
+        expectNoIssues(validationResult);
     });
 });
 

--- a/packages/langium/test/grammar/grammar-validator.test.ts
+++ b/packages/langium/test/grammar/grammar-validator.test.ts
@@ -183,7 +183,12 @@ describe('Langium grammar validation', () => {
         grammar Test
 
         entry Main:
-            Body* FQN* ID*;
+            // Fragment rule
+            Body*
+            // Data type rule
+            FQN*
+            // Terminal rule
+            ID*;
         fragment Body:
             value+='test';
         FQN returns string:


### PR DESCRIPTION
Closes https://github.com/eclipse-langium/langium/issues/1558

Adds exception in case the targeted rule is a data type rule or a terminal rule.

Also already pulls up the versions for the core package and vscode extension.