### PR TITLE
BugFix: Correct isAstTypeInternal checking logic

### DIFF
--- a/packages/langium/src/grammar/type-system/types-util.ts
+++ b/packages/langium/src/grammar/type-system/types-util.ts
@@ -238,6 +238,10 @@ export function isAstTypeInternal(type: PropertyType, visited: Map<PropertyType,
     if (visited.has(type)) {
         return visited.get(type)!;
     }
+    // This is supposed to prevent infinite recursion.
+    // Setting this to true is a pretty safe assumption.
+    // Setting it to false might lead to false negatives for property unions.
+    visited.set(type, true);
 
     let result = false;
 

--- a/packages/langium/src/grammar/type-system/types-util.ts
+++ b/packages/langium/src/grammar/type-system/types-util.ts
@@ -231,27 +231,30 @@ function findAstTypesInternal(type: PropertyType, visited: Set<PropertyType>): s
 }
 
 export function isAstType(type: PropertyType): boolean {
-    return isAstTypeInternal(type, new Set());
+    return isAstTypeInternal(type, new Map());
 }
 
-export function isAstTypeInternal(type: PropertyType, visited: Set<PropertyType>): boolean {
+export function isAstTypeInternal(type: PropertyType, visited: Map<PropertyType, boolean>): boolean {
     if (visited.has(type)) {
-        return false;
-    } else {
-        visited.add(type);
+        return visited.get(type)!;
     }
+
+    let result = false;
+
     if (isPropertyUnion(type)) {
-        return type.types.every(e => isAstTypeInternal(e, visited));
+        result = type.types.every(e => isAstTypeInternal(e, visited));
     } else if (isValueType(type)) {
         const value = type.value;
         if ('type' in value) {
-            return isAstTypeInternal(value.type, visited);
+            result = isAstTypeInternal(value.type, visited);
         } else {
             // Is definitely an interface type
-            return true;
+            result = true;
         }
     }
-    return false;
+
+    visited.set(type, result);
+    return result;
 }
 
 export function escapeQuotes(str: string, type: '"' | "'" = '"'): string {


### PR DESCRIPTION
This corrects a recently found bug where the internal `isAstTypeInternal` logic would return `false` for property types that should otherwise return true. The issue has to do with the fact we always return false when encountering a previously visited prop type, instead of returning it's previously computed result when we visited. To correct, we just make a change from `Set` -> `Map` and adjust the logic accordingly to save results as we go.

I would _really_ like to add a test case to this, but the affected grammar is unable to be shared, and I haven't been able to reliably factor out a small test grammar; at least so far. I'll keep this in draft until we make a decision in this regard.