### PR TITLE
notifyBuildPhase was never called for Parsed state

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "build:clean": "npm run clean && npm run build",
     "lint": "npm run lint --workspaces",
     "test": "vitest",
+    "test:run": "vitest --run",
     "test-ui": "vitest --ui",
     "coverage": "vitest run --coverage",
     "validate-exports": "npm run validate-exports --workspace=langium",

--- a/packages/langium/src/workspace/document-builder.ts
+++ b/packages/langium/src/workspace/document-builder.ts
@@ -357,18 +357,18 @@ export class DefaultDocumentBuilder implements DocumentBuilder {
             await interruptAndCheck(cancelToken);
             await callback(document);
             document.state = targetState;
+            await this.notifyDocumentPhase(document, targetState, cancelToken);
         }
 
         // notify when document state equals target state
         // because initial state for parsed documents is Parsed.
+        const docs = [];
         for (const doc of documents) {
-            const docs = [];
             if (doc.state === targetState) {
-                await this.notifyDocumentPhase(doc, targetState, cancelToken);
                 docs.push(doc);
             }
-            await this.notifyBuildPhase(docs, targetState, cancelToken);
         }
+        await this.notifyBuildPhase(docs, targetState, cancelToken);
         this.currentState = targetState;
     }
 

--- a/packages/langium/src/workspace/document-builder.ts
+++ b/packages/langium/src/workspace/document-builder.ts
@@ -360,15 +360,11 @@ export class DefaultDocumentBuilder implements DocumentBuilder {
             await this.notifyDocumentPhase(document, targetState, cancelToken);
         }
 
-        // notify when document state equals target state
-        // because initial state for parsed documents is Parsed.
-        const docs = [];
-        for (const doc of documents) {
-            if (doc.state === targetState) {
-                docs.push(doc);
-            }
-        }
-        await this.notifyBuildPhase(docs, targetState, cancelToken);
+        // Do not use `filtered` here, as that will miss documents that have previously reached the current target state
+        // For example, this happens in case the cancellation triggers between the processing of two documents
+        // Or files that were picked up during the workspace initialization
+        const targetStateDocs = documents.filter(doc => doc.state === targetState);
+        await this.notifyBuildPhase(targetStateDocs, targetState, cancelToken);
         this.currentState = targetState;
     }
 

--- a/packages/langium/test/workspace/document-builder.test.ts
+++ b/packages/langium/test/workspace/document-builder.test.ts
@@ -4,7 +4,7 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import type { AstNode, Reference, ValidationChecks } from 'langium';
+import type { AstNode, LangiumDocument, Reference, ValidationChecks } from 'langium';
 import { AstUtils, DocumentState, TextDocument, URI, isOperationCancelled } from 'langium';
 import { createServicesForGrammar } from 'langium/grammar';
 import { setTextDocument } from 'langium/test';
@@ -103,7 +103,11 @@ describe('DefaultDocumentBuilder', () => {
 
         const builder = services.shared.workspace.DocumentBuilder;
         const tokenSource1 = new CancellationTokenSource();
-        builder.onBuildPhase(DocumentState.IndexedContent, () => {
+        builder.onBuildPhase(DocumentState.Parsed, (docs: LangiumDocument[]) => {
+            console.log(`Parsed: ${docs[0].uri}`);
+        });
+        builder.onBuildPhase(DocumentState.IndexedContent, (docs: LangiumDocument[]) => {
+            console.log(`Indexed: ${docs[0].uri}`);
             tokenSource1.cancel();
         });
         try {
@@ -393,7 +397,7 @@ describe('DefaultDocumentBuilder', () => {
             expect(isOperationCancelled(err)).toBe(true);
         }
         expect(document1.state).toBe(DocumentState.IndexedReferences);
-        expect(document2.state).toBe(DocumentState.Linked);
+        expect(document2.state).toBe(DocumentState.IndexedReferences);
         expect(buildPhases.has(DocumentState.IndexedReferences)).toBe(false);
     });
 

--- a/packages/langium/test/workspace/document-builder.test.ts
+++ b/packages/langium/test/workspace/document-builder.test.ts
@@ -114,11 +114,11 @@ describe('DefaultDocumentBuilder', () => {
         builder.onBuildPhase(DocumentState.Validated, () => {
             awaiting.push(Promise.resolve());
         });
-        const result = await Promise.all(awaiting);
 
         await builder.build([document], { validation: true });
+        expect(async () => await Promise.all(awaiting)).not.toThrowError();
         expect(document.state).toBe(DocumentState.Validated);
-        expect(result.length).toBe(0);
+        expect(awaiting.length).toBe(6);
     });
 
     test('resumes document build after cancellation', async () => {

--- a/packages/langium/test/workspace/document-builder.test.ts
+++ b/packages/langium/test/workspace/document-builder.test.ts
@@ -397,7 +397,7 @@ describe('DefaultDocumentBuilder', () => {
             expect(isOperationCancelled(err)).toBe(true);
         }
         expect(document1.state).toBe(DocumentState.IndexedReferences);
-        expect(document2.state).toBe(DocumentState.IndexedReferences);
+        expect(document2.state).toBe(DocumentState.Linked);
         expect(buildPhases.has(DocumentState.IndexedReferences)).toBe(false);
     });
 


### PR DESCRIPTION
The first try was more complicated (never pushed). Performing the notification independent of filtering is the simplest and correct solution, IMO. 🙂 