### PR TITLE
Improve type-safety of the TokenBuilder's options

### DIFF
--- a/examples/arithmetics/src/language-server/generated/ast.ts
+++ b/examples/arithmetics/src/language-server/generated/ast.ts
@@ -15,6 +15,8 @@ export const ArithmeticsTerminals = {
     SL_COMMENT: /\/\/[^\n\r]*/,
 };
 
+export type ArithmeticsTerminalNames = keyof typeof ArithmeticsTerminals;
+
 export type AbstractDefinition = DeclaredParameter | Definition;
 
 export const AbstractDefinition = 'AbstractDefinition';

--- a/examples/domainmodel/src/language-server/generated/ast.ts
+++ b/examples/domainmodel/src/language-server/generated/ast.ts
@@ -14,6 +14,8 @@ export const DomainModelTerminals = {
     SL_COMMENT: /\/\/[^\n\r]*/,
 };
 
+export type DomainModelTerminalNames = keyof typeof DomainModelTerminals;
+
 export type AbstractElement = PackageDeclaration | Type;
 
 export const AbstractElement = 'AbstractElement';

--- a/examples/requirements/src/language-server/generated/ast.ts
+++ b/examples/requirements/src/language-server/generated/ast.ts
@@ -15,6 +15,8 @@ export const RequirementsAndTestsTerminals = {
     SL_COMMENT: /\/\/[^\n\r]*/,
 };
 
+export type RequirementsAndTestsTerminalNames = keyof typeof RequirementsAndTestsTerminals;
+
 export interface Contact extends AstNode {
     readonly $container: RequirementModel | TestModel;
     readonly $type: 'Contact';

--- a/examples/statemachine/src/language-server/generated/ast.ts
+++ b/examples/statemachine/src/language-server/generated/ast.ts
@@ -14,6 +14,8 @@ export const StatemachineTerminals = {
     SL_COMMENT: /\/\/[^\n\r]*/,
 };
 
+export type StatemachineTerminalNames = keyof typeof StatemachineTerminals;
+
 export interface Command extends AstNode {
     readonly $container: Statemachine;
     readonly $type: 'Command';

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "eslint": "~8.56.0",
         "eslint-plugin-header": "~3.1.1",
         "shx": "~0.3.4",
-        "typescript": "~5.1.6",
+        "typescript": "~5.4.5",
         "vitest": "~1.5.0"
       },
       "engines": {
@@ -10975,10 +10975,11 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
-      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -31,16 +31,16 @@
     "@vitest/coverage-v8": "~1.0.0",
     "@vitest/ui": "~1.5.0",
     "concurrently": "~8.2.1",
+    "editorconfig": "~2.0.0",
     "esbuild": "~0.19.2",
     "eslint": "~8.56.0",
     "eslint-plugin-header": "~3.1.1",
-    "editorconfig": "~2.0.0",
     "shx": "~0.3.4",
-    "typescript": "~5.1.6",
+    "typescript": "~5.4.5",
     "vitest": "~1.5.0"
   },
   "overrides": {
-   "@types/node": "~16.18.41"
+    "@types/node": "~16.18.41"
   },
   "volta": {
     "node": "18.19.1",

--- a/packages/langium-cli/src/generator/ast-generator.ts
+++ b/packages/langium-cli/src/generator/ast-generator.ts
@@ -240,6 +240,7 @@ function generateTerminalConstants(grammars: Grammar[], config: LangiumConfig): 
         export const ${config.projectName}Terminals = {
             ${joinToNode(Object.entries(collection), ([name, regexp]) => `${name}: ${regexp.toString()},`, { appendNewLineIfNotEmpty: true })}
         };
+
+        export type ${config.projectName}TerminalNames = keyof typeof ${config.projectName}Terminals;
     `.appendNewLine();
 }
-

--- a/packages/langium-cli/test/generator/ast-generator.test.ts
+++ b/packages/langium-cli/test/generator/ast-generator.test.ts
@@ -461,7 +461,7 @@ function testGeneratedInterface(name: string, grammar: string, expected: string)
 }
 
 function testGeneratedAst(name: string, grammar: string, expected: string): void {
-    testGenerated(name, grammar, expected, 'export type', 'export type testAstType');
+    testGenerated(name, grammar, expected, 'export type A', 'export type testAstType');
 }
 
 function testTypeMetaData(name: string, grammar: string, expected: string): void {

--- a/packages/langium-cli/test/generator/ast-generator.test.ts
+++ b/packages/langium-cli/test/generator/ast-generator.test.ts
@@ -461,14 +461,14 @@ function testGeneratedInterface(name: string, grammar: string, expected: string)
 }
 
 function testGeneratedAst(name: string, grammar: string, expected: string): void {
-    testGenerated(name, grammar, expected, 'export type A', 'export type testAstType');
+    testGenerated(name, grammar, expected, 'export type', 'export type testAstType', 1);
 }
 
 function testTypeMetaData(name: string, grammar: string, expected: string): void {
     testGenerated(name, grammar, expected, 'getTypeMetaData', 'export const reflection');
 }
 
-function testGenerated(name: string, grammar: string, expected: string, start: string, end: string): void {
+function testGenerated(name: string, grammar: string, expected: string, start: string, end: string, startCount = 0): void {
     test(name, async () => {
         const result = (await parse(grammar)).parseResult;
         const config: LangiumConfig = {
@@ -478,7 +478,11 @@ function testGenerated(name: string, grammar: string, expected: string, start: s
         };
         const expectedPart = normalizeEOL(expected).trim();
         const typesFileContent = generateAst(services.grammar, [result.value], config);
-        const relevantPart = typesFileContent.substring(typesFileContent.indexOf(start), typesFileContent.indexOf(end)).trim();
+        let startIndex = typesFileContent.indexOf(start);
+        for (let i = 0; i < startCount; i++) {
+            startIndex = typesFileContent.indexOf(start, startIndex + start.length);
+        }
+        const relevantPart = typesFileContent.substring(startIndex, typesFileContent.indexOf(end)).trim();
         expect(relevantPart).toEqual(expectedPart);
     });
 }

--- a/packages/langium/src/languages/generated/ast.ts
+++ b/packages/langium/src/languages/generated/ast.ts
@@ -17,6 +17,8 @@ export const LangiumGrammarTerminals = {
     SL_COMMENT: /\/\/[^\n\r]*/,
 };
 
+export type LangiumGrammarTerminalNames = keyof typeof LangiumGrammarTerminals;
+
 export type AbstractRule = ParserRule | TerminalRule;
 
 export const AbstractRule = 'AbstractRule';

--- a/packages/langium/src/parser/indentation-aware.ts
+++ b/packages/langium/src/parser/indentation-aware.ts
@@ -13,7 +13,7 @@ import { createToken, createTokenInstance, Lexer } from 'chevrotain';
 import { DefaultTokenBuilder } from './token-builder.js';
 import { DefaultLexer, isTokenTypeArray } from './lexer.js';
 
-export interface IndentationTokenBuilderOptions {
+export interface IndentationTokenBuilderOptions<TokenName extends string = string> {
     /**
      * The name of the token used to denote indentation in the grammar.
      * A possible definition in the grammar could look like this:
@@ -23,7 +23,7 @@ export interface IndentationTokenBuilderOptions {
      *
      * @default 'INDENT'
      */
-    indentTokenName: string;
+    indentTokenName: TokenName;
     /**
      * The name of the token used to denote deindentation in the grammar.
      * A possible definition in the grammar could look like this:
@@ -33,7 +33,7 @@ export interface IndentationTokenBuilderOptions {
      *
      * @default 'DEDENT'
      */
-    dedentTokenName: string;
+    dedentTokenName: TokenName;
     /**
      * The name of the token used to denote whitespace other than indentation and newlines in the grammar.
      * A possible definition in the grammar could look like this:
@@ -43,7 +43,7 @@ export interface IndentationTokenBuilderOptions {
      *
      * @default 'WS'
      */
-    whitespaceTokenName: string;
+    whitespaceTokenName: TokenName;
 }
 
 export const indentationBuilderDefaultOptions: IndentationTokenBuilderOptions = {
@@ -58,13 +58,13 @@ export const indentationBuilderDefaultOptions: IndentationTokenBuilderOptions = 
  *
  * Inspired by https://github.com/chevrotain/chevrotain/blob/master/examples/lexer/python_indentation/python_indentation.js
  */
-export class IndentationAwareTokenBuilder extends DefaultTokenBuilder {
+export class IndentationAwareTokenBuilder<Terminals extends string = string> extends DefaultTokenBuilder {
     /**
      * The stack in which all the previous matched indentation levels are stored
      * to understand how deep a the next tokens are nested.
      */
     protected indentationStack: number[] = [0];
-    readonly options: IndentationTokenBuilderOptions;
+    readonly options: IndentationTokenBuilderOptions<Terminals>;
 
     /**
      * The token type to be used for indentation tokens
@@ -82,10 +82,10 @@ export class IndentationAwareTokenBuilder extends DefaultTokenBuilder {
      */
     protected whitespaceRegExp = /[ \t]+/y;
 
-    constructor(options: Partial<IndentationTokenBuilderOptions> = indentationBuilderDefaultOptions) {
+    constructor(options: Partial<IndentationTokenBuilderOptions<NoInfer<Terminals>>> = indentationBuilderDefaultOptions as IndentationTokenBuilderOptions<Terminals>) {
         super();
         this.options = {
-            ...indentationBuilderDefaultOptions,
+            ...indentationBuilderDefaultOptions as IndentationTokenBuilderOptions<Terminals>,
             ...options,
         };
 


### PR DESCRIPTION
It now optionally accepts a generic parameter that is a type union of the names of the available terminals of the given language. It should generally be `keyof typeof MyLanguageTerminals` imported from `'./generated/ast.js'`.

Usage:
```ts
import { MyLanguageTerminals } from './generated/ast.js';

type MyTerminals = keyof typeof MyLanguageTerminals;

export const MyLanguageModule: Module<MyLanguageServices, PartialLangiumServices & MyLanguageAddedServices> = {
    parser: {
        TokenBuilder: () => new IndentationAwareTokenBuilder<MyTerminals>({
            indentTokenName: '' // <-- Now this will require that the given string is actually the name of a token defined in the grammar
                                // and IntelliSense can suggest real token names
        }),
        Lexer: (services) => new IndentationAwareLexer(services),
    },
};
```

If the generic parameter is not passed, if falls back to the previous behaviour of simply using strings.