### PR TITLE
Hotfix: undefined token on indentation-aware empty input

### DIFF
--- a/packages/langium/src/parser/indentation-aware.ts
+++ b/packages/langium/src/parser/indentation-aware.ts
@@ -359,7 +359,9 @@ export class IndentationAwareLexer extends DefaultLexer {
             cleanTokens.push(token);
         }
         // Push last token separately
-        cleanTokens.push(result.tokens[length]);
+        if (length >= 0) {
+            cleanTokens.push(result.tokens[length]);
+        }
         result.tokens = cleanTokens;
 
         return result;

--- a/packages/langium/test/parser/indentation-aware.test.ts
+++ b/packages/langium/test/parser/indentation-aware.test.ts
@@ -192,6 +192,12 @@ describe('IndentationAwareLexer', () => {
         expect(dedent.tokenType.name).toBe('DEDENT');
     });
 
+    test('should not return any tokens for empty input', async () => {
+        const lexer = await getLexer(sampleGrammar);
+        const { tokens } = lexer.tokenize('');
+        expect(tokens).toHaveLength(0);
+    });
+
 });
 
 describe('IndentationAware parsing', () => {


### PR DESCRIPTION
If the input was empty, the `IndentationAwareLexer` would previously return `[ undefined ]` for the list of tokens.