### PR TITLE
Fix language server in standalone mode

### DIFF
--- a/packages/langium-vscode/src/language-server/grammar-workspace-manager.ts
+++ b/packages/langium-vscode/src/language-server/grammar-workspace-manager.ts
@@ -32,7 +32,7 @@ export class LangiumGrammarWorkspaceManager extends DefaultWorkspaceManager {
 
     override async initializeWorkspace(folders: WorkspaceFolder[], cancelToken = Cancellation.CancellationToken.None): Promise<void> {
         const buildConf: WorkspaceManagerConf = await this.configurationProvider.getConfiguration('langium', CONFIG_KEY);
-        const ignorePatterns = buildConf.ignorePatterns?.split(',')?.map(pattern => pattern.trim())?.filter(pattern => pattern.length > 0);
+        const ignorePatterns = buildConf?.ignorePatterns?.split(',')?.map(pattern => pattern.trim())?.filter(pattern => pattern.length > 0);
         this.matcher = ignorePatterns ? ignore.default().add(ignorePatterns) : undefined;
         return super.initializeWorkspace(folders, cancelToken);
     }


### PR DESCRIPTION
Running language server without VS Code and without build configuration resulted in an exception. This is fixed now.

ECL signed.