### PR TITLE
Add support for overriding semantic token types

### DIFF
--- a/packages/langium/src/lsp/language-server.ts
+++ b/packages/langium/src/lsp/language-server.ts
@@ -37,7 +37,7 @@ import type { ConfigurationInitializedParams } from '../workspace/configuration.
 import { DocumentState, type LangiumDocument } from '../workspace/documents.js';
 import { mergeCompletionProviderOptions } from './completion/completion-provider.js';
 import type { LangiumSharedServices, PartialLangiumLSPServices } from './lsp-services.js';
-import { mergeSemanticProviderOptions } from './semantic-token-provider.js';
+import { mergeSemanticTokenProviderOptions } from './semantic-token-provider.js';
 import { mergeSignatureHelpOptions } from './signature-help-provider.js';
 
 export interface LanguageServer {
@@ -105,7 +105,7 @@ export class DefaultLanguageServer implements LanguageServer {
         const formattingOnTypeOptions = allServices.map(e => e.lsp?.Formatter?.formatOnTypeOptions).find(e => Boolean(e));
         const hasCodeActionProvider = this.hasService(e => e.lsp?.CodeActionProvider);
         const hasSemanticTokensProvider = this.hasService(e => e.lsp?.SemanticTokenProvider);
-        const semanticTokensOptions = mergeSemanticProviderOptions(allServices.map(e => e.lsp?.SemanticTokenProvider?.semanticTokensOptions));
+        const semanticTokensOptions = mergeSemanticTokenProviderOptions(allServices.map(e => e.lsp?.SemanticTokenProvider?.semanticTokensOptions));
         const commandNames = this.services.lsp?.ExecuteCommandHandler?.commands;
         const hasDocumentLinkProvider = this.hasService(e => e.lsp?.DocumentLinkProvider);
         const signatureHelpOptions = mergeSignatureHelpOptions(allServices.map(e => e.lsp?.SignatureHelp?.signatureHelpOptions));

--- a/packages/langium/src/lsp/language-server.ts
+++ b/packages/langium/src/lsp/language-server.ts
@@ -37,7 +37,7 @@ import type { ConfigurationInitializedParams } from '../workspace/configuration.
 import { DocumentState, type LangiumDocument } from '../workspace/documents.js';
 import { mergeCompletionProviderOptions } from './completion/completion-provider.js';
 import type { LangiumSharedServices, PartialLangiumLSPServices } from './lsp-services.js';
-import { DefaultSemanticTokenOptions } from './semantic-token-provider.js';
+import { mergeSemanticProviderOptions } from './semantic-token-provider.js';
 import { mergeSignatureHelpOptions } from './signature-help-provider.js';
 
 export interface LanguageServer {
@@ -105,6 +105,7 @@ export class DefaultLanguageServer implements LanguageServer {
         const formattingOnTypeOptions = allServices.map(e => e.lsp?.Formatter?.formatOnTypeOptions).find(e => Boolean(e));
         const hasCodeActionProvider = this.hasService(e => e.lsp?.CodeActionProvider);
         const hasSemanticTokensProvider = this.hasService(e => e.lsp?.SemanticTokenProvider);
+        const semanticTokensOptions = mergeSemanticProviderOptions(allServices.map(e => e.lsp?.SemanticTokenProvider?.semanticTokensOptions));
         const commandNames = this.services.lsp?.ExecuteCommandHandler?.commands;
         const hasDocumentLinkProvider = this.hasService(e => e.lsp?.DocumentLinkProvider);
         const signatureHelpOptions = mergeSignatureHelpOptions(allServices.map(e => e.lsp?.SignatureHelp?.signatureHelpOptions));
@@ -160,7 +161,7 @@ export class DefaultLanguageServer implements LanguageServer {
                     prepareProvider: true
                 } : undefined,
                 semanticTokensProvider: hasSemanticTokensProvider
-                    ? DefaultSemanticTokenOptions
+                    ? semanticTokensOptions
                     : undefined,
                 signatureHelpProvider: signatureHelpOptions,
                 implementationProvider: hasGoToImplementationProvider,

--- a/packages/langium/src/lsp/semantic-token-provider.ts
+++ b/packages/langium/src/lsp/semantic-token-provider.ts
@@ -18,14 +18,49 @@ import { interruptAndCheck } from '../utils/promise-utils.js';
 import type { LangiumDocument } from '../workspace/documents.js';
 import type { LangiumServices } from './lsp-services.js';
 
-export const AllSemanticTokenTypes: string[] = Object.keys(SemanticTokenTypes);
+export const AllSemanticTokenTypes: Record<string, number> = {
+    [SemanticTokenTypes.class]: 0,
+    [SemanticTokenTypes.comment]: 1,
+    [SemanticTokenTypes.enum]: 2,
+    [SemanticTokenTypes.enumMember]: 3,
+    [SemanticTokenTypes.event]: 4,
+    [SemanticTokenTypes.function]: 5,
+    [SemanticTokenTypes.interface]: 6,
+    [SemanticTokenTypes.keyword]: 7,
+    [SemanticTokenTypes.macro]: 8,
+    [SemanticTokenTypes.method]: 9,
+    [SemanticTokenTypes.modifier]: 10,
+    [SemanticTokenTypes.namespace]: 11,
+    [SemanticTokenTypes.number]: 12,
+    [SemanticTokenTypes.operator]: 13,
+    [SemanticTokenTypes.parameter]: 14,
+    [SemanticTokenTypes.property]: 15,
+    [SemanticTokenTypes.regexp]: 16,
+    [SemanticTokenTypes.string]: 17,
+    [SemanticTokenTypes.struct]: 18,
+    [SemanticTokenTypes.type]: 19,
+    [SemanticTokenTypes.typeParameter]: 20,
+    [SemanticTokenTypes.variable]: 21,
+    [SemanticTokenTypes.decorator]: 22
+};
 
-export const AllSemanticTokenModifiers: string[] = Object.keys(SemanticTokenModifiers);
+export const AllSemanticTokenModifiers: Record<string, number> = {
+    [SemanticTokenModifiers.abstract]: 1 << 0,
+    [SemanticTokenModifiers.async]: 1 << 1,
+    [SemanticTokenModifiers.declaration]: 1 << 2,
+    [SemanticTokenModifiers.defaultLibrary]: 1 << 3,
+    [SemanticTokenModifiers.definition]: 1 << 4,
+    [SemanticTokenModifiers.deprecated]: 1 << 5,
+    [SemanticTokenModifiers.documentation]: 1 << 6,
+    [SemanticTokenModifiers.modification]: 1 << 7,
+    [SemanticTokenModifiers.readonly]: 1 << 8,
+    [SemanticTokenModifiers.static]: 1 << 9
+};
 
 export const DefaultSemanticTokenOptions: SemanticTokensOptions = {
     legend: {
-        tokenTypes: AllSemanticTokenTypes,
-        tokenModifiers: AllSemanticTokenModifiers,
+        tokenTypes: Object.keys(AllSemanticTokenTypes),
+        tokenModifiers: Object.keys(AllSemanticTokenModifiers)
     },
     full: {
         delta: true
@@ -37,8 +72,8 @@ export interface SemanticTokenProvider {
     semanticHighlight(document: LangiumDocument, params: SemanticTokensParams, cancelToken?: CancellationToken): MaybePromise<SemanticTokens>
     semanticHighlightRange(document: LangiumDocument, params: SemanticTokensRangeParams, cancelToken?: CancellationToken): MaybePromise<SemanticTokens>
     semanticHighlightDelta(document: LangiumDocument, params: SemanticTokensDeltaParams, cancelToken?: CancellationToken): MaybePromise<SemanticTokens | SemanticTokensDelta>
-    readonly tokenTypes: string[]
-    readonly tokenModifiers: string[]
+    readonly tokenTypes: Record<string, number>
+    readonly tokenModifiers: Record<string, number>
     readonly semanticTokensOptions: SemanticTokensOptions
 }
 
@@ -199,11 +234,11 @@ export abstract class AbstractSemanticTokenProvider implements SemanticTokenProv
         this.clientCapabilities = clientCapabilities;
     }
 
-    get tokenTypes(): string[] {
+    get tokenTypes(): Record<string, number> {
         return AllSemanticTokenTypes;
     }
 
-    get tokenModifiers(): string[] {
+    get tokenModifiers(): Record<string, number> {
         return AllSemanticTokenModifiers;
     }
 
@@ -318,14 +353,14 @@ export abstract class AbstractSemanticTokenProvider implements SemanticTokenProv
         if ((this.currentRange && !inRange(range, this.currentRange)) || !this.currentDocument || !this.currentTokensBuilder) {
             return;
         }
-        const intType = this.tokenTypes.indexOf(type);
+        const intType = this.tokenTypes[type];
         let totalModifier = 0;
         if (modifiers !== undefined) {
             if (typeof modifiers === 'string') {
                 modifiers = [modifiers];
             }
             for (const modifier of modifiers) {
-                const intModifier = 1 << this.tokenModifiers.indexOf(modifier);
+                const intModifier = this.tokenModifiers[modifier];
                 totalModifier |= intModifier;
             }
         }
@@ -443,9 +478,9 @@ export namespace SemanticTokensDecoder {
         text: string;
     }
 
-    export function decode<T extends AstNode = AstNode>(tokens: SemanticTokens, tokenTypes: string[], document: LangiumDocument<T>): DecodedSemanticToken[] {
+    export function decode<T extends AstNode = AstNode>(tokens: SemanticTokens, tokenTypes: Record<string, number>, document: LangiumDocument<T>): DecodedSemanticToken[] {
         const typeMap = new Map<number, SemanticTokenTypes>();
-        tokenTypes.forEach((type, index) => typeMap.set(index, type as SemanticTokenTypes));
+        Object.entries(tokenTypes).forEach(([type, index]) => typeMap.set(index, type as SemanticTokenTypes));
         let line = 0;
         let character = 0;
         return sliceIntoChunks(tokens.data, 5).map(t => {

--- a/packages/langium/src/test/langium-test.ts
+++ b/packages/langium/src/test/langium-test.ts
@@ -736,7 +736,7 @@ export function highlightHelper<T extends AstNode = AstNode>(services: LangiumSe
         const document = await parse(input, options);
         const params: SemanticTokensParams = { textDocument: { uri: document.textDocument.uri } };
         const tokens = await tokenProvider.semanticHighlight(document, params);
-        return { tokens: SemanticTokensDecoder.decode(tokens, document), ranges };
+        return { tokens: SemanticTokensDecoder.decode(tokens, tokenProvider.tokenTypes, document), ranges };
     };
 }
 


### PR DESCRIPTION
Closes #1515 

Example usage:
```ts
export class MySemanticTokenProvider extends AbstractSemanticTokenProvider {
    override get tokenTypes() {
        return {
            ...super.tokenTypes,
            myTokenType: 23,
        };
    }
    // ...
}
```

To be honest, I don't like the manual numbering and would instead prefer to just use an array of strings (and maybe something like `Object.fromEntries(tokenTypes.map((tokenType, idx) => [tokenType, idx]))` to reconstruct the object if needed), but I tried to stick with the current interface as much as possible. Is there a use case in which manually assigning the indexes is preferred?