### PR TITLE
Support ignoring indentation within delimiters

### DIFF
--- a/packages/langium/src/parser/indentation-aware.ts
+++ b/packages/langium/src/parser/indentation-aware.ts
@@ -13,6 +13,8 @@ import { createToken, createTokenInstance, Lexer } from 'chevrotain';
 import { DefaultTokenBuilder } from './token-builder.js';
 import { DefaultLexer, isTokenTypeArray } from './lexer.js';
 
+type IndentationAwareDelimiter<TokenName extends string> = [begin: TokenName, end: TokenName];
+
 export interface IndentationTokenBuilderOptions<TokenName extends string = string> {
     /**
      * The name of the token used to denote indentation in the grammar.
@@ -53,7 +55,7 @@ export interface IndentationTokenBuilderOptions<TokenName extends string = strin
      *
      * @default []
      */
-    ignoreIndentationDelimeters: Array<[begin: TokenName, end: TokenName]>
+    ignoreIndentationDelimeters: Array<IndentationAwareDelimiter<TokenName>>
 }
 
 export const indentationBuilderDefaultOptions: IndentationTokenBuilderOptions = {

--- a/packages/langium/src/parser/indentation-aware.ts
+++ b/packages/langium/src/parser/indentation-aware.ts
@@ -45,8 +45,8 @@ export interface IndentationTokenBuilderOptions<TokenName extends string = strin
      */
     whitespaceTokenName: TokenName;
     /**
-     * The delimeter tokens inside of which indentation should be ignored and treated as normal whitespace.
-     * For example, Python doesn't treat any whitespace between `'('` and `')'` as significant.
+     * The delimiter tokens inside of which indentation should be ignored and treated as normal whitespace.
+     * For example, Python doesn't treat any whitespace between `(` and `)` as significant.
      *
      * Note that this works only with terminal tokens, not keyword tokens,
      * so for `'('` you will have to define `terminal L_PAREN: /\(/;` and pass `'L_PAREN'` here.

--- a/packages/langium/test/parser/indentation-aware.test.ts
+++ b/packages/langium/test/parser/indentation-aware.test.ts
@@ -20,8 +20,12 @@ const tokenBuilder = new IndentationAwareTokenBuilder();
 
 async function getTokens(grammarString: string): Promise<TokenType[]> {
     const grammar = (await helper(grammarString)).parseResult.value;
-    const { modes, defaultMode } = tokenBuilder.buildTokens(grammar);
-    return modes[defaultMode] as TokenType[];
+    const tokens = tokenBuilder.buildTokens(grammar);
+    if (Array.isArray(tokens)) {
+        return tokens;
+    } else {
+        return tokens.modes[tokens.defaultMode];
+    }
 }
 
 async function getLexer(grammar: string, options?: Partial<IndentationTokenBuilderOptions>): Promise<Lexer> {

--- a/packages/langium/test/parser/indentation-aware.test.ts
+++ b/packages/langium/test/parser/indentation-aware.test.ts
@@ -216,16 +216,12 @@ describe('IndentationAwareTokenBuilder#ignoreIndentationDelimeters', async () =>
 
         Expression: List | Tuple | BOOLEAN;
 
-        Tuple: L_PAREN  (elements+=Expression (',' elements+=Expression)*)? R_PAREN;
-        List: L_BRACKET (elements+=Expression (',' elements+=Expression)*)? R_BRACKET;
+        Tuple: '('  (elements+=Expression (',' elements+=Expression)*)? ')';
+        List: '[' (elements+=Expression (',' elements+=Expression)*)? ']';
 
         terminal BOOLEAN returns boolean: /true|false/;
         terminal INDENT: 'synthetic:indent';
         terminal DEDENT: 'synthetic:dedent';
-        terminal L_PAREN: '(';
-        terminal R_PAREN: ')';
-        terminal L_BRACKET: '[';
-        terminal R_BRACKET: ']';
         hidden terminal NL: /[\\r\\n]+/;
         hidden terminal WS: /[\\t ]+/;
         hidden terminal SL_COMMENT: /\\/\\/[^\\n\\r]*/;
@@ -233,8 +229,8 @@ describe('IndentationAwareTokenBuilder#ignoreIndentationDelimeters', async () =>
 
     const lexer = await getLexer(grammar, {
         ignoreIndentationDelimeters: [
-            ['L_PAREN', 'R_PAREN'],
-            ['L_BRACKET', 'R_BRACKET'],
+            ['(', ')'],
+            ['[', ']'],
         ],
     });
 

--- a/packages/langium/test/parser/indentation-aware.test.ts
+++ b/packages/langium/test/parser/indentation-aware.test.ts
@@ -5,7 +5,7 @@
  ******************************************************************************/
 
 import type { TokenType } from '@chevrotain/types';
-import type { AstNode, Grammar, LangiumParser, Lexer, Module } from 'langium';
+import type { AstNode, Grammar, IndentationTokenBuilderOptions, LangiumParser, Lexer, Module } from 'langium';
 import { beforeEach, describe, expect, test } from 'vitest';
 import { EmptyFileSystem, IndentationAwareLexer, IndentationAwareTokenBuilder } from 'langium';
 import { createLangiumGrammarServices, createServicesForGrammar } from 'langium/grammar';
@@ -20,25 +20,26 @@ const tokenBuilder = new IndentationAwareTokenBuilder();
 
 async function getTokens(grammarString: string): Promise<TokenType[]> {
     const grammar = (await helper(grammarString)).parseResult.value;
-    return tokenBuilder.buildTokens(grammar) as TokenType[];
+    const { modes, defaultMode } = tokenBuilder.buildTokens(grammar);
+    return modes[defaultMode] as TokenType[];
 }
 
-async function getLexer(grammar: string): Promise<Lexer> {
-    const services = await createIndentationAwareServices(grammar);
+async function getLexer(grammar: string, options?: Partial<IndentationTokenBuilderOptions>): Promise<Lexer> {
+    const services = await createIndentationAwareServices(grammar, options);
     return services.parser.Lexer;
 }
 
-async function getParser(grammar: string): Promise<LangiumParser> {
-    const services = await createIndentationAwareServices(grammar);
+async function getParser(grammar: string, options?: Partial<IndentationTokenBuilderOptions>): Promise<LangiumParser> {
+    const services = await createIndentationAwareServices(grammar, options);
     return services.parser.LangiumParser;
 }
 
-async function createIndentationAwareServices(grammar: string): Promise<LangiumServices> {
+async function createIndentationAwareServices(grammar: string, options?: Partial<IndentationTokenBuilderOptions>): Promise<LangiumServices> {
     const services = await createServicesForGrammar({
         grammar,
         module: {
             parser: {
-                TokenBuilder: () => new IndentationAwareTokenBuilder(),
+                TokenBuilder: () => new IndentationAwareTokenBuilder(options),
                 Lexer: services => new IndentationAwareLexer(services)
             }
         } satisfies Module<LangiumServices, PartialLangiumServices>
@@ -68,10 +69,9 @@ describe('IndentationAwareTokenBuilder', () => {
 
         expect(tokenTypes).toHaveLength(5);
 
-        const [dedent, indent, ws] = tokenTypes;
+        const [dedent, indent] = tokenTypes;
         expect(dedent.name).toBe('DEDENT');
         expect(indent.name).toBe('INDENT');
-        expect(ws.name).toBe('WS');
     });
 
     test('Modifies indent/dedent patterns to be functions', async () => {
@@ -196,6 +196,98 @@ describe('IndentationAwareLexer', () => {
         const lexer = await getLexer(sampleGrammar);
         const { tokens } = lexer.tokenize('');
         expect(tokens).toHaveLength(0);
+    });
+
+});
+
+describe('IndentationAwareTokenBuilder#ignoreIndentationDelimeters', async () => {
+
+    const grammar = `
+        grammar PythonIfWithLists
+
+        entry Statement: (If | Return)*;
+
+        If:
+            'if' condition=BOOLEAN ':'
+            INDENT thenBlock+=Statement+ DEDENT
+            ('else' ':' INDENT elseBlock+=Statement+ DEDENT)?;
+
+        Return: 'return' value=Expression;
+
+        Expression: List | Tuple | BOOLEAN;
+
+        Tuple: L_PAREN  (elements+=Expression (',' elements+=Expression)*)? R_PAREN;
+        List: L_BRACKET (elements+=Expression (',' elements+=Expression)*)? R_BRACKET;
+
+        terminal BOOLEAN returns boolean: /true|false/;
+        terminal INDENT: 'synthetic:indent';
+        terminal DEDENT: 'synthetic:dedent';
+        terminal L_PAREN: '(';
+        terminal R_PAREN: ')';
+        terminal L_BRACKET: '[';
+        terminal R_BRACKET: ']';
+        hidden terminal NL: /[\\r\\n]+/;
+        hidden terminal WS: /[\\t ]+/;
+        hidden terminal SL_COMMENT: /\\/\\/[^\\n\\r]*/;
+    `;
+
+    const lexer = await getLexer(grammar, {
+        ignoreIndentationDelimeters: [
+            ['L_PAREN', 'R_PAREN'],
+            ['L_BRACKET', 'R_BRACKET'],
+        ],
+    });
+
+    test('should behave as usual without the given tokens in the input', async () => {
+        const { errors } = lexer.tokenize(expandToString`
+        if true:
+            return false
+        else:
+            return true
+        `);
+        expect(errors).toHaveLength(0);
+    });
+
+    test('should ignore indentation inside the given delimeters', async () => {
+        const { errors, tokens } = lexer.tokenize(expandToString`
+            return [
+                false,
+            true, // including inconsitent indentation
+                    true
+            ]
+            return (true,
+                    false
+                   )
+        `);
+
+        expect(errors).toHaveLength(0);
+
+        const tokenNames = tokens.map(token => token.tokenType.name);
+        expect(tokenNames).not.toContain('INDENT');
+        expect(tokenNames).not.toContain('DEDENT');
+    });
+
+    test('should handle nested delimeters', async () => {
+        const { errors, tokens } = lexer.tokenize(expandToString`
+            return [
+                [
+                    false,
+                    true
+                ],
+                    ([true,
+                    true],
+                    false)
+                [
+                    true
+                ]
+            ]
+        `);
+
+        expect(errors).toHaveLength(0);
+
+        const tokenNames = tokens.map(token => token.tokenType.name);
+        expect(tokenNames).not.toContain('INDENT');
+        expect(tokenNames).not.toContain('DEDENT');
     });
 
 });


### PR DESCRIPTION
Added an option to the `IndentationAwareTokenBuilder` that makes use of multi-mode lexing to support turning off indentation sensitivity inside some range of tokens (for example, between `'('` and `')'`)