### PR TITLE
Fix formatter

### DIFF
--- a/packages/langium/src/lsp/formatter.ts
+++ b/packages/langium/src/lsp/formatter.ts
@@ -206,7 +206,7 @@ export abstract class AbstractFormatter implements Formatter {
 
 
     protected isNecessary(edit: TextEdit, document: TextDocument): boolean {
-        return edit.newText !== document.getText(edit.range);
+        return edit.newText !== document.getText(edit.range).replace(/\r/g, '');
     }
 
     protected iterateCstFormatting(document: LangiumDocument, formattings: Map<string, FormattingAction>, options: FormattingOptions, range?: Range): TextEdit[] {

--- a/packages/langium/src/lsp/formatter.ts
+++ b/packages/langium/src/lsp/formatter.ts
@@ -150,12 +150,16 @@ export abstract class AbstractFormatter implements Formatter {
     protected avoidOverlappingEdits(textDocument: TextDocument, textEdits: TextEdit[]): TextEdit[] {
         const edits: TextEdit[] = [];
         for (const edit of textEdits) {
-            const last = edits[edits.length - 1];
-            if (last) {
+            let last = edits[edits.length - 1];
+            while (last) {
                 const currentStart = textDocument.offsetAt(edit.range.start);
                 const lastEnd = textDocument.offsetAt(last.range.end);
                 if (currentStart < lastEnd) {
                     edits.pop();
+                    last = edits[edits.length - 1];
+                }
+                else {
+                    break;
                 }
             }
             edits.push(edit);

--- a/packages/langium/src/lsp/formatter.ts
+++ b/packages/langium/src/lsp/formatter.ts
@@ -164,7 +164,7 @@ export abstract class AbstractFormatter implements Formatter {
             }
             edits.push(edit);
         }
-        return edits.filter(edit=>this.isNecessary(edit, textDocument));
+        return edits.filter(edit => this.isNecessary(edit, textDocument));
     }
 
     protected iterateAstFormatting(document: LangiumDocument, range?: Range): void {
@@ -204,7 +204,7 @@ export abstract class AbstractFormatter implements Formatter {
         return false;
     }
 
-   
+
     protected isNecessary(edit: TextEdit, document: TextDocument): boolean {
         return edit.newText !== document.getText(edit.range);
     }
@@ -379,7 +379,10 @@ export abstract class AbstractFormatter implements Formatter {
         context.indentation += (tabs ?? 0);
         const edits: TextEdit[] = [];
         if (chars !== undefined) {
-            edits.push(this.createSpaceTextEdit(betweenRange, chars, formatting.options));
+            // Do not apply formatting on the same line if preceding node is hidden
+            if (!a?.hidden) {
+                edits.push(this.createSpaceTextEdit(betweenRange, chars, formatting.options));
+            }
         } else if (lines !== undefined) {
             edits.push(this.createLineTextEdit(betweenRange, lines, context, formatting.options));
         } else if (tabs !== undefined) {

--- a/packages/langium/src/lsp/formatter.ts
+++ b/packages/langium/src/lsp/formatter.ts
@@ -160,7 +160,7 @@ export abstract class AbstractFormatter implements Formatter {
             }
             edits.push(edit);
         }
-        return edits;
+        return edits.filter(edit=>this.isNecessary(edit, textDocument));
     }
 
     protected iterateAstFormatting(document: LangiumDocument, range?: Range): void {
@@ -200,11 +200,9 @@ export abstract class AbstractFormatter implements Formatter {
         return false;
     }
 
-    /**
-     * @deprecated This method has been deprecated with 3.1. It now always returns `true` and is no longer used by the default formatter implementation.
-     */
-    protected isNecessary(_edit: TextEdit, _document: TextDocument): boolean {
-        return true;
+   
+    protected isNecessary(edit: TextEdit, document: TextDocument): boolean {
+        return edit.newText !== document.getText(edit.range);
     }
 
     protected iterateCstFormatting(document: LangiumDocument, formattings: Map<string, FormattingAction>, options: FormattingOptions, range?: Range): TextEdit[] {

--- a/packages/langium/src/lsp/formatter.ts
+++ b/packages/langium/src/lsp/formatter.ts
@@ -204,7 +204,6 @@ export abstract class AbstractFormatter implements Formatter {
         return false;
     }
 
-
     protected isNecessary(edit: TextEdit, document: TextDocument): boolean {
         return edit.newText !== document.getText(edit.range).replace(/\r/g, '');
     }

--- a/packages/langium/test/grammar/lsp/grammar-formatter.test.ts
+++ b/packages/langium/test/grammar/lsp/grammar-formatter.test.ts
@@ -7,8 +7,8 @@
 import { EmptyFileSystem } from 'langium';
 import { expandToString } from 'langium/generate';
 import { createLangiumGrammarServices } from 'langium/grammar';
-import { expectFormatting } from 'langium/test';
-import { describe, test } from 'vitest';
+import { expectFormatting, parseDocument } from 'langium/test';
+import { describe, expect, test } from 'vitest';
 
 const services = createLangiumGrammarServices(EmptyFileSystem);
 const formatting = expectFormatting(services.grammar);
@@ -62,6 +62,30 @@ describe('Grammar Formatter', () => {
                 type A = B | C | D;
             `
         });
+    });
+
+    test('No edits if document is already formatted', async () => {
+
+        const formatter = services.grammar.lsp.Formatter;
+        if (!formatter) {
+            throw new Error(`No formatter registered for language ${services.grammar.LanguageMetaData.languageId}`);
+        }
+        const document = await parseDocument(services.grammar, expandToString`
+            interface Test {
+                // This is a comment
+                a: string
+                b: number
+                // This is another comment
+                c: boolean
+            }
+            `);
+        const identifier = { uri: document.uri.toString() };
+        const options = {
+            insertSpaces: true,
+            tabSize: 4
+        };
+        const edits = await formatter.formatDocument(document, { options, textDocument: identifier });
+        expect(edits.length).toBe(0);
     });
 
 });

--- a/packages/langium/test/grammar/lsp/grammar-formatter.test.ts
+++ b/packages/langium/test/grammar/lsp/grammar-formatter.test.ts
@@ -41,10 +41,12 @@ describe('Grammar Formatter', () => {
     test('Formats interface extends references', async () => {
         await formatting({
             before: expandToString`
-                interface A extends   B,C,    D,E{}
+                interface A // This is a comment
+                extends   B,C,    D,E{}
             `,
             after: expandToString`
-                interface A extends B, C, D, E {
+                interface A // This is a comment
+                extends B, C, D, E {
                 }
             `
         });


### PR DESCRIPTION
Hello,

This PR addresses several issues in the current formatter implementation:

- Return only the necessary edits: This ensures that only the edits which actually change the document are returned, rather than all possible edits.

- Fix `avoidOverlappingEdits`: This change improves the removal of overlapping edits, ensuring they are handled correctly across multiple levels.

- Prevent formatting on the same line: This update prevents formatting actions from being applied to the same line if the previous node is hidden.

These improvements aim to enhance the accuracy and efficiency of the formatter. Please let me know if you have any questions or need further clarifications.

