### PR TITLE
Take CST node boundaries into account for formatting

### DIFF
--- a/packages/langium/src/lsp/formatter.ts
+++ b/packages/langium/src/lsp/formatter.ts
@@ -359,6 +359,11 @@ export abstract class AbstractFormatter implements Formatter {
         if (b.hidden) {
             return this.createHiddenTextEdits(a, b, formatting, context);
         }
+        // Ignore the edit if the previous node ends after the current node starts
+        if (a && (a.range.end.line > b.range.start.line ||
+            (a.range.end.line === b.range.start.line && a.range.end.character > b.range.start.character))) {
+            return [];
+        }
         const betweenRange: Range = {
             start: a?.range.end ?? {
                 character: 0,

--- a/packages/langium/test/grammar/lsp/grammar-formatter.test.ts
+++ b/packages/langium/test/grammar/lsp/grammar-formatter.test.ts
@@ -62,4 +62,16 @@ describe('Grammar Formatter', () => {
         });
     });
 
+    test('Formats parser rule definitions with alternatives', async () => {
+        await formatting({
+            before: expandToString`
+                Type:
+                DataType | Entity;
+            `,
+            after: expandToString`
+                Type:
+                    DataType | Entity;
+            `
+        });
+    });
 });


### PR DESCRIPTION
Closes https://github.com/eclipse-langium/langium/issues/1571

Do not perform formatting if the previous node ends after the current node starts.