### PR TITLE
Fix false positive on regex flag validation

### DIFF
--- a/packages/langium/src/grammar/validation/validator.ts
+++ b/packages/langium/src/grammar/validation/validator.ts
@@ -491,10 +491,13 @@ export class LangiumGrammarValidator {
     }
 
     checkDirectlyUsedRegexFlags(token: ast.RegexToken, accept: ValidationAcceptor): void {
-        if (!ast.isTerminalRule(token.$container)) {
+        const regex = token.regex;
+        if (!ast.isTerminalRule(token.$container) && regex) {
+            const slashIndex = regex.lastIndexOf('/');
+            const flags = regex.substring(slashIndex + 1);
             const range = this.getFlagRange(token);
-            if (range) {
-                accept('warning', 'Regular expression flags are only applied if the terminal is not a composition', {
+            if (range && flags) {
+                accept('warning', 'Regular expression flags are only applied if the terminal is not a composition.', {
                     node: token,
                     range
                 });

--- a/packages/langium/test/grammar/grammar-validator.test.ts
+++ b/packages/langium/test/grammar/grammar-validator.test.ts
@@ -200,6 +200,24 @@ describe('Langium grammar validation', () => {
         const validationResult = await validate(grammar);
         expectNoIssues(validationResult);
     });
+
+    test('Composite terminal regex flags', async () => {
+        const grammar = `
+        terminal Test: 'Test' /test/i;
+        `;
+        const validationResult = await validate(grammar);
+        expectWarning(validationResult, 'Regular expression flags are only applied if the terminal is not a composition.', {
+            node: undefined
+        });
+    });
+
+    test('Composite terminal regex flags - negative', async () => {
+        const grammar = `
+        terminal Test: /test/i;
+        `;
+        const validationResult = await validate(grammar);
+        expectNoIssues(validationResult);
+    });
 });
 
 describe('Data type rule return type', () => {

--- a/packages/langium/test/grammar/grammar-validator.test.ts
+++ b/packages/langium/test/grammar/grammar-validator.test.ts
@@ -218,6 +218,14 @@ describe('Langium grammar validation', () => {
         const validationResult = await validate(grammar);
         expectNoIssues(validationResult);
     });
+
+    test('Composite terminal no regex flags', async () => {
+        const grammar = `
+        terminal Test: 'Test' /test/;
+        `;
+        const validationResult = await validate(grammar);
+        expectNoIssues(validationResult);
+    });
 });
 
 describe('Data type rule return type', () => {


### PR DESCRIPTION
Just a minor fix for a warning that would incorrectly appear when mix & matching non-regex terminal elements with regex terminal elements.