### PR TITLE
Make Langium language server more robust

### DIFF
--- a/packages/langium/src/grammar/type-system/type-collector/all-types.ts
+++ b/packages/langium/src/grammar/type-system/type-collector/all-types.ts
@@ -16,17 +16,17 @@ import { isParserRule } from '../../../languages/generated/ast.js';
 import { resolveImport } from '../../internal-grammar-util.js';
 import { isDataTypeRule } from '../../../utils/grammar-utils.js';
 
-export type AstResources = {
-    parserRules: ParserRule[],
-    datatypeRules: ParserRule[],
-    interfaces: Interface[],
-    types: Type[],
+export interface AstResources {
+    parserRules: ParserRule[]
+    datatypeRules: ParserRule[]
+    interfaces: Interface[]
+    types: Type[]
 }
 
-export type TypeResources = {
-    inferred: PlainAstTypes,
-    declared: PlainAstTypes,
-    astResources: AstResources,
+export interface TypeResources {
+    inferred: PlainAstTypes
+    declared: PlainAstTypes
+    astResources: AstResources
 }
 
 export interface ValidationAstTypes {

--- a/packages/langium/src/grammar/type-system/type-collector/inferred-types.ts
+++ b/packages/langium/src/grammar/type-system/type-collector/inferred-types.ts
@@ -320,9 +320,16 @@ function buildDataRuleType(element: AbstractElement, cancel: () => PlainProperty
         const ref = element.rule?.ref;
         if (ref) {
             if (isTerminalRule(ref)) {
+                let regex: string | undefined;
+                try {
+                    regex = terminalRegex(ref).toString();
+                } catch {
+                    // If the regex cannot be built, we assume it's just a string
+                    regex = undefined;
+                }
                 return {
                     primitive: ref.type?.name ?? 'string',
-                    regex: terminalRegex(ref).toString()
+                    regex
                 };
             } else {
                 return {

--- a/packages/langium/src/grammar/validation/validation-resources-collector.ts
+++ b/packages/langium/src/grammar/validation/validation-resources-collector.ts
@@ -25,11 +25,16 @@ export class LangiumGrammarValidationResourcesCollector {
     }
 
     collectValidationResources(grammar: Grammar): ValidationResources {
-        const typeResources = collectValidationAst(grammar, this.documents);
-        return {
-            typeToValidationInfo: this.collectValidationInfo(typeResources),
-            typeToSuperProperties: this.collectSuperProperties(typeResources),
-        };
+        try {
+            const typeResources = collectValidationAst(grammar, this.documents);
+            return {
+                typeToValidationInfo: this.collectValidationInfo(typeResources),
+                typeToSuperProperties: this.collectSuperProperties(typeResources),
+            };
+        } catch (err) {
+            console.error('Error collecting validation resources', err);
+            return { typeToValidationInfo: new Map(), typeToSuperProperties: new Map() };
+        }
     }
 
     private collectValidationInfo({ astResources, inferred, declared }: ValidationAstTypes) {

--- a/packages/langium/test/grammar/grammar-validator.test.ts
+++ b/packages/langium/test/grammar/grammar-validator.test.ts
@@ -1039,3 +1039,19 @@ describe('Prohibit empty parser rules', async () => {
         detectEmptyRules(validationResult, 'EmptyItem');
     });
 });
+
+describe('Check validation is not crashing', async () => {
+
+    test('Calling missing terminal rule', async () => {
+        const specialGrammar = `
+        grammar Foo
+        entry Foo:
+            TERMINAL;
+
+        terminal TERMINAL returns string:
+            MISSING_TERMINAL;
+        `;
+        const validationResult = await validate(specialGrammar);
+        expect(validationResult).toBeDefined();
+    });
+});


### PR DESCRIPTION
Closes https://github.com/eclipse-langium/langium/issues/1633

Makes the type inference methods more robust against errors due to missing elements. In some cases, this could make some validations "disappear", but only in the presence of parser errors - this is alright, since the file doesn't compile anyway.