### PR TITLE
Make service containers readonly

### DIFF
--- a/packages/langium/src/dependency-injection.ts
+++ b/packages/langium/src/dependency-injection.ts
@@ -74,6 +74,9 @@ export function eagerLoad<T>(item: T): T {
 function _inject<I, T>(module: Module<I, T>, injector?: any): T {
     const proxy: any = new Proxy({} as any, {
         deleteProperty: () => false,
+        set: () => {
+            throw new Error('Cannot set values on service container');
+        },
         get: (obj, prop) => _resolve(obj, prop, module, injector || proxy),
         getOwnPropertyDescriptor: (obj, prop) => (_resolve(obj, prop, module, injector || proxy), Object.getOwnPropertyDescriptor(obj, prop)), // used by for..in
         has: (_, prop) => prop in module, // used by ..in..

--- a/packages/langium/src/dependency-injection.ts
+++ b/packages/langium/src/dependency-injection.ts
@@ -75,14 +75,19 @@ function _inject<I, T>(module: Module<I, T>, injector?: any): T {
     const proxy: any = new Proxy({} as any, {
         deleteProperty: () => false,
         set: () => {
-            throw new Error('Cannot set values on service container');
+            throw new Error('Cannot set property on injected service container');
         },
-        get: (obj, prop) => _resolve(obj, prop, module, injector || proxy),
+        get: (obj, prop) => {
+            if (prop === isProxy) {
+                return true;
+            } else {
+                return _resolve(obj, prop, module, injector || proxy);
+            }
+        },
         getOwnPropertyDescriptor: (obj, prop) => (_resolve(obj, prop, module, injector || proxy), Object.getOwnPropertyDescriptor(obj, prop)), // used by for..in
         has: (_, prop) => prop in module, // used by ..in..
-        ownKeys: () => [...Reflect.ownKeys(module), isProxy] // used by for..in
+        ownKeys: () => [...Object.getOwnPropertyNames(module)] // used by for..in
     });
-    proxy[isProxy] = true;
     return proxy;
 }
 

--- a/packages/langium/src/lsp/default-lsp-module.ts
+++ b/packages/langium/src/lsp/default-lsp-module.ts
@@ -28,7 +28,7 @@ import { DefaultWorkspaceSymbolProvider } from './workspace-symbol-provider.js';
  * Context required for creating the default language-specific dependency injection module.
  */
 export interface DefaultModuleContext extends DefaultCoreModuleContext {
-    shared: LangiumSharedServices;
+    readonly shared: LangiumSharedServices;
 }
 
 /**
@@ -66,7 +66,7 @@ export interface DefaultSharedModuleContext extends DefaultSharedCoreModuleConte
     /**
      * Represents an abstract language server connection
      */
-    connection?: Connection;
+    readonly connection?: Connection;
 }
 
 /**

--- a/packages/langium/src/lsp/lsp-services.ts
+++ b/packages/langium/src/lsp/lsp-services.ts
@@ -49,47 +49,47 @@ export type LangiumSharedServices = LangiumSharedCoreServices & LangiumSharedLSP
  * LSP services for a specific language of which Langium provides default implementations.
  */
 export type LangiumLSPServices = {
-    lsp: {
-        CompletionProvider?: CompletionProvider
-        DocumentHighlightProvider?: DocumentHighlightProvider
-        DocumentSymbolProvider?: DocumentSymbolProvider
-        HoverProvider?: HoverProvider
-        FoldingRangeProvider?: FoldingRangeProvider
-        DefinitionProvider?: DefinitionProvider
-        TypeProvider?: TypeDefinitionProvider
-        ImplementationProvider?: ImplementationProvider
-        ReferencesProvider?: ReferencesProvider
-        CodeActionProvider?: CodeActionProvider
-        SemanticTokenProvider?: SemanticTokenProvider
-        RenameProvider?: RenameProvider
-        Formatter?: Formatter
-        SignatureHelp?: SignatureHelpProvider
-        CallHierarchyProvider?: CallHierarchyProvider
-        TypeHierarchyProvider?: TypeHierarchyProvider
-        DeclarationProvider?: DeclarationProvider
-        InlayHintProvider?: InlayHintProvider
-        CodeLensProvider?: CodeLensProvider
-        DocumentLinkProvider?: DocumentLinkProvider
+    readonly lsp: {
+        readonly CompletionProvider?: CompletionProvider
+        readonly DocumentHighlightProvider?: DocumentHighlightProvider
+        readonly DocumentSymbolProvider?: DocumentSymbolProvider
+        readonly HoverProvider?: HoverProvider
+        readonly FoldingRangeProvider?: FoldingRangeProvider
+        readonly DefinitionProvider?: DefinitionProvider
+        readonly TypeProvider?: TypeDefinitionProvider
+        readonly ImplementationProvider?: ImplementationProvider
+        readonly ReferencesProvider?: ReferencesProvider
+        readonly CodeActionProvider?: CodeActionProvider
+        readonly SemanticTokenProvider?: SemanticTokenProvider
+        readonly RenameProvider?: RenameProvider
+        readonly Formatter?: Formatter
+        readonly SignatureHelp?: SignatureHelpProvider
+        readonly CallHierarchyProvider?: CallHierarchyProvider
+        readonly TypeHierarchyProvider?: TypeHierarchyProvider
+        readonly DeclarationProvider?: DeclarationProvider
+        readonly InlayHintProvider?: InlayHintProvider
+        readonly CodeLensProvider?: CodeLensProvider
+        readonly DocumentLinkProvider?: DocumentLinkProvider
     },
-    shared: LangiumSharedServices
+    readonly shared: LangiumSharedServices
 };
 
 /**
  * LSP services shared between multiple languages of which Langium provides default implementations.
  */
 export type LangiumSharedLSPServices = {
-    lsp: {
-        Connection?: Connection
-        DocumentUpdateHandler: DocumentUpdateHandler
-        ExecuteCommandHandler?: ExecuteCommandHandler
-        FileOperationHandler?: FileOperationHandler
-        FuzzyMatcher: FuzzyMatcher
-        LanguageServer: LanguageServer
-        NodeKindProvider: NodeKindProvider
-        WorkspaceSymbolProvider?: WorkspaceSymbolProvider
+    readonly lsp: {
+        readonly Connection?: Connection
+        readonly DocumentUpdateHandler: DocumentUpdateHandler
+        readonly ExecuteCommandHandler?: ExecuteCommandHandler
+        readonly FileOperationHandler?: FileOperationHandler
+        readonly FuzzyMatcher: FuzzyMatcher
+        readonly LanguageServer: LanguageServer
+        readonly NodeKindProvider: NodeKindProvider
+        readonly WorkspaceSymbolProvider?: WorkspaceSymbolProvider
     },
-    workspace: {
-        TextDocuments: TextDocuments<TextDocument>
+    readonly workspace: {
+        readonly TextDocuments: TextDocuments<TextDocument>
     }
 };
 

--- a/packages/langium/src/services.ts
+++ b/packages/langium/src/services.ts
@@ -43,10 +43,10 @@ import type { WorkspaceManager } from './workspace/workspace-manager.js';
  * grammar definition and the language configuration.
  */
 export type LangiumGeneratedCoreServices = {
-    Grammar: Grammar
-    LanguageMetaData: LanguageMetaData
-    parser: {
-        ParserConfig?: IParserConfig
+    readonly Grammar: Grammar
+    readonly LanguageMetaData: LanguageMetaData
+    readonly parser: {
+        readonly ParserConfig?: IParserConfig
     }
 }
 
@@ -54,41 +54,41 @@ export type LangiumGeneratedCoreServices = {
  * Core services for a specific language of which Langium provides default implementations.
  */
 export type LangiumDefaultCoreServices = {
-    parser: {
-        AsyncParser: AsyncParser
-        GrammarConfig: GrammarConfig
-        ValueConverter: ValueConverter
-        LangiumParser: LangiumParser
-        ParserErrorMessageProvider: IParserErrorMessageProvider
-        CompletionParser: LangiumCompletionParser
-        TokenBuilder: TokenBuilder
-        Lexer: Lexer
+    readonly parser: {
+        readonly AsyncParser: AsyncParser
+        readonly GrammarConfig: GrammarConfig
+        readonly ValueConverter: ValueConverter
+        readonly LangiumParser: LangiumParser
+        readonly ParserErrorMessageProvider: IParserErrorMessageProvider
+        readonly CompletionParser: LangiumCompletionParser
+        readonly TokenBuilder: TokenBuilder
+        readonly Lexer: Lexer
     }
-    documentation: {
-        CommentProvider: CommentProvider
-        DocumentationProvider: DocumentationProvider
+    readonly documentation: {
+        readonly CommentProvider: CommentProvider
+        readonly DocumentationProvider: DocumentationProvider
     }
-    references: {
-        Linker: Linker
-        NameProvider: NameProvider
-        References: References
-        ScopeProvider: ScopeProvider
-        ScopeComputation: ScopeComputation
+    readonly references: {
+        readonly Linker: Linker
+        readonly NameProvider: NameProvider
+        readonly References: References
+        readonly ScopeProvider: ScopeProvider
+        readonly ScopeComputation: ScopeComputation
     }
-    serializer: {
-        Hydrator: Hydrator
-        JsonSerializer: JsonSerializer
+    readonly serializer: {
+        readonly Hydrator: Hydrator
+        readonly JsonSerializer: JsonSerializer
     }
-    validation: {
-        DocumentValidator: DocumentValidator
-        ValidationRegistry: ValidationRegistry
+    readonly validation: {
+        readonly DocumentValidator: DocumentValidator
+        readonly ValidationRegistry: ValidationRegistry
     }
-    workspace: {
-        AstNodeLocator: AstNodeLocator
-        AstNodeDescriptionProvider: AstNodeDescriptionProvider
-        ReferenceDescriptionProvider: ReferenceDescriptionProvider
+    readonly workspace: {
+        readonly AstNodeLocator: AstNodeLocator
+        readonly AstNodeDescriptionProvider: AstNodeDescriptionProvider
+        readonly ReferenceDescriptionProvider: ReferenceDescriptionProvider
     }
-    shared: LangiumSharedCoreServices
+    readonly shared: LangiumSharedCoreServices
 }
 
 /**
@@ -102,24 +102,24 @@ export type LangiumCoreServices = LangiumGeneratedCoreServices & LangiumDefaultC
  * derived from the grammar definition.
  */
 export type LangiumGeneratedSharedCoreServices = {
-    AstReflection: AstReflection
+    readonly AstReflection: AstReflection
 }
 
 /**
  * Core services shared between multiple languages where Langium provides default implementations.
  */
 export type LangiumDefaultSharedCoreServices = {
-    ServiceRegistry: ServiceRegistry
-    workspace: {
-        ConfigurationProvider: ConfigurationProvider
-        DocumentBuilder: DocumentBuilder
-        FileSystemProvider: FileSystemProvider
-        IndexManager: IndexManager
-        LangiumDocuments: LangiumDocuments
-        LangiumDocumentFactory: LangiumDocumentFactory
-        TextDocuments?: TextDocumentProvider
-        WorkspaceLock: WorkspaceLock
-        WorkspaceManager: WorkspaceManager
+    readonly ServiceRegistry: ServiceRegistry
+    readonly workspace: {
+        readonly ConfigurationProvider: ConfigurationProvider
+        readonly DocumentBuilder: DocumentBuilder
+        readonly FileSystemProvider: FileSystemProvider
+        readonly IndexManager: IndexManager
+        readonly LangiumDocuments: LangiumDocuments
+        readonly LangiumDocumentFactory: LangiumDocumentFactory
+        readonly TextDocuments?: TextDocumentProvider
+        readonly WorkspaceLock: WorkspaceLock
+        readonly WorkspaceManager: WorkspaceManager
     }
 }
 

--- a/packages/langium/test/dependency-injection.test.ts
+++ b/packages/langium/test/dependency-injection.test.ts
@@ -352,18 +352,9 @@ describe('The inject result', () => {
         expect('b' in obj).toBe(false);
     });
 
-    test('should be extensible', () => {
+    test('should not be extensible', () => {
         const obj: any = inject({});
-        expect(Object.isExtensible(obj)).toBe(true);
-        expect(obj.a).toBeUndefined();
-        expect(() => obj.a = 1).not.toThrow();
-        expect(obj.a).toBe(1);
-    });
-
-    test('should be sealable', () => {
-        const obj: any = Object.seal(inject({}));
-        expect(Object.isExtensible(obj)).toBe(false);
-        expect(() => (obj.a = 1)).toThrowError('Cannot define property a, object is not extensible');
+        expect(() => (obj.a = 1)).toThrowError('Cannot set property on injected service container');
     });
 
 });


### PR DESCRIPTION
Fixes something that was encountered in https://github.com/eclipse-langium/langium/discussions/1621#discussioncomment-10362924.

Essentially, our API (and runtime as well - to some degree) allows to override the values of services simply by performing assignments. However, this almost certainly breaks runtime behavior in case the service that is being assigned is used as a service dependency somewhere.

This change adds readonly modifiers where necessary and adds a `set` method to the service proxies that ensure that no service can be assigned.