### PR TITLE
Fix start column of indentation token instances

### DIFF
--- a/packages/langium/src/parser/indentation-aware.ts
+++ b/packages/langium/src/parser/indentation-aware.ts
@@ -177,7 +177,7 @@ export class IndentationAwareTokenBuilder<Terminals extends string = string> ext
             image,
             offset, offset + image.length,
             lineNumber, lineNumber,
-            0, image.length,
+            1, image.length,
         );
     }
 


### PR DESCRIPTION
I was not previously aware that chevrotain tokens are 1-indexed and started the indentation token from column 0 instead of 1. This caused an `Error: Illegal argument: character must be non-negative` when sending diagnostics, causing parse errors to not be shown to the user.