### PR TITLE
Perform read lock on LSP requests

### DIFF
--- a/examples/domainmodel/src/language-server/domain-model-scope.ts
+++ b/examples/domainmodel/src/language-server/domain-model-scope.ts
@@ -8,7 +8,7 @@ import type { AstNode, AstNodeDescription, LangiumDocument, PrecomputedScopes } 
 import type { DomainModelServices } from './domain-model-module.js';
 import type { QualifiedNameProvider } from './domain-model-naming.js';
 import type { Domainmodel, PackageDeclaration } from './generated/ast.js';
-import { AstUtils, Cancellation, DefaultScopeComputation, interruptAndCheck, MultiMap } from 'langium';
+import { AstUtils, DefaultScopeComputation, MultiMap, CancellationToken } from 'langium';
 import { isType, isPackageDeclaration } from './generated/ast.js';
 
 export class DomainModelScopeComputation extends DefaultScopeComputation {
@@ -23,10 +23,10 @@ export class DomainModelScopeComputation extends DefaultScopeComputation {
     /**
      * Exports only types (`DataType or `Entity`) with their qualified names.
      */
-    override async computeExports(document: LangiumDocument, cancelToken = Cancellation.CancellationToken.None): Promise<AstNodeDescription[]> {
+    override async computeExports(document: LangiumDocument, cancelToken = CancellationToken.None): Promise<AstNodeDescription[]> {
         const descr: AstNodeDescription[] = [];
         for (const modelNode of AstUtils.streamAllContents(document.parseResult.value)) {
-            await interruptAndCheck(cancelToken);
+            await cancelToken.check();
             if (isType(modelNode)) {
                 let name = this.nameProvider.getName(modelNode);
                 if (name) {
@@ -40,17 +40,17 @@ export class DomainModelScopeComputation extends DefaultScopeComputation {
         return descr;
     }
 
-    override async computeLocalScopes(document: LangiumDocument, cancelToken = Cancellation.CancellationToken.None): Promise<PrecomputedScopes> {
+    override async computeLocalScopes(document: LangiumDocument, cancelToken = CancellationToken.None): Promise<PrecomputedScopes> {
         const model = document.parseResult.value as Domainmodel;
         const scopes = new MultiMap<AstNode, AstNodeDescription>();
         await this.processContainer(model, scopes, document, cancelToken);
         return scopes;
     }
 
-    protected async processContainer(container: Domainmodel | PackageDeclaration, scopes: PrecomputedScopes, document: LangiumDocument, cancelToken: Cancellation.CancellationToken): Promise<AstNodeDescription[]> {
+    protected async processContainer(container: Domainmodel | PackageDeclaration, scopes: PrecomputedScopes, document: LangiumDocument, cancelToken: CancellationToken): Promise<AstNodeDescription[]> {
         const localDescriptions: AstNodeDescription[] = [];
         for (const element of container.elements) {
-            await interruptAndCheck(cancelToken);
+            await cancelToken.check();
             if (isType(element) && element.name) {
                 const description = this.descriptions.createDescription(element, element.name, document);
                 localDescriptions.push(description);

--- a/packages/langium-sprotty/src/diagram-server-manager.ts
+++ b/packages/langium-sprotty/src/diagram-server-manager.ts
@@ -4,13 +4,13 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import type { CancellationToken, Connection } from 'vscode-languageserver';
+import type { Connection } from 'vscode-languageserver';
 import type { ActionMessage, DiagramOptions, DiagramServer, RequestModelAction } from 'sprotty-protocol';
-import type { LangiumDocument, ServiceRegistry, URI } from 'langium';
+import type { CancellationToken, LangiumDocument, ServiceRegistry, URI } from 'langium';
 import type { LangiumSprottyServices, LangiumSprottySharedServices } from './sprotty-services.js';
 import type { LangiumDiagramGeneratorArguments } from './diagram-generator.js';
 import { isRequestAction, RejectAction } from 'sprotty-protocol';
-import { DocumentState, UriUtils, interruptAndCheck, stream } from 'langium';
+import { DocumentState, UriUtils, stream } from 'langium';
 import { DiagramActionNotification } from './lsp.js';
 
 /**
@@ -89,7 +89,7 @@ export class DefaultDiagramServerManager implements DiagramServerManager {
 
     protected async updateDiagrams(documents: Map<LangiumDocument, DiagramServer[]>, cancelToken: CancellationToken): Promise<void> {
         while (documents.size > 0) {
-            await interruptAndCheck(cancelToken);
+            await cancelToken.check();
             const [firstEntry] = documents;
             const [document, diagramServers] = firstEntry;
             const language = this.serviceRegistry.getServices(document.uri) as LangiumSprottyServices;

--- a/packages/langium/src/lsp/inlay-hint-provider.ts
+++ b/packages/langium/src/lsp/inlay-hint-provider.ts
@@ -10,7 +10,6 @@ import { CancellationToken } from '../utils/cancellation.js';
 import type { MaybePromise } from '../utils/promise-utils.js';
 import type { LangiumDocument } from '../workspace/documents.js';
 import { streamAst } from '../utils/ast-utils.js';
-import { interruptAndCheck } from '../utils/promise-utils.js';
 
 export type InlayHintAcceptor = (inlayHint: InlayHint) => void;
 
@@ -33,7 +32,7 @@ export abstract class AbstractInlayHintProvider implements InlayHintProvider {
         const inlayHints: InlayHint[] = [];
         const acceptor: InlayHintAcceptor = hint => inlayHints.push(hint);
         for (const node of streamAst(root, { range: params.range })) {
-            await interruptAndCheck(cancelToken);
+            await cancelToken.check();
             this.computeInlayHint(node, acceptor);
         }
         return inlayHints;

--- a/packages/langium/src/lsp/language-server.ts
+++ b/packages/langium/src/lsp/language-server.ts
@@ -552,12 +552,14 @@ export function addCodeLensHandler(connection: Connection, services: LangiumShar
 
 export function addWorkspaceSymbolHandler(connection: Connection, services: LangiumSharedServices): void {
     const workspaceSymbolProvider = services.lsp.WorkspaceSymbolProvider;
+    const lock = services.workspace.WorkspaceLock;
     if (workspaceSymbolProvider) {
         const documentBuilder = services.workspace.DocumentBuilder;
         connection.onWorkspaceSymbol(async (params, token) => {
             try {
                 await documentBuilder.waitUntil(DocumentState.IndexedContent, token);
-                return await workspaceSymbolProvider.getSymbols(params, token);
+                const result = await lock.read(() => workspaceSymbolProvider.getSymbols(params, token), true);
+                return result;
             } catch (err) {
                 return responseError(err);
             }
@@ -567,7 +569,8 @@ export function addWorkspaceSymbolHandler(connection: Connection, services: Lang
             connection.onWorkspaceSymbolResolve(async (workspaceSymbol, token) => {
                 try {
                     await documentBuilder.waitUntil(DocumentState.IndexedContent, token);
-                    return await resolveWorkspaceSymbol(workspaceSymbol, token);
+                    const result = await lock.read(() => resolveWorkspaceSymbol(workspaceSymbol, token), true);
+                    return result;
                 } catch (err) {
                     return responseError(err);
                 }
@@ -654,6 +657,7 @@ export function createHierarchyRequestHandler<P extends TypeHierarchySupertypesP
     serviceCall: (services: LangiumCoreAndPartialLSPServices, params: P, cancelToken: CancellationToken) => HandlerResult<R, E>,
     sharedServices: LangiumSharedServices,
 ): ServerRequestHandler<P, R, PR, E> {
+    const lock = sharedServices.workspace.WorkspaceLock;
     const serviceRegistry = sharedServices.ServiceRegistry;
     return async (params: P, cancelToken: CancellationToken) => {
         const uri = URI.parse(params.item.uri);
@@ -668,7 +672,10 @@ export function createHierarchyRequestHandler<P extends TypeHierarchySupertypesP
         }
         const language = serviceRegistry.getServices(uri);
         try {
-            return await serviceCall(language, params, cancelToken);
+            const result = await lock.read(async () => {
+                return await serviceCall(language, params, cancelToken);
+            }, true); // Give this priority, since we already waited until the target state
+            return result;
         } catch (err) {
             return responseError<E>(err);
         }
@@ -681,6 +688,7 @@ export function createServerRequestHandler<P extends { textDocument: TextDocumen
     targetState?: DocumentState
 ): ServerRequestHandler<P, R, PR, E> {
     const documents = sharedServices.workspace.LangiumDocuments;
+    const lock = sharedServices.workspace.WorkspaceLock;
     const serviceRegistry = sharedServices.ServiceRegistry;
     return async (params: P, cancelToken: CancellationToken) => {
         const uri = URI.parse(params.textDocument.uri);
@@ -694,9 +702,17 @@ export function createServerRequestHandler<P extends { textDocument: TextDocumen
             return responseError<E>(new Error(errorText));
         }
         const language = serviceRegistry.getServices(uri);
+        const document = documents.getDocument(uri);
+        if (!document) {
+            const errorText = `Could not find document for uri: '${uri}'`;
+            console.debug(errorText);
+            return responseError<E>(new Error(errorText));
+        }
         try {
-            const document = await documents.getOrCreateDocument(uri);
-            return await serviceCall(language, document, params, cancelToken);
+            const result = await lock.read(async () => {
+                return await serviceCall(language, document, params, cancelToken);
+            }, true); // Give this priority, since we already waited until the target state
+            return result;
         } catch (err) {
             return responseError<E>(err);
         }
@@ -709,6 +725,7 @@ export function createRequestHandler<P extends { textDocument: TextDocumentIdent
     targetState?: DocumentState
 ): RequestHandler<P, R | null, E> {
     const documents = sharedServices.workspace.LangiumDocuments;
+    const lock = sharedServices.workspace.WorkspaceLock;
     const serviceRegistry = sharedServices.ServiceRegistry;
     return async (params: P, cancelToken: CancellationToken) => {
         const uri = URI.parse(params.textDocument.uri);
@@ -721,9 +738,17 @@ export function createRequestHandler<P extends { textDocument: TextDocumentIdent
             return null;
         }
         const language = serviceRegistry.getServices(uri);
+        const document = documents.getDocument(uri);
+        if (!document) {
+            const errorText = `Could not find document for uri: '${uri}'`;
+            console.debug(errorText);
+            return responseError<E>(new Error(errorText));
+        }
         try {
-            const document = await documents.getOrCreateDocument(uri);
-            return await serviceCall(language, document, params, cancelToken);
+            const result = await lock.read(async () => {
+                return await serviceCall(language, document, params, cancelToken);
+            }, true); // Give this priority, since we already waited until the target state
+            return result;
         } catch (err) {
             return responseError<E>(err);
         }

--- a/packages/langium/src/lsp/semantic-token-provider.ts
+++ b/packages/langium/src/lsp/semantic-token-provider.ts
@@ -14,7 +14,6 @@ import { streamAst } from '../utils/ast-utils.js';
 import { inRange } from '../utils/cst-utils.js';
 import { findNodeForKeyword, findNodeForProperty, findNodesForKeyword, findNodesForProperty } from '../utils/grammar-utils.js';
 import type { MaybePromise } from '../utils/promise-utils.js';
-import { interruptAndCheck } from '../utils/promise-utils.js';
 import type { LangiumDocument } from '../workspace/documents.js';
 import type { LangiumServices } from './lsp-services.js';
 
@@ -287,7 +286,7 @@ export abstract class AbstractSemanticTokenProvider implements SemanticTokenProv
         do {
             result = treeIterator.next();
             if (!result.done) {
-                await interruptAndCheck(cancelToken);
+                await cancelToken.check();
                 const node = result.value;
                 if (this.highlightElement(node, acceptor) === 'prune') {
                     treeIterator.prune();

--- a/packages/langium/src/lsp/workspace-symbol-provider.ts
+++ b/packages/langium/src/lsp/workspace-symbol-provider.ts
@@ -12,7 +12,6 @@ import type { AstNodeDescription } from '../syntax-tree.js';
 import type { NodeKindProvider } from './node-kind-provider.js';
 import type { FuzzyMatcher } from './fuzzy-matcher.js';
 import { CancellationToken } from '../utils/cancellation.js';
-import { interruptAndCheck } from '../utils/promise-utils.js';
 
 /**
  * Shared service for handling workspace symbols requests.
@@ -58,7 +57,7 @@ export class DefaultWorkspaceSymbolProvider implements WorkspaceSymbolProvider {
         const workspaceSymbols: WorkspaceSymbol[] = [];
         const query = params.query.toLowerCase();
         for (const description of this.indexManager.allElements()) {
-            await interruptAndCheck(cancelToken);
+            await cancelToken.check();
             if (this.fuzzyMatcher.match(query, description.name)) {
                 const symbol = this.getWorkspaceSymbol(description);
                 if (symbol) {

--- a/packages/langium/src/parser/async-parser.ts
+++ b/packages/langium/src/parser/async-parser.ts
@@ -4,13 +4,13 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import type { CancellationToken } from '../utils/cancellation.js';
+import { OperationCancelled, type CancellationToken } from '../utils/cancellation.js';
 import type { LangiumCoreServices } from '../services.js';
 import type { AstNode } from '../syntax-tree.js';
 import type { LangiumParser, ParseResult } from './langium-parser.js';
 import type { Hydrator } from '../serializer/hydrator.js';
 import type { Event } from '../utils/event.js';
-import { Deferred, OperationCancelled } from '../utils/promise-utils.js';
+import { Deferred } from '../utils/promise-utils.js';
 import { Emitter } from '../utils/event.js';
 
 /**

--- a/packages/langium/src/references/linker.ts
+++ b/packages/langium/src/references/linker.ts
@@ -12,7 +12,6 @@ import type { ScopeProvider } from './scope-provider.js';
 import { CancellationToken } from '../utils/cancellation.js';
 import { isAstNode, isAstNodeDescription, isLinkingError } from '../syntax-tree.js';
 import { findRootNode, streamAst, streamReferences } from '../utils/ast-utils.js';
-import { interruptAndCheck } from '../utils/promise-utils.js';
 import { DocumentState } from '../workspace/documents.js';
 
 /**
@@ -91,7 +90,7 @@ export class DefaultLinker implements Linker {
 
     async link(document: LangiumDocument, cancelToken = CancellationToken.None): Promise<void> {
         for (const node of streamAst(document.parseResult.value)) {
-            await interruptAndCheck(cancelToken);
+            await cancelToken.check();
             streamReferences(node).forEach(ref => this.doLink(ref, document));
         }
     }

--- a/packages/langium/src/references/scope-computation.ts
+++ b/packages/langium/src/references/scope-computation.ts
@@ -12,7 +12,6 @@ import type { NameProvider } from './name-provider.js';
 import { CancellationToken } from '../utils/cancellation.js';
 import { streamAllContents, streamContents } from '../utils/ast-utils.js';
 import { MultiMap } from '../utils/collections.js';
-import { interruptAndCheck } from '../utils/promise-utils.js';
 
 /**
  * Language-specific service for precomputing global and local scopes. The service methods are executed
@@ -94,7 +93,7 @@ export class DefaultScopeComputation implements ScopeComputation {
 
         this.exportNode(parentNode, exports, document);
         for (const node of children(parentNode)) {
-            await interruptAndCheck(cancelToken);
+            await cancelToken.check();
             this.exportNode(node, exports, document);
         }
         return exports;
@@ -116,7 +115,7 @@ export class DefaultScopeComputation implements ScopeComputation {
         const scopes = new MultiMap<AstNode, AstNodeDescription>();
         // Here we navigate the full AST - local scopes shall be available in the whole document
         for (const node of streamAllContents(rootNode)) {
-            await interruptAndCheck(cancelToken);
+            await cancelToken.check();
             this.processNode(node, document, scopes);
         }
         return scopes;

--- a/packages/langium/src/utils/cancellation.ts
+++ b/packages/langium/src/utils/cancellation.ts
@@ -4,5 +4,226 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-// eslint-disable-next-line no-restricted-imports
-export * from 'vscode-jsonrpc/lib/common/cancellation.js';
+import type { Disposable } from './disposable.js';
+import { Emitter, Event } from './event.js';
+import { delayNextTick } from './promise-utils.js';
+
+let lastTick = 0;
+let globalInterruptionPeriod = 10;
+
+/**
+ * Reset the global interruption period and create a cancellation token source.
+ *
+ * @deprecated Use {@link CancellationTokenSource} directly instead.
+ */
+export function startCancelableOperation(): AbstractCancellationTokenSource {
+    lastTick = Date.now();
+    return new CancellationTokenSource();
+}
+
+/**
+ * This symbol may be thrown in an asynchronous context by any Langium service that receives
+ * a `CancellationToken`. This means that the promise returned by such a service is rejected with
+ * this symbol as rejection reason.
+ */
+export const OperationCancelled = Symbol('OperationCancelled');
+
+/**
+ * Use this in a `catch` block to check whether the thrown object indicates that the operation
+ * has been cancelled.
+ */
+export function isOperationCancelled(err: unknown): err is typeof OperationCancelled {
+    return err === OperationCancelled;
+}
+
+/**
+ * Change the period duration for {@link CancellationToken#check} and {@link interruptAndCheck} to the given number of milliseconds.
+ * The default value is 10ms.
+ */
+export function setInterruptionPeriod(period: number): void {
+    globalInterruptionPeriod = period;
+}
+
+/**
+ * This function does two things:
+ *  1. Check the elapsed time since the last call to this function or to {@link startCancelableOperation}. If the predefined
+ *     period (configured with {@link setInterruptionPeriod}) is exceeded, execution is delayed with {@link delayNextTick}.
+ *  2. If the predefined period is not met yet or execution is resumed after an interruption, the given cancellation
+ *     token is checked, and if cancellation is requested, {@link OperationCancelled} is thrown.
+ *
+ * All services in Langium that receive a `CancellationToken` may potentially call this function, so the
+ * {@link OperationCancelled} must be caught (with an `async` try-catch block or a `catch` callback attached to
+ * the promise) to avoid that event being exposed as an error.
+ *
+ * @deprecated Use {@link CancellationToken#check} instead.
+ */
+export async function interruptAndCheck(token: CancellationToken): Promise<void> {
+    if (token === CancellationToken.None) {
+        // Early exit in case cancellation was disabled by the caller
+        return;
+    }
+    const current = Date.now();
+    if (current - lastTick >= globalInterruptionPeriod) {
+        lastTick = current;
+        await delayNextTick();
+    }
+    if (token.isCancellationRequested) {
+        throw OperationCancelled;
+    }
+}
+
+export interface SimpleCancellationToken {
+    /**
+     * Is `true` when the token has been cancelled, `false` otherwise.
+     */
+    readonly isCancellationRequested: boolean;
+    /**
+     * An {@link Event event} which fires upon cancellation.
+     */
+    readonly onCancellationRequested: Event<void>;
+}
+
+/**
+ * Defines a CancellationToken. This interface is not
+ * intended to be implemented. A CancellationToken must
+ * be created via a CancellationTokenSource.
+ */
+export interface CancellationToken extends SimpleCancellationToken {
+    /**
+     * This function does two things:
+     *  1. Check the elapsed time since the last call to this function or the creation time of this token. If the predefined
+     *     period (configured with {@link setInterruptionPeriod}) is exceeded, execution is delayed with {@link delayNextTick}.
+     *  2. If the predefined period is not met yet or execution is resumed after an interruption, the given cancellation
+     *     token is checked, and if cancellation is requested, {@link OperationCancelled} is thrown.
+     *
+     * All services in Langium that receive a {@link CancellationToken} may potentially call this function, so the
+     * {@link OperationCancelled} must be caught (with an `async` try-catch block or a `catch` callback attached to
+     * the promise) to avoid that event being exposed as an error.
+     */
+    check(): Promise<void>;
+}
+
+export namespace CancellationToken {
+    export const None: CancellationToken = {
+        isCancellationRequested: false,
+        onCancellationRequested: Event.None,
+        check: () => Promise.resolve()
+    };
+    export const Cancelled: CancellationToken = {
+        isCancellationRequested: true,
+        onCancellationRequested: Event.None,
+        check: () => {
+            throw OperationCancelled;
+        }
+    };
+    export function is(value: unknown): value is CancellationToken {
+        return typeof value === 'object' && !!value
+            && 'isCancellationRequested' in value
+            && 'onCancellationRequested' in value;
+    }
+    export function create(other: SimpleCancellationToken): CancellationToken {
+        let time = performance.now();
+        return {
+            get isCancellationRequested() {
+                return other.isCancellationRequested;
+            },
+            onCancellationRequested: other.onCancellationRequested,
+            async check() {
+                const now = performance.now();
+                if (time - now >= 10) {
+                    time = now;
+                    await delayNextTick();
+                }
+                if (other.isCancellationRequested) {
+                    throw OperationCancelled;
+                }
+            }
+        };
+    }
+}
+
+class MutableToken implements CancellationToken {
+
+    private _tick = performance.now();
+    private _isCancelled: boolean = false;
+    private _emitter: Emitter<void> | undefined;
+
+    public cancel() {
+        if (!this._isCancelled) {
+            this._isCancelled = true;
+            if (this._emitter) {
+                this._emitter.fire(undefined);
+                this.dispose();
+            }
+        }
+    }
+
+    get isCancellationRequested(): boolean {
+        return this._isCancelled;
+    }
+
+    get onCancellationRequested(): Event<void> {
+        if (!this._emitter) {
+            this._emitter = new Emitter<void>();
+        }
+        return this._emitter.event;
+    }
+
+    async check(): Promise<void> {
+        const now = performance.now();
+        if (now - this._tick >= globalInterruptionPeriod) {
+            this._tick = now;
+            await delayNextTick();
+        }
+        if (this.isCancellationRequested) {
+            throw OperationCancelled;
+        }
+    }
+
+    public dispose(): void {
+        if (this._emitter) {
+            this._emitter.dispose();
+            this._emitter = undefined;
+        }
+    }
+}
+
+export interface AbstractCancellationTokenSource extends Disposable {
+    token: CancellationToken;
+    cancel(): void;
+}
+
+export class CancellationTokenSource implements AbstractCancellationTokenSource {
+
+    private _token: CancellationToken | undefined;
+
+    get token(): CancellationToken {
+        if (!this._token) {
+            // be lazy and create the token only when
+            // actually needed
+            this._token = new MutableToken();
+        }
+        return this._token;
+    }
+
+    cancel(): void {
+        if (!this._token) {
+            // save an object by returning the default
+            // cancelled token when cancellation happens
+            // before someone asks for the token
+            this._token = CancellationToken.Cancelled;
+        } else {
+            (<MutableToken>this._token).cancel();
+        }
+    }
+
+    dispose(): void {
+        if (!this._token) {
+            // ensure to initialize with an empty token if we had none
+            this._token = CancellationToken.None;
+        } else if (this._token instanceof MutableToken) {
+            // actually dispose
+            this._token.dispose();
+        }
+    }
+}

--- a/packages/langium/src/utils/index.ts
+++ b/packages/langium/src/utils/index.ts
@@ -5,6 +5,7 @@
  ******************************************************************************/
 
 export * from './caching.js';
+export * from './cancellation.js';
 export * from './event.js';
 export * from './collections.js';
 export * from './disposable.js';
@@ -15,8 +16,7 @@ export * from './stream.js';
 export * from './uri-utils.js';
 
 import * as AstUtils from './ast-utils.js';
-import * as Cancellation from './cancellation.js';
 import * as CstUtils from './cst-utils.js';
 import * as GrammarUtils from './grammar-utils.js';
 import * as RegExpUtils from './regexp-utils.js';
-export { AstUtils, Cancellation, CstUtils, GrammarUtils, RegExpUtils };
+export { AstUtils, CstUtils, GrammarUtils, RegExpUtils };

--- a/packages/langium/src/validation/validation-registry.ts
+++ b/packages/langium/src/validation/validation-registry.ts
@@ -5,14 +5,13 @@
  ******************************************************************************/
 
 import type { CodeDescription, DiagnosticRelatedInformation, DiagnosticTag, integer, Range } from 'vscode-languageserver-types';
-import type { CancellationToken } from '../utils/cancellation.js';
+import { isOperationCancelled, type CancellationToken } from '../utils/cancellation.js';
 import type { LangiumCoreServices } from '../services.js';
 import type { AstNode, AstReflection, Properties } from '../syntax-tree.js';
 import type { MaybePromise } from '../utils/promise-utils.js';
 import type { Stream } from '../utils/stream.js';
 import type { DocumentSegment } from '../workspace/documents.js';
 import { MultiMap } from '../utils/collections.js';
-import { isOperationCancelled } from '../utils/promise-utils.js';
 import { stream } from '../utils/stream.js';
 
 export type DiagnosticInfo<N extends AstNode, P extends string = Properties<N>> = {

--- a/packages/langium/src/workspace/ast-descriptions.ts
+++ b/packages/langium/src/workspace/ast-descriptions.ts
@@ -14,7 +14,6 @@ import { CancellationToken } from '../utils/cancellation.js';
 import { isLinkingError } from '../syntax-tree.js';
 import { getDocument, streamAst, streamReferences } from '../utils/ast-utils.js';
 import { toDocumentSegment } from '../utils/cst-utils.js';
-import { interruptAndCheck } from '../utils/promise-utils.js';
 import { UriUtils } from '../utils/uri-utils.js';
 
 /**
@@ -117,7 +116,7 @@ export class DefaultReferenceDescriptionProvider implements ReferenceDescription
         const descr: ReferenceDescription[] = [];
         const rootNode = document.parseResult.value;
         for (const astNode of streamAst(rootNode)) {
-            await interruptAndCheck(cancelToken);
+            await cancelToken.check();
             streamReferences(astNode).filter(refInfo => !isLinkingError(refInfo)).forEach(refInfo => {
                 // TODO: Consider logging a warning or throw an exception when DocumentState is < than Linked
                 const description = this.createDescription(refInfo);

--- a/packages/langium/src/workspace/workspace-manager.ts
+++ b/packages/langium/src/workspace/workspace-manager.ts
@@ -9,7 +9,7 @@ import type { WorkspaceFolder } from 'vscode-languageserver-types';
 import type { ServiceRegistry } from '../service-registry.js';
 import type { LangiumSharedCoreServices } from '../services.js';
 import { CancellationToken } from '../utils/cancellation.js';
-import { Deferred, interruptAndCheck } from '../utils/promise-utils.js';
+import { Deferred } from '../utils/promise-utils.js';
 import { URI, UriUtils } from '../utils/uri-utils.js';
 import type { BuildOptions, DocumentBuilder } from './document-builder.js';
 import type { LangiumDocument, LangiumDocuments } from './documents.js';
@@ -99,7 +99,7 @@ export class DefaultWorkspaceManager implements WorkspaceManager {
         const documents = await this.performStartup(folders);
         // Only after creating all documents do we check whether we need to cancel the initialization
         // The document builder will later pick up on all unprocessed documents
-        await interruptAndCheck(cancelToken);
+        await cancelToken.check();
         await this.documentBuilder.build(documents, this.initialBuildOptions, cancelToken);
     }
 

--- a/packages/langium/test/parser/worker-thread-async-parser.test.ts
+++ b/packages/langium/test/parser/worker-thread-async-parser.test.ts
@@ -9,8 +9,7 @@ import { WorkerThreadAsyncParser } from 'langium/node';
 import { createLangiumGrammarServices } from 'langium/grammar';
 import type { Grammar, LangiumCoreServices, ParseResult } from 'langium';
 import type { LangiumServices } from 'langium/lsp';
-import { EmptyFileSystem, GrammarUtils, CstUtils, GrammarAST, isOperationCancelled } from 'langium';
-import { CancellationToken, CancellationTokenSource } from 'vscode-languageserver';
+import { EmptyFileSystem, GrammarUtils, CstUtils, GrammarAST, isOperationCancelled, CancellationToken, CancellationTokenSource } from 'langium';
 import { fail } from 'node:assert';
 import { fileURLToPath } from 'node:url';
 

--- a/packages/langium/test/workspace/document-builder.test.ts
+++ b/packages/langium/test/workspace/document-builder.test.ts
@@ -5,11 +5,10 @@
  ******************************************************************************/
 
 import type { AstNode, DocumentBuilder, FileSystemProvider, LangiumDocument, LangiumDocumentFactory, LangiumDocuments, Module, Reference, TextDocumentProvider, ValidationChecks } from 'langium';
-import { AstUtils, DocumentState, TextDocument, URI, isOperationCancelled } from 'langium';
+import { AstUtils, DocumentState, TextDocument, URI, isOperationCancelled, CancellationToken, CancellationTokenSource } from 'langium';
 import { createServicesForGrammar } from 'langium/grammar';
 import { setTextDocument } from 'langium/test';
 import { describe, expect, test, vi, beforeEach, afterEach } from 'vitest';
-import { CancellationToken, CancellationTokenSource } from 'vscode-languageserver';
 import { fail } from 'assert';
 import type { LangiumServices, LangiumSharedServices } from '../../lib/lsp/lsp-services.js';
 

--- a/packages/langium/test/workspace/document-factory.test.ts
+++ b/packages/langium/test/workspace/document-factory.test.ts
@@ -7,10 +7,9 @@
 import type { Grammar } from 'langium';
 import type { LangiumServices } from 'langium/lsp';
 import { describe, expect, test } from 'vitest';
-import { DocumentState, EmptyFileSystem, TextDocument } from 'langium';
+import { DocumentState, EmptyFileSystem, TextDocument, CancellationToken } from 'langium';
 import { createLangiumGrammarServices } from 'langium/grammar';
 import { setTextDocument } from 'langium/test';
-import { CancellationToken } from 'vscode-languageserver';
 
 describe('DefaultLangiumDocumentFactory', () => {
 

--- a/packages/langium/test/workspace/workspace-lock.test.ts
+++ b/packages/langium/test/workspace/workspace-lock.test.ts
@@ -5,7 +5,7 @@
  ******************************************************************************/
 
 import { describe, expect, test } from 'vitest';
-import { Deferred, delayNextTick, DefaultWorkspaceLock } from 'langium';
+import { Deferred, delayNextTick, DefaultWorkspaceLock, WorkspaceLockPriority } from 'langium';
 
 describe('WorkspaceLock', () => {
 
@@ -124,7 +124,7 @@ describe('WorkspaceLock', () => {
         await mutex.read(() => {
             // Set counter to 5
             counter = 5;
-        }, true);
+        }, WorkspaceLockPriority.Immediate);
         // Assert that the read action has received priority
         expect(counter).toBe(5);
         await delayNextTick();


### PR DESCRIPTION
I've noticed that some long running requests (i.e. completion in large files, sometimes semantic highlighting) can break pretty heavily and lead to unresolved references if the specified document gets a new build triggered. This change adds a new type of read to the `WorkspaceLock` service that allows to instantly serve a read request - all other requests are queued up until this read request has finished (or has been aborted).