### PR TITLE
Add `sideEffects` flag to library packages

### DIFF
--- a/packages/langium-railroad/package.json
+++ b/packages/langium-railroad/package.json
@@ -18,6 +18,7 @@
     "lib",
     "src"
   ],
+  "sideEffects": false,
   "type": "module",
   "exports": {
     ".": {

--- a/packages/langium-sprotty/package.json
+++ b/packages/langium-sprotty/package.json
@@ -18,6 +18,7 @@
     "lib",
     "src"
   ],
+  "sideEffects": false,
   "type": "module",
   "exports": {
     ".": {

--- a/packages/langium/package.json
+++ b/packages/langium/package.json
@@ -24,6 +24,7 @@
     "test.js",
     "test.d.ts"
   ],
+  "sideEffects": false,
   "type": "module",
   "exports": {
     ".": {


### PR DESCRIPTION
Closes https://github.com/eclipse-langium/langium/issues/1642

Adds the `sideEffects: false` flag to our library package.json files. Since we only export methods/constants/classes and don't perform any polyfills, our libraries don't have any side effects. This results in smaller bundles when only a subset of Langium's features are used.