### PR TITLE
Rename "delimeter" to "delimiter"

### DIFF
--- a/packages/langium/src/parser/indentation-aware.ts
+++ b/packages/langium/src/parser/indentation-aware.ts
@@ -54,14 +54,14 @@ export interface IndentationTokenBuilderOptions<TerminalName extends string = st
      *
      * @default []
      */
-    ignoreIndentationDelimeters: Array<IndentationAwareDelimiter<TerminalName | KeywordName>>
+    ignoreIndentationDelimiters: Array<IndentationAwareDelimiter<TerminalName | KeywordName>>
 }
 
 export const indentationBuilderDefaultOptions: IndentationTokenBuilderOptions = {
     indentTokenName: 'INDENT',
     dedentTokenName: 'DEDENT',
     whitespaceTokenName: 'WS',
-    ignoreIndentationDelimeters: [],
+    ignoreIndentationDelimiters: [],
 };
 
 export enum LexingMode {
@@ -129,7 +129,7 @@ export class IndentationAwareTokenBuilder<Terminals extends string = string, Key
             throw new Error('Invalid tokens built by default builder');
         }
 
-        const { indentTokenName, dedentTokenName, whitespaceTokenName, ignoreIndentationDelimeters } = this.options;
+        const { indentTokenName, dedentTokenName, whitespaceTokenName, ignoreIndentationDelimiters } = this.options;
 
         // Rearrange tokens because whitespace (which is ignored) goes to the beginning by default, consuming indentation as well
         // Order should be: dedent, indent, spaces
@@ -138,7 +138,7 @@ export class IndentationAwareTokenBuilder<Terminals extends string = string, Key
         let ws: TokenType | undefined;
         const otherTokens: TokenType[] = [];
         for (const tokenType of tokenTypes) {
-            for (const [begin, end] of ignoreIndentationDelimeters) {
+            for (const [begin, end] of ignoreIndentationDelimiters) {
                 if (tokenType.name === begin) {
                     tokenType.PUSH_MODE = LexingMode.IGNORE_INDENTATION;
                 } else if (tokenType.name === end) {
@@ -159,7 +159,7 @@ export class IndentationAwareTokenBuilder<Terminals extends string = string, Key
             throw new Error('Some indentation/whitespace tokens not found!');
         }
 
-        if (ignoreIndentationDelimeters.length > 0) {
+        if (ignoreIndentationDelimiters.length > 0) {
             const multiModeLexerDef: IMultiModeLexerDefinition = {
                 modes: {
                     [LexingMode.REGULAR]: [dedent, indent, ...otherTokens, ws],

--- a/packages/langium/test/parser/indentation-aware.test.ts
+++ b/packages/langium/test/parser/indentation-aware.test.ts
@@ -204,7 +204,7 @@ describe('IndentationAwareLexer', () => {
 
 });
 
-describe('IndentationAwareTokenBuilder#ignoreIndentationDelimeters', async () => {
+describe('IndentationAwareTokenBuilder#ignoreIndentationDelimiters', async () => {
 
     const grammar = `
         grammar PythonIfWithLists
@@ -232,7 +232,7 @@ describe('IndentationAwareTokenBuilder#ignoreIndentationDelimeters', async () =>
     `;
 
     const lexer = await getLexer(grammar, {
-        ignoreIndentationDelimeters: [
+        ignoreIndentationDelimiters: [
             ['(', ')'],
             ['[', ']'],
         ],
@@ -248,7 +248,7 @@ describe('IndentationAwareTokenBuilder#ignoreIndentationDelimeters', async () =>
         expect(errors).toHaveLength(0);
     });
 
-    test('should ignore indentation inside the given delimeters', async () => {
+    test('should ignore indentation inside the given delimiters', async () => {
         const { errors, tokens } = lexer.tokenize(expandToString`
             return [
                 false,
@@ -267,7 +267,7 @@ describe('IndentationAwareTokenBuilder#ignoreIndentationDelimeters', async () =>
         expect(tokenNames).not.toContain('DEDENT');
     });
 
-    test('should handle nested delimeters', async () => {
+    test('should handle nested delimiters', async () => {
         const { errors, tokens } = lexer.tokenize(expandToString`
             return [
                 [


### PR DESCRIPTION
Funny how I seem to have originally thought it's from `"deli" + "meter"` rather than `"de" + "limit" + "er"` :D