### PR TITLE
Export 'createParser' function to ease completion parser customization

### DIFF
--- a/packages/langium/src/parser/index.ts
+++ b/packages/langium/src/parser/index.ts
@@ -11,6 +11,7 @@ export * from './indentation-aware.js';
 export * from './langium-parser-builder.js';
 export * from './langium-parser.js';
 export * from './lexer.js';
+export * from './parser-builder-base.js';
 export * from './parser-config.js';
 export * from './token-builder.js';
 export * from './value-converter.js';


### PR DESCRIPTION
When creating a custom completion parser with the `createCompletionParser` function, the class `LangiumCompletionParser` is fixed. Doing customizations is therefore difficult and would be easier if the `createParser` function would be exposed.