### PR TITLE
Extend Lexer interface to expose diagnostics and data as a lexing report

### DIFF
--- a/packages/langium/src/parser/indentation-aware.ts
+++ b/packages/langium/src/parser/indentation-aware.ts
@@ -4,9 +4,9 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import type { CustomPatternMatcherFunc, TokenType, IToken, IMultiModeLexerDefinition } from 'chevrotain';
+import type { CustomPatternMatcherFunc, TokenType, IToken, IMultiModeLexerDefinition, TokenVocabulary } from 'chevrotain';
 import type { Grammar, TerminalRule } from '../languages/generated/ast.js';
-import type { ILexingReport, TokenBuilderOptions } from './token-builder.js';
+import type { LexingReport, TokenBuilderOptions } from './token-builder.js';
 import type { LexerResult } from './lexer.js';
 import type { LangiumCoreServices } from '../services.js';
 import { createToken, createTokenInstance, Lexer } from 'chevrotain';
@@ -69,7 +69,7 @@ export enum LexingMode {
     IGNORE_INDENTATION = 'ignore-indentation',
 }
 
-export interface IndentationLexingReport extends ILexingReport {
+export interface IndentationLexingReport extends LexingReport {
     /** Dedent tokens that are necessary to close the remaining indents. */
     remainingDedents: IToken[];
 }
@@ -129,7 +129,7 @@ export class IndentationAwareTokenBuilder<Terminals extends string = string, Key
         });
     }
 
-    override buildTokens(grammar: Grammar, options?: TokenBuilderOptions | undefined): TokenType[] | IMultiModeLexerDefinition {
+    override buildTokens(grammar: Grammar, options?: TokenBuilderOptions | undefined): TokenVocabulary {
         const tokenTypes = super.buildTokens(grammar, options);
         if (!isTokenTypeArray(tokenTypes)) {
             throw new Error('Invalid tokens built by default builder');
@@ -312,7 +312,7 @@ export class IndentationAwareTokenBuilder<Terminals extends string = string, Key
         if (matchIndentIndex === -1) {
             this.diagnostics.push({
                 severity: 'error',
-                message: `Invalid dedent level ${currIndentLevel} at offset: ${offset}. Current indetation stack: ${this.indentationStack}`,
+                message: `Invalid dedent level ${currIndentLevel} at offset: ${offset}. Current indentation stack: ${this.indentationStack}`,
                 offset,
                 length: match?.[0]?.length ?? 0,
                 line: this.getLineNumber(text, offset),

--- a/packages/langium/src/parser/langium-parser.ts
+++ b/packages/langium/src/parser/langium-parser.ts
@@ -19,13 +19,13 @@ import { isAssignment, isCrossReference, isKeyword } from '../languages/generate
 import { getExplicitRuleType, isDataTypeRule } from '../utils/grammar-utils.js';
 import { assignMandatoryProperties, getContainerOfType, linkContentToContainer } from '../utils/ast-utils.js';
 import { CstNodeBuilder } from './cst-node-builder.js';
-import type { ILexingReport } from './token-builder.js';
+import type { LexingReport } from './token-builder.js';
 
 export type ParseResult<T = AstNode> = {
     value: T,
     parserErrors: IRecognitionException[],
     lexerErrors: ILexingError[],
-    lexerReport?: ILexingReport
+    lexerReport?: LexingReport
 }
 
 export const DatatypeSymbol = Symbol('Datatype');

--- a/packages/langium/src/parser/langium-parser.ts
+++ b/packages/langium/src/parser/langium-parser.ts
@@ -19,11 +19,13 @@ import { isAssignment, isCrossReference, isKeyword } from '../languages/generate
 import { getExplicitRuleType, isDataTypeRule } from '../utils/grammar-utils.js';
 import { assignMandatoryProperties, getContainerOfType, linkContentToContainer } from '../utils/ast-utils.js';
 import { CstNodeBuilder } from './cst-node-builder.js';
+import type { ILexingReport } from './token-builder.js';
 
 export type ParseResult<T = AstNode> = {
     value: T,
     parserErrors: IRecognitionException[],
-    lexerErrors: ILexingError[]
+    lexerErrors: ILexingError[],
+    lexerReport?: ILexingReport
 }
 
 export const DatatypeSymbol = Symbol('Datatype');
@@ -240,6 +242,7 @@ export class LangiumParser extends AbstractLangiumParser {
         return {
             value: result,
             lexerErrors: lexerResult.errors,
+            lexerReport: lexerResult.report,
             parserErrors: this.wrapper.errors
         };
     }

--- a/packages/langium/src/parser/lexer.ts
+++ b/packages/langium/src/parser/lexer.ts
@@ -7,11 +7,7 @@
 import type { ILexingError, IMultiModeLexerDefinition, IToken, TokenType, TokenTypeDictionary, TokenVocabulary } from 'chevrotain';
 import type { LangiumCoreServices } from '../services.js';
 import { Lexer as ChevrotainLexer } from 'chevrotain';
-import type { ILexingReport, TokenBuilder } from './token-builder.js';
-
-export interface ILexingDiagnostic extends ILexingError {
-    severity?: 'error' | 'warning' | 'info' | 'hint';
-}
+import type { LexingReport, TokenBuilder } from './token-builder.js';
 
 export interface LexerResult {
     /**
@@ -26,7 +22,7 @@ export interface LexerResult {
      */
     hidden: IToken[];
     errors: ILexingError[];
-    report?: ILexingReport;
+    report?: LexingReport;
 }
 
 export interface Lexer {

--- a/packages/langium/src/serializer/hydrator.ts
+++ b/packages/langium/src/serializer/hydrator.ts
@@ -18,7 +18,7 @@ import { isRootCstNode, isCompositeCstNode, isLeafCstNode, isAstNode, isReferenc
 import { streamAst } from '../utils/ast-utils.js';
 import { BiMap } from '../utils/collections.js';
 import { streamCst } from '../utils/cst-utils.js';
-import type { ILexingReport } from '../parser/token-builder.js';
+import type { LexingReport } from '../parser/token-builder.js';
 
 /**
  * The hydrator service is responsible for allowing AST parse results to be sent across worker threads.
@@ -62,20 +62,18 @@ export class DefaultHydrator implements Hydrator {
 
     dehydrate(result: ParseResult<AstNode>): ParseResult<object> {
         return {
+            lexerErrors: result.lexerErrors,
+            lexerReport: result.lexerReport ? this.dehydrateLexerReport(result.lexerReport) : undefined,
             // We need to create shallow copies of the errors
             // The original errors inherit from the `Error` class, which is not transferable across worker threads
-            lexerErrors: result.lexerErrors.map(e => ({ ...e, message: e.message })),
-            lexerReport: result.lexerReport ? this.dehydrateLexerReport(result.lexerReport) : undefined,
             parserErrors: result.parserErrors.map(e => ({ ...e, message: e.message })),
             value: this.dehydrateAstNode(result.value, this.createDehyrationContext(result.value))
         };
     }
 
-    protected dehydrateLexerReport(lexerReport: ILexingReport): ILexingReport {
-        return {
-            ...lexerReport,
-            diagnostics: lexerReport.diagnostics.map(d => ({ ...d, message: d.message }))
-        };
+    protected dehydrateLexerReport(lexerReport: LexingReport): LexingReport {
+        // By default, lexer reports are serializable
+        return lexerReport;
     }
 
     protected createDehyrationContext(node: AstNode): DehydrateContext {

--- a/packages/langium/src/serializer/hydrator.ts
+++ b/packages/langium/src/serializer/hydrator.ts
@@ -18,6 +18,7 @@ import { isRootCstNode, isCompositeCstNode, isLeafCstNode, isAstNode, isReferenc
 import { streamAst } from '../utils/ast-utils.js';
 import { BiMap } from '../utils/collections.js';
 import { streamCst } from '../utils/cst-utils.js';
+import type { ILexingReport } from '../parser/token-builder.js';
 
 /**
  * The hydrator service is responsible for allowing AST parse results to be sent across worker threads.
@@ -64,8 +65,16 @@ export class DefaultHydrator implements Hydrator {
             // We need to create shallow copies of the errors
             // The original errors inherit from the `Error` class, which is not transferable across worker threads
             lexerErrors: result.lexerErrors.map(e => ({ ...e, message: e.message })),
+            lexerReport: result.lexerReport ? this.dehydrateLexerReport(result.lexerReport) : undefined,
             parserErrors: result.parserErrors.map(e => ({ ...e, message: e.message })),
             value: this.dehydrateAstNode(result.value, this.createDehyrationContext(result.value))
+        };
+    }
+
+    protected dehydrateLexerReport(lexerReport: ILexingReport): ILexingReport {
+        return {
+            ...lexerReport,
+            diagnostics: lexerReport.diagnostics.map(d => ({ ...d, message: d.message }))
         };
     }
 
@@ -162,6 +171,7 @@ export class DefaultHydrator implements Hydrator {
         }
         return {
             lexerErrors: result.lexerErrors,
+            lexerReport: result.lexerReport,
             parserErrors: result.parserErrors,
             value: this.hydrateAstNode(node, context) as T
         };

--- a/packages/langium/src/validation/document-validator.ts
+++ b/packages/langium/src/validation/document-validator.ts
@@ -18,6 +18,7 @@ import { streamAst } from '../utils/ast-utils.js';
 import { tokenToRange } from '../utils/cst-utils.js';
 import { interruptAndCheck, isOperationCancelled } from '../utils/promise-utils.js';
 import { diagnosticData } from './validation-registry.js';
+import type { ILexingDiagnostic } from '../parser/lexer.js';
 
 export interface ValidationOptions {
     /**
@@ -97,21 +98,23 @@ export class DefaultDocumentValidator implements DocumentValidator {
     }
 
     protected processLexingErrors(parseResult: ParseResult, diagnostics: Diagnostic[], _options: ValidationOptions): void {
-        for (const lexerError of parseResult.lexerErrors) {
+        const lexerDiagnostics = [...parseResult.lexerErrors, ...parseResult.lexerReport?.diagnostics ?? []] as ILexingDiagnostic[];
+        for (const lexerDiagnostic of lexerDiagnostics) {
+            const severity = lexerDiagnostic?.severity ?? 'error';
             const diagnostic: Diagnostic = {
-                severity: toDiagnosticSeverity('error'),
+                severity: toDiagnosticSeverity(severity),
                 range: {
                     start: {
-                        line: lexerError.line! - 1,
-                        character: lexerError.column! - 1
+                        line: lexerDiagnostic.line! - 1,
+                        character: lexerDiagnostic.column! - 1
                     },
                     end: {
-                        line: lexerError.line! - 1,
-                        character: lexerError.column! + lexerError.length - 1
+                        line: lexerDiagnostic.line! - 1,
+                        character: lexerDiagnostic.column! + lexerDiagnostic.length - 1
                     }
                 },
-                message: lexerError.message,
-                data: diagnosticData(DocumentValidator.LexingError),
+                message: lexerDiagnostic.message,
+                data: toDiagnosticData(severity),
                 source: this.getSource()
             };
             diagnostics.push(diagnostic);
@@ -245,8 +248,26 @@ export function toDiagnosticSeverity(severity: 'error' | 'warning' | 'info' | 'h
     }
 }
 
+export function toDiagnosticData(severity: 'error' | 'warning' | 'info' | 'hint'): DiagnosticData {
+    switch (severity) {
+        case 'error':
+            return diagnosticData(DocumentValidator.LexingError);
+        case 'warning':
+            return diagnosticData(DocumentValidator.LexingWarning);
+        case 'info':
+            return diagnosticData(DocumentValidator.LexingInfo);
+        case 'hint':
+            return diagnosticData(DocumentValidator.LexingHint);
+        default:
+            throw new Error('Invalid diagnostic severity: ' + severity);
+    }
+}
+
 export namespace DocumentValidator {
     export const LexingError = 'lexing-error';
+    export const LexingWarning = 'lexing-warning';
+    export const LexingInfo = 'lexing-info';
+    export const LexingHint = 'lexing-hint';
     export const ParsingError = 'parsing-error';
     export const LinkingError = 'linking-error';
 }

--- a/packages/langium/src/validation/document-validator.ts
+++ b/packages/langium/src/validation/document-validator.ts
@@ -18,7 +18,7 @@ import { streamAst } from '../utils/ast-utils.js';
 import { tokenToRange } from '../utils/cst-utils.js';
 import { interruptAndCheck, isOperationCancelled } from '../utils/promise-utils.js';
 import { diagnosticData } from './validation-registry.js';
-import type { ILexingDiagnostic } from '../parser/lexer.js';
+import type { LexingDiagnostic } from '../parser/token-builder.js';
 
 export interface ValidationOptions {
     /**
@@ -98,7 +98,7 @@ export class DefaultDocumentValidator implements DocumentValidator {
     }
 
     protected processLexingErrors(parseResult: ParseResult, diagnostics: Diagnostic[], _options: ValidationOptions): void {
-        const lexerDiagnostics = [...parseResult.lexerErrors, ...parseResult.lexerReport?.diagnostics ?? []] as ILexingDiagnostic[];
+        const lexerDiagnostics = [...parseResult.lexerErrors, ...parseResult.lexerReport?.diagnostics ?? []] as LexingDiagnostic[];
         for (const lexerDiagnostic of lexerDiagnostics) {
             const severity = lexerDiagnostic?.severity ?? 'error';
             const diagnostic: Diagnostic = {

--- a/packages/langium/test/parser/indentation-aware.test.ts
+++ b/packages/langium/test/parser/indentation-aware.test.ts
@@ -12,6 +12,7 @@ import { createLangiumGrammarServices, createServicesForGrammar } from 'langium/
 import type { LangiumServices, PartialLangiumServices } from 'langium/lsp';
 import { expandToString } from 'langium/generate';
 import { parseHelper } from 'langium/test';
+import type { IMultiModeLexerDefinition } from 'chevrotain';
 
 const grammarServices = createLangiumGrammarServices(EmptyFileSystem).grammar;
 const helper = parseHelper<Grammar>(grammarServices);
@@ -20,7 +21,7 @@ const tokenBuilder = new IndentationAwareTokenBuilder();
 
 async function getTokens(grammarString: string): Promise<TokenType[]> {
     const grammar = (await helper(grammarString)).parseResult.value;
-    const tokens = tokenBuilder.buildTokens(grammar);
+    const tokens = tokenBuilder.buildTokens(grammar) as IMultiModeLexerDefinition | TokenType[];
     if (Array.isArray(tokens)) {
         return tokens;
     } else {


### PR DESCRIPTION
This is based on a discussion that started in https://github.com/eclipse-langium/langium/discussions/1653 and was already marked as a TODO in-code:
```
// TODO: find a way to report error diagnostics message
``` 

- Add support to report diagnostics during lexing process
- Properly map diagnostic severities
- Mark method and report as optional for backwards-compatibility

For indentation:
- Add dedent tokens to report until consumed by lexer

Please note this PR is based on https://github.com/eclipse-langium/langium/pull/1664 which was already approved but has yet to be merged.