### PR TITLE
Specify `LINE_BREAKS` on tokens with custom patterns

### DIFF
--- a/packages/langium/src/parser/token-builder.ts
+++ b/packages/langium/src/parser/token-builder.ts
@@ -131,13 +131,17 @@ export class DefaultTokenBuilder implements TokenBuilder {
 
     protected buildKeywordToken(keyword: Keyword, terminalTokens: TokenType[], caseInsensitive: boolean): TokenType {
         const keywordPattern = this.buildKeywordPattern(keyword, caseInsensitive);
-
-        return {
+        const tokenType: TokenType = {
             name: keyword.value,
             PATTERN: keywordPattern,
-            LINE_BREAKS: typeof keywordPattern === 'function',
             LONGER_ALT: this.findLongerAlt(keyword, terminalTokens)
         };
+
+        if (typeof keywordPattern === 'function') {
+            tokenType.LINE_BREAKS = true;
+        }
+
+        return tokenType;
     }
 
     protected buildKeywordPattern(keyword: Keyword, caseInsensitive: boolean): TokenPattern {

--- a/packages/langium/src/parser/token-builder.ts
+++ b/packages/langium/src/parser/token-builder.ts
@@ -88,8 +88,10 @@ export class DefaultTokenBuilder implements TokenBuilder {
         const tokenType: TokenType = {
             name: terminal.name,
             PATTERN: pattern,
-            LINE_BREAKS: true
         };
+        if (typeof pattern === 'function') {
+            tokenType.LINE_BREAKS = true;
+        }
         if (terminal.hidden) {
             // Only skip tokens that are able to accept whitespace
             tokenType.GROUP = isWhitespace(regex) ? Lexer.SKIPPED : 'hidden';

--- a/packages/langium/src/parser/token-builder.ts
+++ b/packages/langium/src/parser/token-builder.ts
@@ -130,9 +130,12 @@ export class DefaultTokenBuilder implements TokenBuilder {
     }
 
     protected buildKeywordToken(keyword: Keyword, terminalTokens: TokenType[], caseInsensitive: boolean): TokenType {
+        const keywordPattern = this.buildKeywordPattern(keyword, caseInsensitive);
+
         return {
             name: keyword.value,
-            PATTERN: this.buildKeywordPattern(keyword, caseInsensitive),
+            PATTERN: keywordPattern,
+            LINE_BREAKS: typeof keywordPattern === 'function',
             LONGER_ALT: this.findLongerAlt(keyword, terminalTokens)
         };
     }


### PR DESCRIPTION
A warning was printed by Chevrotain for keyword tokens using a custom matcher function for the pattern.
While the default implementation does not use a custom matcher function, it is possible to override `buildKeywordPattern` to return one.
