### PR TITLE
Perform parser optimizations in production mode

### DIFF
--- a/examples/arithmetics/src/language-server/generated/module.ts
+++ b/examples/arithmetics/src/language-server/generated/module.ts
@@ -10,7 +10,8 @@ import { ArithmeticsGrammar } from './grammar.js';
 export const ArithmeticsLanguageMetaData = {
     languageId: 'arithmetics',
     fileExtensions: ['.calc'],
-    caseInsensitive: true
+    caseInsensitive: true,
+    mode: 'development'
 } as const satisfies LanguageMetaData;
 
 export const ArithmeticsGeneratedSharedModule: Module<LangiumSharedCoreServices, LangiumGeneratedSharedCoreServices> = {

--- a/examples/domainmodel/src/language-server/generated/module.ts
+++ b/examples/domainmodel/src/language-server/generated/module.ts
@@ -10,7 +10,8 @@ import { DomainModelGrammar } from './grammar.js';
 export const DomainModelLanguageMetaData = {
     languageId: 'domain-model',
     fileExtensions: ['.dmodel'],
-    caseInsensitive: false
+    caseInsensitive: false,
+    mode: 'development'
 } as const satisfies LanguageMetaData;
 
 export const parserConfig: IParserConfig = {

--- a/examples/requirements/src/language-server/generated/module.ts
+++ b/examples/requirements/src/language-server/generated/module.ts
@@ -10,13 +10,15 @@ import { RequirementsGrammar, TestsGrammar } from './grammar.js';
 export const RequirementsLanguageMetaData = {
     languageId: 'requirements-lang',
     fileExtensions: ['.req'],
-    caseInsensitive: false
+    caseInsensitive: false,
+    mode: 'development'
 } as const satisfies LanguageMetaData;
 
 export const TestsLanguageMetaData = {
     languageId: 'tests-lang',
     fileExtensions: ['.tst'],
-    caseInsensitive: false
+    caseInsensitive: false,
+    mode: 'development'
 } as const satisfies LanguageMetaData;
 
 export const RequirementsAndTestsGeneratedSharedModule: Module<LangiumSharedCoreServices, LangiumGeneratedSharedCoreServices> = {

--- a/examples/statemachine/src/language-server/generated/module.ts
+++ b/examples/statemachine/src/language-server/generated/module.ts
@@ -10,7 +10,8 @@ import { StatemachineGrammar } from './grammar.js';
 export const StatemachineLanguageMetaData = {
     languageId: 'statemachine',
     fileExtensions: ['.statemachine'],
-    caseInsensitive: false
+    caseInsensitive: false,
+    mode: 'development'
 } as const satisfies LanguageMetaData;
 
 export const StatemachineGeneratedSharedModule: Module<LangiumSharedCoreServices, LangiumGeneratedSharedCoreServices> = {

--- a/packages/generator-langium/templates/core/.package.json
+++ b/packages/generator-langium/templates/core/.package.json
@@ -12,6 +12,7 @@
         "watch": "tsc -b <%= tsconfig %> --watch",
         "lint": "eslint src --ext ts",
         "langium:generate": "langium generate",
+        "langium:generate:production": "langium generate --mode=production",
         "langium:watch": "langium generate --watch"
     },
     "dependencies": {

--- a/packages/langium-cli/src/generator/module-generator.ts
+++ b/packages/langium-cli/src/generator/module-generator.ts
@@ -5,7 +5,7 @@
  ******************************************************************************/
 
 import type { Grammar, IParserConfig } from 'langium';
-import { EOL, type Generated, expandToNode, joinToNode, toString } from 'langium/generate';
+import { type Generated, expandToNode, joinToNode, toString } from 'langium/generate';
 import type { LangiumConfig, LangiumLanguageConfig } from '../package-types.js';
 import { generatedHeader } from './node-util.js';
 
@@ -42,13 +42,14 @@ export function generateModule(grammars: Grammar[], config: LangiumConfig, gramm
             grammarsWithName,
             grammar => {
                 const config = grammarConfigMap.get(grammar)!;
-                const modeValue = mode ? `,${EOL}    mode: '${mode}'` : '';
+                const modeValue = mode === 'production' ? mode : 'development';
                 return expandToNode`
 
                     export const ${ grammar.name }LanguageMetaData = {
                         languageId: '${config.id}',
                         fileExtensions: [${config.fileExtensions && joinToNode(config.fileExtensions, e => appendQuotesAndDot(e), { separator: ', ' })}],
-                        caseInsensitive: ${Boolean(config.caseInsensitive)}${modeValue}
+                        caseInsensitive: ${Boolean(config.caseInsensitive)},
+                        mode: '${modeValue}'
                     } as const satisfies LanguageMetaData;
                 `;
             },

--- a/packages/langium-cli/src/generator/module-generator.ts
+++ b/packages/langium-cli/src/generator/module-generator.ts
@@ -5,13 +5,14 @@
  ******************************************************************************/
 
 import type { Grammar, IParserConfig } from 'langium';
-import { type Generated, expandToNode, joinToNode, toString } from 'langium/generate';
+import { EOL, type Generated, expandToNode, joinToNode, toString } from 'langium/generate';
 import type { LangiumConfig, LangiumLanguageConfig } from '../package-types.js';
 import { generatedHeader } from './node-util.js';
 
 export function generateModule(grammars: Grammar[], config: LangiumConfig, grammarConfigMap: Map<Grammar, LangiumLanguageConfig>): string {
     const grammarsWithName = grammars.filter(grammar => !!grammar.name);
     const parserConfig = config.chevrotainParserConfig;
+    const mode = config.mode;
     const hasIParserConfigImport = Boolean(parserConfig) || grammars.some(grammar => grammarConfigMap.get(grammar)?.chevrotainParserConfig !== undefined);
     let needsGeneralParserConfig = undefined;
 
@@ -41,12 +42,13 @@ export function generateModule(grammars: Grammar[], config: LangiumConfig, gramm
             grammarsWithName,
             grammar => {
                 const config = grammarConfigMap.get(grammar)!;
+                const modeValue = mode ? `,${EOL}    mode: '${mode}'` : '';
                 return expandToNode`
 
                     export const ${ grammar.name }LanguageMetaData = {
                         languageId: '${config.id}',
                         fileExtensions: [${config.fileExtensions && joinToNode(config.fileExtensions, e => appendQuotesAndDot(e), { separator: ', ' })}],
-                        caseInsensitive: ${Boolean(config.caseInsensitive)}
+                        caseInsensitive: ${Boolean(config.caseInsensitive)}${modeValue}
                     } as const satisfies LanguageMetaData;
                 `;
             },

--- a/packages/langium-cli/src/parser-validation.ts
+++ b/packages/langium-cli/src/parser-validation.ts
@@ -59,7 +59,8 @@ function languageConfigToMetaData(config: LangiumLanguageConfig): LanguageMetaDa
     return {
         languageId: config.id,
         fileExtensions: config.fileExtensions ?? [],
-        caseInsensitive: Boolean(config.caseInsensitive)
+        caseInsensitive: Boolean(config.caseInsensitive),
+        mode: 'development'
     };
 }
 

--- a/packages/langium/src/grammar/generated/module.ts
+++ b/packages/langium/src/grammar/generated/module.ts
@@ -13,7 +13,8 @@ import { LangiumGrammarGrammar } from './grammar.js';
 export const LangiumGrammarLanguageMetaData = {
     languageId: 'langium',
     fileExtensions: ['.langium'],
-    caseInsensitive: false
+    caseInsensitive: false,
+    mode: 'development'
 } as const satisfies LanguageMetaData;
 
 export const LangiumGrammarParserConfig: IParserConfig = {

--- a/packages/langium/src/grammar/internal-grammar-util.ts
+++ b/packages/langium/src/grammar/internal-grammar-util.ts
@@ -182,7 +182,8 @@ export async function createServicesForGrammar<L extends LangiumServices = Langi
     const languageMetaData = config.languageMetaData ?? {
         caseInsensitive: false,
         fileExtensions: [`.${grammarNode.name?.toLowerCase() ?? 'unknown'}`],
-        languageId: grammarNode.name ?? 'UNKNOWN'
+        languageId: grammarNode.name ?? 'UNKNOWN',
+        mode: 'development'
     };
     const generatedSharedModule: Module<LangiumGeneratedSharedCoreServices> = {
         AstReflection: () => interpretAstReflection(grammarNode),

--- a/packages/langium/src/languages/language-meta-data.ts
+++ b/packages/langium/src/languages/language-meta-data.ts
@@ -4,8 +4,17 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
+/**
+ * Metadata of a language.
+ */
 export interface LanguageMetaData {
     languageId: string;
     fileExtensions: readonly string[];
     caseInsensitive: boolean;
+    /**
+     * Mode used to optimize code for development or production environments.
+     * 
+     * In production mode, all lexer/parser validations are disabled.
+     */
+    mode?: 'development' | 'production';
 }

--- a/packages/langium/src/languages/language-meta-data.ts
+++ b/packages/langium/src/languages/language-meta-data.ts
@@ -13,8 +13,8 @@ export interface LanguageMetaData {
     caseInsensitive: boolean;
     /**
      * Mode used to optimize code for development or production environments.
-     * 
-     * In production mode, all lexer/parser validations are disabled.
+     *
+     * In production mode, all Chevrotain lexer/parser validations are disabled.
      */
-    mode?: 'development' | 'production';
+    mode: 'development' | 'production';
 }

--- a/packages/langium/src/parser/lexer.ts
+++ b/packages/langium/src/parser/lexer.ts
@@ -51,8 +51,10 @@ export class DefaultLexer implements Lexer {
         });
         this.tokenTypes = this.toTokenTypeDictionary(tokens);
         const lexerTokens = isTokenTypeDictionary(tokens) ? Object.values(tokens) : tokens;
+        const production = services.LanguageMetaData.mode === 'production';
         this.chevrotainLexer = new ChevrotainLexer(lexerTokens, {
-            positionTracking: 'full'
+            positionTracking: 'full',
+            skipValidations: production
         });
     }
 


### PR DESCRIPTION
Closes https://github.com/eclipse-langium/langium/issues/1687

Improves the `production` mode setting for the langium CLI. It's now generated into the language meta data and is used to skip validations and ignore ambiguity issues in the parser if activated.

This should improve the startup time of all grammars and is quite noticeable on larger grammars.