### PR TITLE
Fix indentation tokens lengths

### DIFF
--- a/packages/langium/src/parser/indentation-aware.ts
+++ b/packages/langium/src/parser/indentation-aware.ts
@@ -272,16 +272,7 @@ export class IndentationAwareTokenBuilder<Terminals extends string = string, Key
 
         this.indentationStack.push(currIndentLevel);
 
-        const indentToken = this.createIndentationTokenInstance(
-            this.indentTokenType,
-            text,
-            match?.[0] ?? '',
-            offset,
-        );
-        tokens.push(indentToken);
-
-        // Token already added, let the indentation now be consumed as whitespace and ignored
-        return null;
+        return match;
     }
 
     /**

--- a/packages/langium/src/parser/indentation-aware.ts
+++ b/packages/langium/src/parser/indentation-aware.ts
@@ -312,13 +312,14 @@ export class IndentationAwareTokenBuilder<Terminals extends string = string, Key
         }
 
         const numberOfDedents = this.indentationStack.length - matchIndentIndex - 1;
+        const newlinesBeforeDedent = text.substring(0, offset).match(/[\r\n]+$/)?.[0].length ?? 1;
 
         for (let i = 0; i < numberOfDedents; i++) {
             const token = this.createIndentationTokenInstance(
                 this.dedentTokenType,
                 text,
                 '',  // Dedents are 0-width tokens
-                offset,
+                offset - (newlinesBeforeDedent - 1), // Place the dedent after the first new line character
             );
             tokens.push(token);
             this.indentationStack.pop();

--- a/packages/langium/src/parser/indentation-aware.ts
+++ b/packages/langium/src/parser/indentation-aware.ts
@@ -317,14 +317,14 @@ export class IndentationAwareTokenBuilder<Terminals extends string = string, Key
             const token = this.createIndentationTokenInstance(
                 this.dedentTokenType,
                 text,
-                match?.[0] ?? '',
+                '',  // Dedents are 0-width tokens
                 offset,
             );
             tokens.push(token);
             this.indentationStack.pop();
         }
 
-        // Token already added, let the dedentation now be consumed as whitespace and ignored
+        // Token already added, let the dedentation now be consumed as whitespace (if any) and ignored
         return null;
     }
 
@@ -356,7 +356,7 @@ export class IndentationAwareTokenBuilder<Terminals extends string = string, Key
         const remainingDedents: IToken[] = [];
         while (this.indentationStack.length > 1) {
             remainingDedents.push(
-                this.createIndentationTokenInstance(this.dedentTokenType, text, this.options.dedentTokenName, text.length)
+                this.createIndentationTokenInstance(this.dedentTokenType, text, '', text.length)
             );
             this.indentationStack.pop();
         }


### PR DESCRIPTION
Removed the duplication of indent tokens as whitespace, and ensured that dedent tokens are 0-width (empty string).
The dedent token could previously contain the matched whitespace of the following indentation (if it matched a previous indentation and didn't introduce a new indent token).

For example, in this snippet:
```python
if True:
    if False:
        print('impossible')
    else:
        print('makes sense')
```
the dedent token after the first `print` statement contained the whitespace before the `else` keyword

Additionally, fixed a minor issue (mostly inconvenience with folding) where the dedent tokens were placed after all newline tokens. For example, in the snippet:
```python
if True:
    print('yes')


else:
    print('no')
```
the dedent was placed on the 5th line, right before the `else` keyword. This PR moves it such that it is on the 3rd line.