### PR TITLE
Add optional AST node type

### DIFF
--- a/examples/arithmetics/src/language-server/arithmetics-util.ts
+++ b/examples/arithmetics/src/language-server/arithmetics-util.ts
@@ -4,7 +4,7 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import type { ResolvedReference } from 'langium';
+import type { OptionalAstNode, ResolvedReference } from 'langium';
 import { isDefinition, type BinaryExpression, type Definition, type FunctionCall } from './generated/ast.js';
 
 export function applyOp(op: BinaryExpression['operator']): (x: number, y: number) => number {
@@ -28,6 +28,6 @@ export type ResolvedFunctionCall = FunctionCall & {
     func: ResolvedReference<Definition>
 }
 
-export function isResolvedFunctionCall(functionCall: FunctionCall): functionCall is ResolvedFunctionCall {
-    return isDefinition(functionCall.func.ref);
+export function isResolvedFunctionCall(functionCall: OptionalAstNode<FunctionCall>): functionCall is ResolvedFunctionCall {
+    return !!functionCall.func && isDefinition(functionCall.func.ref);
 }

--- a/packages/langium/src/syntax-tree.ts
+++ b/packages/langium/src/syntax-tree.ts
@@ -35,6 +35,11 @@ export interface GenericAstNode extends AstNode {
     [key: string]: unknown
 }
 
+export type OptionalAstNode<T extends AstNode> = {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    [P in keyof T]: P extends keyof AstNode ? T[P] : T[P] extends any[] | boolean ? T[P] : T[P] | undefined;
+};
+
 type SpecificNodeProperties<N extends AstNode> = keyof Omit<N, keyof AstNode | number | symbol>;
 
 /**


### PR DESCRIPTION
The proposed `OptionalAstNode<T>` is a generic type that sets all properties, that could be potentially missing due to parser errors, to be optional. However, this excludes specificially:

* Properties inherited from `AstNode` (mainly the `$type` property which is always set).
* All `boolean` properties. Those will be set to `false` by the parser, even if the property wasn't parsed.
* All array property. Those will be set to `[]` by the parser.

This change adjusts the arithmetics language validator to use that new type to ensure that all properties are properly checked for truthyness before they are accessed. Inspired by the discussion in https://github.com/eclipse-langium/langium/discussions/1758.