### PR TITLE
Fix references in fragment rules

### DIFF
--- a/examples/arithmetics/src/language-server/generated/grammar.ts
+++ b/examples/arithmetics/src/language-server/generated/grammar.ts
@@ -14,8 +14,8 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ?? (lo
   "rules": [
     {
       "$type": "ParserRule",
-      "name": "Module",
       "entry": true,
+      "name": "Module",
       "definition": {
         "$type": "Group",
         "elements": [

--- a/examples/domainmodel/src/language-server/generated/grammar.ts
+++ b/examples/domainmodel/src/language-server/generated/grammar.ts
@@ -14,8 +14,8 @@ export const DomainModelGrammar = (): Grammar => loadedDomainModelGrammar ?? (lo
   "rules": [
     {
       "$type": "ParserRule",
-      "name": "Domainmodel",
       "entry": true,
+      "name": "Domainmodel",
       "definition": {
         "$type": "Assignment",
         "feature": "elements",

--- a/examples/requirements/src/language-server/generated/grammar.ts
+++ b/examples/requirements/src/language-server/generated/grammar.ts
@@ -15,8 +15,8 @@ export const RequirementsGrammar = (): Grammar => loadedRequirementsGrammar ?? (
   "rules": [
     {
       "$type": "ParserRule",
-      "name": "RequirementModel",
       "entry": true,
+      "name": "RequirementModel",
       "definition": {
         "$type": "Group",
         "elements": [
@@ -321,8 +321,8 @@ export const TestsGrammar = (): Grammar => loadedTestsGrammar ?? (loadedTestsGra
   "rules": [
     {
       "$type": "ParserRule",
-      "name": "TestModel",
       "entry": true,
+      "name": "TestModel",
       "definition": {
         "$type": "Group",
         "elements": [
@@ -519,8 +519,8 @@ export const TestsGrammar = (): Grammar => loadedTestsGrammar ?? (loadedTestsGra
     },
     {
       "$type": "ParserRule",
-      "name": "RequirementModel",
       "entry": false,
+      "name": "RequirementModel",
       "definition": {
         "$type": "Group",
         "elements": [

--- a/examples/statemachine/src/language-server/generated/grammar.ts
+++ b/examples/statemachine/src/language-server/generated/grammar.ts
@@ -14,8 +14,8 @@ export const StatemachineGrammar = (): Grammar => loadedStatemachineGrammar ?? (
   "rules": [
     {
       "$type": "ParserRule",
-      "name": "Statemachine",
       "entry": true,
+      "name": "Statemachine",
       "definition": {
         "$type": "Group",
         "elements": [

--- a/packages/langium/src/grammar/generated/grammar.ts
+++ b/packages/langium/src/grammar/generated/grammar.ts
@@ -14,8 +14,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
   "rules": [
     {
       "$type": "ParserRule",
-      "name": "Grammar",
       "entry": true,
+      "name": "Grammar",
       "definition": {
         "$type": "Group",
         "elements": [
@@ -1348,8 +1348,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
     },
     {
       "$type": "ParserRule",
-      "name": "RuleNameAndParams",
       "fragment": true,
+      "name": "RuleNameAndParams",
       "definition": {
         "$type": "Group",
         "elements": [

--- a/packages/langium/src/parser/cst-node-builder.ts
+++ b/packages/langium/src/parser/cst-node-builder.ts
@@ -18,7 +18,7 @@ export class CstNodeBuilder {
     private nodeStack: CompositeCstNodeImpl[] = [];
 
     private get current(): CompositeCstNodeImpl {
-        return this.nodeStack[this.nodeStack.length - 1];
+        return this.nodeStack[this.nodeStack.length - 1] ?? this.rootNode;
     }
 
     buildRootNode(input: string): RootCstNode {

--- a/packages/langium/src/parser/langium-parser.ts
+++ b/packages/langium/src/parser/langium-parser.ts
@@ -305,8 +305,9 @@ export class LangiumParser extends AbstractLangiumParser {
     subrule(idx: number, rule: RuleResult, fragment: boolean, feature: AbstractElement, args: Args): void {
         let cstNode: CompositeCstNode | undefined;
         if (!this.isRecording() && !fragment) {
-            // If the called rule is a fragment rule, we just add all parsed CST nodes to the already existing CST node
-            // Note that this also skips the subrule assignment later on. This is intended, as fragment rules only enrich the current AST node
+            // We only want to create a new CST node if the subrule actually creates a new AST node.
+            // In other cases like calls of fragment rules the current CST/AST is populated further.
+            // This also then skips the subrule assignment.
             cstNode = this.nodeBuilder.buildCompositeNode(feature);
         }
         const subruleResult = this.wrapper.wrapSubrule(idx, rule, args) as any;

--- a/packages/langium/src/parser/langium-parser.ts
+++ b/packages/langium/src/parser/langium-parser.ts
@@ -252,8 +252,8 @@ export class LangiumParser extends AbstractLangiumParser {
     private startImplementation($type: string | symbol | undefined, implementation: RuleImpl): RuleImpl {
         return (args) => {
             // Only create a new AST node in case the calling rule is not a fragment rule
-            const createNode = $type !== undefined;
-            if (!this.isRecording() && createNode) {
+            const createNode = !this.isRecording() && $type !== undefined;
+            if (createNode) {
                 const node: any = { $type };
                 this.stack.push(node);
                 if ($type === DatatypeSymbol) {
@@ -266,7 +266,7 @@ export class LangiumParser extends AbstractLangiumParser {
             } catch (err) {
                 result = undefined;
             }
-            if (!this.isRecording() && result === undefined && createNode) {
+            if (result === undefined && createNode) {
                 result = this.construct();
             }
             return result;
@@ -307,7 +307,8 @@ export class LangiumParser extends AbstractLangiumParser {
         if (!this.isRecording() && !fragment) {
             // We only want to create a new CST node if the subrule actually creates a new AST node.
             // In other cases like calls of fragment rules the current CST/AST is populated further.
-            // This also then skips the subrule assignment.
+            // Note that skipping this initialization and leaving cstNode unassigned also skips the subrule assignment later on.
+            // This is intended, as fragment rules only enrich the current AST node
             cstNode = this.nodeBuilder.buildCompositeNode(feature);
         }
         const subruleResult = this.wrapper.wrapSubrule(idx, rule, args) as any;

--- a/packages/langium/src/parser/parser-builder-base.ts
+++ b/packages/langium/src/parser/parser-builder-base.ts
@@ -274,6 +274,7 @@ function buildCrossReference(ctx: RuleContext, crossRef: CrossReference, termina
         }
         return buildCrossReference(ctx, crossRef, assignTerminal);
     } else if (isRuleCall(terminal) && isParserRule(terminal.rule.ref)) {
+        // The terminal is a data type rule here. Everything else will result in a validation error.
         const rule = terminal.rule.ref;
         const idx = ctx.subrule++;
         return (args) => ctx.parser.subrule(idx, getRule(ctx, rule), false, crossRef, args);

--- a/packages/langium/src/parser/parser-builder-base.ts
+++ b/packages/langium/src/parser/parser-builder-base.ts
@@ -99,8 +99,9 @@ function buildRuleCall(ctx: RuleContext, ruleCall: RuleCall): Method {
     const rule = ruleCall.rule.ref;
     if (isParserRule(rule)) {
         const idx = ctx.subrule++;
+        const fragment = rule.fragment;
         const predicate = ruleCall.arguments.length > 0 ? buildRuleCallPredicate(rule, ruleCall.arguments) : () => ({});
-        return (args) => ctx.parser.subrule(idx, getRule(ctx, rule), ruleCall, predicate(args));
+        return (args) => ctx.parser.subrule(idx, getRule(ctx, rule), fragment, ruleCall, predicate(args));
     } else if (isTerminalRule(rule)) {
         const idx = ctx.consume++;
         const method = getToken(ctx, rule.name);
@@ -273,8 +274,9 @@ function buildCrossReference(ctx: RuleContext, crossRef: CrossReference, termina
         }
         return buildCrossReference(ctx, crossRef, assignTerminal);
     } else if (isRuleCall(terminal) && isParserRule(terminal.rule.ref)) {
+        const rule = terminal.rule.ref;
         const idx = ctx.subrule++;
-        return (args) => ctx.parser.subrule(idx, getRule(ctx, terminal.rule.ref as ParserRule), crossRef, args);
+        return (args) => ctx.parser.subrule(idx, getRule(ctx, rule), false, crossRef, args);
     } else if (isRuleCall(terminal) && isTerminalRule(terminal.rule.ref)) {
         const idx = ctx.consume++;
         const terminalRule = getToken(ctx, terminal.rule.ref.name);

--- a/packages/langium/src/parser/parser-builder-base.ts
+++ b/packages/langium/src/parser/parser-builder-base.ts
@@ -107,7 +107,7 @@ function buildRuleCall(ctx: RuleContext, ruleCall: RuleCall): Method {
         const method = getToken(ctx, rule.name);
         return () => ctx.parser.consume(idx, method, ruleCall);
     } else if (!rule) {
-        throw new ErrorWithLocation(ruleCall.$cstNode, `Undefined rule type: ${ruleCall.$type}`);
+        throw new ErrorWithLocation(ruleCall.$cstNode, `Undefined rule: ${ruleCall.rule.$refText}`);
     } else {
         assertUnreachable(rule);
     }

--- a/packages/langium/test/parser/langium-parser-builder.test.ts
+++ b/packages/langium/test/parser/langium-parser-builder.test.ts
@@ -4,9 +4,11 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
 import type { TokenType, TokenVocabulary } from 'chevrotain';
-import type { AstNode, CstNode, GenericAstNode, Grammar, GrammarAST, LangiumParser, ParseResult, TokenBuilderOptions } from 'langium';
-import { EmptyFileSystem, DefaultTokenBuilder, GrammarUtils, CstUtils } from 'langium';
+import type { AstNode, CstNode, GenericAstNode, Grammar, GrammarAST, LangiumParser, ParseResult, ReferenceInfo, Scope, TokenBuilderOptions } from 'langium';
+import { EmptyFileSystem, DefaultTokenBuilder, GrammarUtils, CstUtils, DefaultScopeProvider, URI } from 'langium';
 import { describe, expect, test, onTestFailed, beforeAll } from 'vitest';
 import { createLangiumGrammarServices, createServicesForGrammar } from 'langium/grammar';
 import { expandToString } from 'langium/generate';
@@ -706,6 +708,56 @@ describe('Fragment rules', () => {
         expect(result.value).toHaveProperty('values', ['ab', 'cd', 'ef']);
     });
 
+    test("Fragment rules don't create AST elements during parsing", async () => {
+        // This test is mostly based on a bug report in a GitHub discussion:
+        // https://github.com/eclipse-langium/langium/discussions/1638
+        // In particular, the issue was that fragment rules used to create AST elements with type "undefined"
+        // When passing those into references, the reference would fail to resolve because the created AST element was just a placeholder
+        // Eventually, the parser would assign the properties of the fragment rule to the actual AST element
+        // But the reference would still use the old reference
+        // The fixed implementation no longer creates these fake AST elements, thereby skipping any potential issues completely.
+        let resolved = false;
+        const services = await createServicesForGrammar({
+            grammar: `
+                grammar FragmentRuleOverride
+                entry Entry: items+=(MemberCall|Def)*;
+                Def: 'def' name=ID;
+                MemberCall:
+                    Start ({infer MemberCall.previous=current} "." element=[Def]
+                    ArrayCallSignature? )*;
+
+                Start:
+                    element=[Def]
+                    ArrayCallSignature?;
+
+                fragment ArrayCallSignature:
+                    (isArray?='[' ']');
+
+                terminal ID: /[_a-zA-Z][\\w_]*/;
+                hidden terminal WS: /\\s+/;
+            `, module: {
+                references: {
+                    ScopeProvider: (services: any) => new class extends DefaultScopeProvider {
+                        override getScope(context: ReferenceInfo): Scope {
+                            const item = context.container as any;
+                            const previous = item.previous;
+                            if (previous) {
+                                const previousElement = previous.element.ref;
+                                // Ensure that the reference can be resolved
+                                resolved = Boolean(previousElement);
+                            }
+                            return super.getScope(context);
+                        }
+                    }(services)
+                }
+            }
+        });
+        const document = services.shared.workspace.LangiumDocumentFactory.fromString('def a def b a[].b', URI.parse('file:///test'));
+        await services.shared.workspace.DocumentBuilder.build([document]);
+        expect(document.parseResult.lexerErrors).toHaveLength(0);
+        expect(document.parseResult.parserErrors).toHaveLength(0);
+        expect(resolved).toBe(true);
+    });
 });
 
 describe('Unicode terminal rules', () => {


### PR DESCRIPTION
This is a fix for an issue exposed in https://github.com/eclipse-langium/langium/discussions/1638.

Essentially, this is caused by the combination of cross references, actions and fragment rule calls. The main culprit is that we temporarily create AST nodes for fragment rule calls (which wasn't really necessary in the first place) and then use those temporary elements for the `Reference` object. As these AST nodes never get into the final AST, they don't have a document reference and result in errors during the scoping phase.

This change simply removes the temporary AST element, and lets the parser assign the properties to the original AST node that called the fragment rule.

Testing this fix requires a more complicated testing setup, but hopefully the comment explains this well enough.