### PR TITLE
Validation for multiple assignments takes rewrite actions into account now

### DIFF
--- a/packages/langium/src/grammar/validation/validator.ts
+++ b/packages/langium/src/grammar/validation/validator.ts
@@ -877,11 +877,11 @@ export class LangiumGrammarValidator {
     checkOperatorMultiplicitiesForMultiAssignments(rule: ast.ParserRule, accept: ValidationAcceptor): void {
         // for usual parser rules AND for fragments, but not for data type rules!
         if (!rule.dataType) {
-            this.checkOperatorMultiplicitiesForMultiAssignmentsIndependent([rule.definition], new Map(), accept);
+            this.checkOperatorMultiplicitiesForMultiAssignmentsIndependent([rule.definition], accept);
         }
     }
 
-    private checkOperatorMultiplicitiesForMultiAssignmentsIndependent(startNodes: AstNode[], map: Map<string, AssignmentUse>, accept: ValidationAcceptor): void {
+    private checkOperatorMultiplicitiesForMultiAssignmentsIndependent(startNodes: AstNode[], accept: ValidationAcceptor, map: Map<string, AssignmentUse> = new Map()): void {
         // check all starting nodes
         this.checkOperatorMultiplicitiesForMultiAssignmentsNested(startNodes, 1, map, accept);
 
@@ -913,7 +913,7 @@ export class LangiumGrammarValidator {
                 const mapForNewObject = new Map();
                 storeAssignmentUse(mapForNewObject, currentNode.feature, 1, currentNode); // remember the special rewriting feature
                 // all following nodes are put into the new object => check their assignments independently
-                this.checkOperatorMultiplicitiesForMultiAssignmentsIndependent(nodes.slice(i + 1), mapForNewObject, accept);
+                this.checkOperatorMultiplicitiesForMultiAssignmentsIndependent(nodes.slice(i + 1), accept, mapForNewObject);
                 resultCreatedNewObject = true;
                 break; // breaks the current loop
             }
@@ -928,7 +928,7 @@ export class LangiumGrammarValidator {
 
             // assignment
             if (ast.isAssignment(currentNode)) {
-                storeAssignmentUse(map, currentNode.feature, 1 * currentMultiplicity, currentNode);
+                storeAssignmentUse(map, currentNode.feature, currentMultiplicity, currentNode);
             }
 
             // Search for assignments in used fragments as well, since their property values are stored in the current object.

--- a/packages/langium/test/grammar/grammar-validator.test.ts
+++ b/packages/langium/test/grammar/grammar-validator.test.ts
@@ -857,7 +857,7 @@ describe('Assignments with = instead of +=', () => {
                 (persons=Person) | (persons=Person);
             Person: 'person' name=ID ;
         `));
-        expect(validation.diagnostics.length).toBe(0);
+        expectNoIssues(validation);
     });
 
     test('assignments in different alternatives, but looped', async () => {
@@ -978,7 +978,7 @@ describe('Assignments with = instead of +=', () => {
                 ',' persons=Person;
             Person: 'person' name=ID ;
         `));
-        expect(validation.diagnostics.length).toBe(0);
+        expectNoIssues(validation);
     });
 
     test('no problem: assignments in different parser rules', async () => {
@@ -987,7 +987,7 @@ describe('Assignments with = instead of +=', () => {
                 persons=Person;
             Person: 'person' name=ID persons=Person;
         `));
-        expect(validation.diagnostics.length).toBe(0);
+        expectNoIssues(validation);
     });
 
     test('no problem with actions: assignment is looped, but stored in a new object each time', async () => {
@@ -997,7 +997,7 @@ describe('Assignments with = instead of +=', () => {
             Person infers Expression:
                 {infer Person} 'person' name=ID ;
         `));
-        expect(validation.diagnostics.length).toBe(0);
+        expectNoIssues(validation);
     });
 
     test('no problem with actions: second assignment is stored in a new object', async () => {
@@ -1007,7 +1007,7 @@ describe('Assignments with = instead of +=', () => {
             Person infers Expression:
                 {infer Person} 'person' name=ID ;
         `));
-        expect(validation.diagnostics.length).toBe(0);
+        expectNoIssues(validation);
     });
 
     test('no problem with actions: three assignments into three different objects', async () => {
@@ -1017,7 +1017,7 @@ describe('Assignments with = instead of +=', () => {
             Person infers Expression:
                 {infer Person} 'person' name=ID ;
         `));
-        expect(validation.diagnostics.length).toBe(0);
+        expectNoIssues(validation);
     });
 
     test('actions: the rewrite part is a special assignment, which needs to be checked as well!', async () => {


### PR DESCRIPTION
Fixes #1756.

This PR contributes the following improvements for the validation for multiple assignments with `=` instead of `+=` (see #1412):

* unassigned actions don't create new objects, only rewrite actions create new objects
* respect looped rewrite actions, even when they are deeply nested or occur as top-level elements of rules
* handle asymmetric use of rewrite actions in alternatives

Beyond that, this PR ...

* simplified the validation logic
* improved error logging in test utils