### PR TITLE
Extend file system provider interface

### DIFF
--- a/packages/langium/src/node/node-file-system-provider.ts
+++ b/packages/langium/src/node/node-file-system-provider.ts
@@ -33,17 +33,51 @@ export class NodeFileSystemProvider implements FileSystemProvider {
         };
     }
 
+    exists(uri: URI): Promise<boolean> {
+        return new Promise(resolve => {
+            fs.stat(uri.fsPath, err => {
+                resolve(!err);
+            });
+        });
+    }
+
+    existsSync(uri: URI): boolean {
+        return fs.existsSync(uri.fsPath);
+    }
+
+    readBinary(uri: URI): Promise<Uint8Array> {
+        return fs.promises.readFile(uri.fsPath);
+    }
+
+    readBinarySync(uri: URI): Uint8Array {
+        return fs.readFileSync(uri.fsPath);
+    }
+
     readFile(uri: URI): Promise<string> {
         return fs.promises.readFile(uri.fsPath, this.encoding);
     }
 
-    async readDirectory(folderPath: URI): Promise<FileSystemNode[]> {
-        const dirents = await fs.promises.readdir(folderPath.fsPath, { withFileTypes: true });
+    readFileSync(uri: URI): string {
+        return fs.readFileSync(uri.fsPath, this.encoding);
+    }
+
+    async readDirectory(uri: URI): Promise<FileSystemNode[]> {
+        const dirents = await fs.promises.readdir(uri.fsPath, { withFileTypes: true });
         return dirents.map(dirent => ({
             dirent, // Include the raw entry, it may be useful...
             isFile: dirent.isFile(),
             isDirectory: dirent.isDirectory(),
-            uri: UriUtils.joinPath(folderPath, dirent.name)
+            uri: UriUtils.joinPath(uri, dirent.name)
+        }));
+    }
+
+    readDirectorySync(uri: URI): FileSystemNode[] {
+        const dirents = fs.readdirSync(uri.fsPath, { withFileTypes: true });
+        return dirents.map(dirent => ({
+            dirent, // Include the raw entry, it may be useful...
+            isFile: dirent.isFile(),
+            isDirectory: dirent.isDirectory(),
+            uri: UriUtils.joinPath(uri, dirent.name)
         }));
     }
 }

--- a/packages/langium/src/test/virtual-file-system.ts
+++ b/packages/langium/src/test/virtual-file-system.ts
@@ -37,26 +37,50 @@ export class VirtualFileSystemProvider implements FileSystemProvider {
         }
     }
 
+    exists(uri: URI): Promise<boolean> {
+        return Promise.resolve(this.existsSync(uri));
+    }
+
+    existsSync(uri: URI): boolean {
+        return this.trie.findNode(uri) !== undefined;
+    }
+    readBinary(uri: URI): Promise<Uint8Array> {
+        return Promise.resolve(this.readBinarySync(uri));
+    }
+
+    readBinarySync(uri: URI): Uint8Array {
+        const encoder = new TextEncoder();
+        return encoder.encode(this.readFileSync(uri));
+    }
+
     readFile(uri: URI): Promise<string> {
+        return Promise.resolve(this.readFileSync(uri));
+    }
+
+    readFileSync(uri: URI): string {
         const data = this.trie.find(uri);
         if (typeof data === 'string') {
-            return Promise.resolve(data);
+            return data;
         } else {
             throw new Error('File not found');
         }
     }
 
     readDirectory(uri: URI): Promise<FileSystemNode[]> {
+        return Promise.resolve(this.readDirectorySync(uri));
+    }
+
+    readDirectorySync(uri: URI): FileSystemNode[] {
         const node = this.trie.findNode(uri);
         if (!node) {
             throw new Error('Directory not found');
         }
         const children = this.trie.findChildren(uri);
-        return Promise.resolve(children.map(child => ({
+        return children.map(child => ({
             isDirectory: child.element === undefined,
             isFile: child.element !== undefined,
             uri: URI.parse(child.uri)
-        })));
+        }));
     }
 
 }

--- a/packages/langium/src/workspace/file-system-provider.ts
+++ b/packages/langium/src/workspace/file-system-provider.ts
@@ -31,15 +31,45 @@ export interface FileSystemProvider {
      */
     statSync(uri: URI): FileSystemNode;
     /**
+     * Checks if a file exists at the specified URI.
+     * @returns `true` if a file exists at the specified URI, `false` otherwise.
+     */
+    exists(uri: URI): Promise<boolean>;
+    /**
+     * Checks if a file exists at the specified URI synchronously.
+     * @returns `true` if a file exists at the specified URI, `false` otherwise.
+     */
+    existsSync(uri: URI): boolean;
+    /**
+     * Reads a binary file asynchronously from a given URI.
+     * @returns The binary content of the file with the specified URI.
+     */
+    readBinary(uri: URI): Promise<Uint8Array>;
+    /**
+     * Reads a binary file synchronously from a given URI.
+     * @returns The binary content of the file with the specified URI.
+     */
+    readBinarySync(uri: URI): Uint8Array;
+    /**
      * Reads a document asynchronously from a given URI.
      * @returns The string content of the file with the specified URI.
      */
     readFile(uri: URI): Promise<string>;
     /**
+     * Reads a document synchronously from a given URI.
+     * @returns The string content of the file with the specified
+     */
+    readFileSync(uri: URI): string;
+    /**
      * Reads the directory information for the given URI.
      * @returns The list of file system entries that are contained within the specified directory.
      */
     readDirectory(uri: URI): Promise<FileSystemNode[]>;
+    /**
+     * Reads the directory information for the given URI synchronously.
+     * @returns The list of file system entries that are contained within the specified directory.
+     */
+    readDirectorySync(uri: URI): FileSystemNode[];
 }
 
 export class EmptyFileSystemProvider implements FileSystemProvider {
@@ -51,12 +81,35 @@ export class EmptyFileSystemProvider implements FileSystemProvider {
     statSync(_uri: URI): FileSystemNode {
         throw new Error('No file system is available.');
     }
+    async exists(): Promise<boolean> {
+        return false;
+    }
+
+    existsSync(): boolean {
+        return false;
+    }
+
+    readBinary(): Promise<Uint8Array> {
+        throw new Error('No file system is available.');
+    }
+
+    readBinarySync(): Uint8Array {
+        throw new Error('No file system is available.');
+    }
 
     readFile(): Promise<string> {
         throw new Error('No file system is available.');
     }
 
+    readFileSync(): string {
+        throw new Error('No file system is available.');
+    }
+
     async readDirectory(): Promise<FileSystemNode[]> {
+        return [];
+    }
+
+    readDirectorySync(): FileSystemNode[] {
         return [];
     }
 

--- a/packages/langium/src/workspace/workspace-manager.ts
+++ b/packages/langium/src/workspace/workspace-manager.ts
@@ -159,8 +159,11 @@ export class DefaultWorkspaceManager implements WorkspaceManager {
             folders.map(wf => this.getRootFolder(wf))
                 .map(async entry => this.traverseFolder(entry, uris))
         );
-        // Ensure that we only create one document per URI/file
-        const uniqueUris = stream(uris).distinct(uri => uri.toString());
+        const uniqueUris = stream(uris)
+            // Ensure that we only create one document per URI/file
+            .distinct(uri => uri.toString())
+            // Also ensure that the documents don't already exist
+            .filter(uri => !this.langiumDocuments.hasDocument(uri));
         await Promise.all(uniqueUris.map(async uri => {
             const document = await this.langiumDocuments.getOrCreateDocument(uri);
             collector(document);

--- a/packages/langium/test/workspace/document-builder.test.ts
+++ b/packages/langium/test/workspace/document-builder.test.ts
@@ -803,6 +803,25 @@ class MockFileSystemProvider implements FileSystemProvider {
         return Promise.resolve('');
     }
 
+    async exists(_uri: URI): Promise<boolean> {
+        return false;
+    }
+    existsSync(): boolean {
+        return false;
+    }
+    async readBinary(_uri: URI): Promise<Uint8Array> {
+        return new Uint8Array();
+    }
+    readBinarySync(_uri: URI): Uint8Array {
+        return new Uint8Array();
+    }
+    readFileSync(_uri: URI): string {
+        return '';
+    }
+    readDirectorySync(_uri: URI): FileSystemNode[] {
+        return [];
+    }
+
     // Return an empty array for any directory
     readDirectory(_uri: URI): Promise<[]> {
         return Promise.resolve([]);


### PR DESCRIPTION
Extends the file system provider to have the common file system operations:

1. Reading text file
2. Reading directory
3. Reading binary file
4. Checking whether a file exists

Both of these are now available in their respective sync and async versions. However, the framework itself exclusively uses the async methods. The sync method is available for adopters.

This change required to update the `@types/node` dev dependency to 18, as the `Buffer` class only started to correctly subtypethe `Uint8Array` class during that release.