### PR TITLE
Prevent interruptAndCheck from delaying too often when delay takes to…

### DIFF
--- a/packages/langium/src/utils/promise-utils.ts
+++ b/packages/langium/src/utils/promise-utils.ts
@@ -76,8 +76,11 @@ export async function interruptAndCheck(token: CancellationToken): Promise<void>
     }
     const current = performance.now();
     if (current - lastTick >= globalInterruptionPeriod) {
-        lastTick = current;
         await delayNextTick();
+        // prevent calling delayNextTick every iteration of loop
+        // where delayNextTick takes up the majority or all of the
+        // globalInterruptionPeriod itself
+        lastTick = performance.now();
     }
     if (token.isCancellationRequested) {
         throw OperationCancelled;

--- a/packages/langium/src/utils/promise-utils.ts
+++ b/packages/langium/src/utils/promise-utils.ts
@@ -76,6 +76,7 @@ export async function interruptAndCheck(token: CancellationToken): Promise<void>
     }
     const current = performance.now();
     if (current - lastTick >= globalInterruptionPeriod) {
+        lastTick = current;
         await delayNextTick();
         // prevent calling delayNextTick every iteration of loop
         // where delayNextTick takes up the majority or all of the


### PR DESCRIPTION
…o long

I ran into an issue where Firefox setTimeout(resolve, 0) was taking the majority of the time between interruptAndCheck calls.

performance.now() - current will be greater than globalInterruptionPeriod so it gets called every iteration

As a work around I can greatly increase the globalinterruptionPeriod with something like setInterruptionPeriod(150) - but then other browsers that don't have the slower setTimeout callback will have slower cancellation responses.

Other fixes I considered: have delayNextTick return performance.now() only for setTimout path (code below) or letting users provide a function that gets called back with current and they can either return current or process.now()

```ts
export function delayNextTick(current: number): Promise<number> {
    return new Promise(resolve => {
        // In case we are running in a non-node environment, `setImmediate` isn't available.
        // Using `setTimeout` of the browser API accomplishes the same result.
        if (typeof setImmediate === 'undefined') {
            // there is no way to guarantee
            setTimeout(() => resolve(performance.now()), 0);
        } else {
            setImmediate(() => resolve(current));
        }
    });
}
```