### PR TITLE
langium generate: fixed a hidden bug in 'node-processor.ts' of Langium's 'generate' facility

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -158,19 +158,25 @@
             "skipFiles": ["<node_internals>/**", "**/node_modules/**"],
             "program": "${workspaceRoot}/node_modules/vitest/vitest.mjs",
             "args": ["run", "--no-color", "--no-coverage", "--no-watch"],
-            "smartStep": true,
             "console": "integratedTerminal",
+            "smartStep": true,
         },
         {
             "name": "Vitest: Run Selected File",
             "type": "node",
             "request": "launch",
             "autoAttachChildProcesses": true,
-            "skipFiles": ["<node_internals>/**", "**/node_modules/**"],
+            "skipFiles": ["<node_internals>/**", "**/node_modules/**", "!**/node_modules/vscode-*/**"],
             "program": "${workspaceRoot}/node_modules/vitest/vitest.mjs",
             "args": ["run", "${relativeFile}"],
-            "smartStep": true,
             "console": "integratedTerminal",
+            "smartStep": true,
+            "sourceMaps": true,
+            "outFiles": [
+                // cs: surprisingly, it makes a significant difference whether the "outFiles" property is not mentioned at all or an empty array is given here;
+                //  this setup seems to work best here, cross check with 'uri-utils.test.ts', for example
+                // my assumption is that vitest now relies on it's on the fly generated source maps plus those being available in the folder of the particular js modules, like in case of external libraries
+            ]
         }
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,7 +11,10 @@
         "javascript",
         "typescript"
     ],
-    "vitest.enable": true,
+    "vitest.configSearchPatternExclude": "{**/node_modules/**,**/dist/**,**/generated/**,**/templates/**,**/examples/hello*/**,**/.*/**,**/*.d.ts}",
+    "vitest.debugExclude": [
+        "<node_internals>/**", "**/node_modules/**", "!**/node_modules/vscode-uri/**"
+    ],
     "[json]": {
         "editor.defaultFormatter": "vscode.json-language-features"
     },

--- a/packages/langium/test/generate/node.test.ts
+++ b/packages/langium/test/generate/node.test.ts
@@ -172,6 +172,22 @@ describe('indentation', () => {
         expect(process(comp, '\t')).toBe(`No indent${EOL}\tIndent {${EOL}\t}${EOL}`);
     });
 
+    test('should indent nested template starting with a new line with \'ifNotEmpty\', with \'indentImmediately: false\'', () => {
+        const comp = new CompositeGeneratorNode();
+        comp.append('No indent', NL);
+        comp.indent({
+            indentImmediately: false,
+            indentedChildren: [
+                '\t',
+                NLEmpty,
+                'Indented',
+                NL,
+                'Indented',
+                NL
+            ]
+        });
+        expect(process(comp, '\t')).toBe(`No indent${EOL}\tIndented${EOL}\tIndented${EOL}`);
+    });
 });
 
 describe('composite', () => {

--- a/packages/langium/test/generate/template-node.test.ts
+++ b/packages/langium/test/generate/template-node.test.ts
@@ -832,9 +832,47 @@ describe('Multiple nested substitution templates', () => {
                         generated text!
         `);
     });
+
+    test('Nested substitution of with indented nested template starting with an _undefined_ line', () => {
+        expect(
+            toString(n`
+                begin:
+                  ${n`
+                    ${undefined}
+                    ${nestedNode}
+                  `}
+            `)
+        ).toBe(
+            s`
+                begin:
+                  More
+                  generated text!
+            `
+        );
+    });
+
+    test('Nested substitution of with indented nested template starting with an _empty string_ line', () => {
+        expect(
+            toString(n`
+                begin:
+                  ${n`
+                    ${''}
+                    ${nestedNode}
+                  `}
+            `)
+        ).toBe(
+            s`
+                begin:
+                  ${/* 's' automatically trims the empty lines completely, so insert */'<DUMMY>'}
+                  More
+                  generated text!
+            `.replace('<DUMMY>', '')
+        );
+    });
+
 });
 
-describe('Embedded forEach loops', () => {
+describe('Joining lists', () => {
     test('ForEach loop with empty iterable', () => {
         const node = n`
             Data:
@@ -1083,6 +1121,18 @@ describe('Embedded forEach loops', () => {
               b
         `);
     });
+
+    test('Nested ForEach loop with empty iterable followed by an indented line', () => {
+        const node = n`
+            ${joinToNode([], { appendNewLineIfNotEmpty: true})}
+            a
+        `;
+        const text = toString(node);
+        expect(text).toBe(s`
+            a
+        `);
+    });
+
 });
 
 describe('Appending templates to existing nodes', () => {


### PR DESCRIPTION
* added some test cases
* extended 'Vitest: Run Selected File' launch config
* brought config of the Vitest VSCode extension closer to the Vitest setup in 'vite.config.mts'


The actual bug fix is this the addition of the following line, everything else is just polishing:
https://github.com/eclipse-langium/langium/blob/1df3bcfed9c50f49cc2a66d0a4beb984bbf28962/packages/langium/src/generate/node-processor.ts#L97