### PR TITLE
Improve chevrotain parser error recovery

### DIFF
--- a/packages/langium/src/grammar/generated/grammar.ts
+++ b/packages/langium/src/grammar/generated/grammar.ts
@@ -234,7 +234,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 }
               }
             ],
-            "cardinality": "+"
+            "cardinality": "*"
           }
         ]
       },

--- a/packages/langium/src/grammar/langium-grammar.langium
+++ b/packages/langium/src/grammar/langium-grammar.langium
@@ -12,7 +12,7 @@ entry Grammar:
         (definesHiddenTokens?='hidden' '(' (hiddenTokens+=[AbstractRule:ID] (',' hiddenTokens+=[AbstractRule:ID])*)? ')')?
     )?
     imports+=GrammarImport*
-    (rules+=AbstractRule | interfaces+=Interface | types+=Type)+;
+    (rules+=AbstractRule | interfaces+=Interface | types+=Type)*;
 
 Interface:
     'interface' name=ID

--- a/packages/langium/test/parser/langium-parser-builder.test.ts
+++ b/packages/langium/test/parser/langium-parser-builder.test.ts
@@ -231,7 +231,7 @@ describe('Handle unordered group', () => {
             description "New description"
             author "foo"
             `);
-        expect(parsed.parserErrors.length).toBe(2);
+        expect(parsed.parserErrors).toHaveLength(1);
     });
 
     test('Should parse multiple instances', () => {
@@ -250,8 +250,7 @@ describe('Handle unordered group', () => {
             description "Cool book2"
             author "foo2"
 
-            `, parser) as { parserErrors?: string | string[], books?: string[] });
-        expect(lib.parserErrors).toBeUndefined();
+            `, parser) as { books?: string[] });
         expect(lib.books).not.toBeUndefined();
         expect(lib.books?.length).toBe(2);
     });
@@ -321,7 +320,7 @@ describe('check the default value converter for data type rules using terminal r
         const result = parser.parse('123 true abc');
         expect(result.lexerErrors.length).toBe(0);
         expect(result.parserErrors.length).toBe(0);
-        const value = result.value as unknown as { propInteger: number, propBoolean: boolean, propString: string };
+        const value = result.value as AstNode & { propInteger: number, propBoolean: boolean, propString: string };
         expect(value.propInteger).not.toBe('123');
         expect(value.propInteger).toBe(123);
         expect(value.propBoolean).toBe(true);
@@ -343,7 +342,7 @@ describe('Boolean value converter', () => {
     });
 
     function expectValue(input: string, value: unknown): void {
-        const main = parser.parse(input).value as unknown as { value: unknown };
+        const main = parser.parse(input).value as AstNode & { value: unknown };
         expect(main.value).toBe(value);
     }
 
@@ -375,7 +374,7 @@ describe('BigInt Parser value converter', () => {
     });
 
     function expectValue(input: string, value: unknown): void {
-        const main = parser.parse(input).value as unknown as { value: unknown };
+        const main = parser.parse(input).value as AstNode & { value: unknown };
         expect(main.value).toBe(value);
     }
 
@@ -412,7 +411,7 @@ describe('Date Parser value converter', () => {
     });
 
     test('Parsed Date is correct Date object', () => {
-        const parseResult = parser.parse('2022-10-12T00:00').value as unknown as { value: unknown };
+        const parseResult = parser.parse('2022-10-12T00:00').value as AstNode & { value: unknown };
         expect(parseResult.value).toEqual(new Date('2022-10-12T00:00'));
     });
 });
@@ -451,12 +450,12 @@ describe('Parser calls value converter', () => {
     });
 
     function expectValue(input: string, value: unknown): void {
-        const main = parser.parse(input).value as unknown as { value: unknown };
+        const main = parser.parse(input).value as AstNode & { value: unknown };
         expect(main.value).toBe(value);
     }
 
     function expectEqual(input: string, value: unknown): void {
-        const main = parser.parse(input).value as unknown as { value: unknown };
+        const main = parser.parse(input).value as AstNode & { value: unknown };
         expect(main.value).toEqual(value);
     }
 
@@ -527,7 +526,7 @@ describe('Parser calls value converter', () => {
         const result = parser.parse('A');
         expect(result.lexerErrors.length).toBe(0);
         expect(result.parserErrors.length).toBe(0);
-        const value = result.value as unknown as { value: string };
+        const value = result.value as AstNode & { value: string };
         expect(value.value).toBeTypeOf('string');
         expect(value.value).toBe('A');
     });
@@ -547,7 +546,7 @@ describe('Parser calls value converter', () => {
         const result = parser.parse('A');
         expect(result.lexerErrors.length).toBe(0);
         expect(result.parserErrors.length).toBe(0);
-        const value = result.value as unknown as { value: string };
+        const value = result.value as AstNode & { value: string };
         expect(value.value).toBeTypeOf('string');
         expect(value.value).toBe('A');
     });
@@ -817,7 +816,7 @@ describe('Parsing default values', () => {
 
     test('Assigns default values for properties', async () => {
         const result = parser.parse('hi');
-        const model = result.value as unknown as {
+        const model = result.value as AstNode & {
             a: string
             b: string
             c: string[]
@@ -829,7 +828,7 @@ describe('Parsing default values', () => {
 
     test('Does not overwrite parsed value for "b"', async () => {
         const result = parser.parse('hi world');
-        const model = result.value as unknown as {
+        const model = result.value as AstNode & {
             a: string
             b: string
             c: string[]
@@ -840,7 +839,7 @@ describe('Parsing default values', () => {
 
     test('Does not overwrite parsed value for "c"', async () => {
         const result = parser.parse('hi world d e');
-        const model = result.value as unknown as {
+        const model = result.value as AstNode & {
             a: string
             b: string
             c: string[]

--- a/packages/langium/test/parser/langium-parser.test.ts
+++ b/packages/langium/test/parser/langium-parser.test.ts
@@ -105,7 +105,6 @@ describe('parser error recovery', () => {
             const closing = ')'.repeat(close);
             const result = services.parser.LangiumParser.parse(`${opening}a${closing};`);
             // Expect only one parser error independent of the number of missing closing parenthesis
-            console.log(result.parserErrors);
             expect(result.parserErrors).toHaveLength(1);
         });
     }

--- a/packages/langium/test/parser/langium-parser.test.ts
+++ b/packages/langium/test/parser/langium-parser.test.ts
@@ -89,6 +89,29 @@ describe('hidden node parsing', () => {
 
 });
 
+describe('parser error recovery', () => {
+
+    for (const [open, close] of [[1, 0], [2, 0], [3, 0], [2, 1], [3, 1], [3, 2]]) {
+        test(`recovers from lexer error with ${open} open and ${close} close parenthesis`, async () => {
+            const text = `
+                grammar Test
+                entry Model: value=Expr ';';
+                Expr: '(' Expr ')' | value=ID;
+                terminal ID: /[_a-zA-Z][\\w_]*/;
+                hidden terminal WS: /\\s+/;
+            `;
+            const services = await createServicesForGrammar({ grammar: text });
+            const opening = '('.repeat(open);
+            const closing = ')'.repeat(close);
+            const result = services.parser.LangiumParser.parse(`${opening}a${closing};`);
+            // Expect only one parser error independent of the number of missing closing parenthesis
+            console.log(result.parserErrors);
+            expect(result.parserErrors).toHaveLength(1);
+        });
+    }
+
+});
+
 interface A extends AstNode {
     name: string
 }


### PR DESCRIPTION
While looking into the [Chevrotain documentation on fault tolerance](https://chevrotain.io/docs/tutorial/step4_fault_tolerance.html), I've noticed that we're not supposed to catch the errors thrown by Chevrotain ourselves, but let them propagate. We've been effectively starving the `catch` block in [this method](https://github.com/Chevrotain/chevrotain/blob/e1479dfe848838c26a4b5a3ae12b4c8430eaeee8/packages/chevrotain/src/parse/parser/traits/recognizer_engine.ts#L244-L245), which is in charge of actually recovering from the error.

This results in some less-than-optimal behavior from Langium when it comes to error recovery. I've been playing around with this change using our example languages and it seems to behave pretty well. Refer to the additional comments to see why some of the changes were required.