### PR TITLE
Resolve wait until if document already in desired state

### DIFF
--- a/packages/langium/src/workspace/document-builder.ts
+++ b/packages/langium/src/workspace/document-builder.ts
@@ -422,7 +422,7 @@ export class DefaultDocumentBuilder implements DocumentBuilder {
         cancelToken ??= CancellationToken.None;
         if (uri) {
             const document = this.langiumDocuments.getDocument(uri);
-            if (document && document.state > state) {
+            if (document && document.state >= state) {
                 return Promise.resolve(uri);
             }
         }

--- a/packages/langium/test/workspace/document-builder.test.ts
+++ b/packages/langium/test/workspace/document-builder.test.ts
@@ -417,7 +417,7 @@ describe('DefaultDocumentBuilder', () => {
         await builder.build([document], { validation: true });
     });
 
-    test.only('`waitUntil` will correctly resolve if the document is already in the target state.', async () => {
+    test('`waitUntil` will correctly resolve if the document is already in the target state.', async () => {
         const services = await createServices();
         const documentFactory = services.shared.workspace.LangiumDocumentFactory;
         const documents = services.shared.workspace.LangiumDocuments;

--- a/packages/langium/test/workspace/document-builder.test.ts
+++ b/packages/langium/test/workspace/document-builder.test.ts
@@ -417,6 +417,25 @@ describe('DefaultDocumentBuilder', () => {
         await builder.build([document], { validation: true });
     });
 
+    test.only('`waitUntil` will correctly resolve if the document is already in the target state.', async () => {
+        const services = await createServices();
+        const documentFactory = services.shared.workspace.LangiumDocumentFactory;
+        const documents = services.shared.workspace.LangiumDocuments;
+        const builder = services.shared.workspace.DocumentBuilder;
+        const documentUri = URI.parse('file:///test1.txt');
+        const document = documentFactory.fromString('', documentUri);
+        documents.addDocument(document);
+        await builder.build([document], { validation: true });
+        expect(document.state).toBe(DocumentState.Validated);
+        // Should instantly resolve, since the document is already validated.
+        await expect(
+            Promise.race([
+                builder.waitUntil(DocumentState.Validated, documentUri),
+                new Promise((_, rej) => setTimeout(rej))
+            ])
+        ).resolves.toEqual(documentUri);
+    });
+
     test('`onDocumentPhase` always triggers before the respective `onBuildPhase`', async () => {
         const services = await createServices();
         const documentFactory = services.shared.workspace.LangiumDocumentFactory;


### PR DESCRIPTION
Fixes #1827

As discussed on the issue, should be `>=` rather than `>` so that the promise resolves immediately if a document is already in the desired state.