### PR TITLE
Copy JSDoc comments to generated AST

### DIFF
--- a/examples/statemachine/src/language-server/generated/ast.ts
+++ b/examples/statemachine/src/language-server/generated/ast.ts
@@ -41,6 +41,7 @@ export function isCommand(item: unknown): item is Command {
     return reflection.isInstance(item, Command);
 }
 
+/** An event is the trigger for a transition */
 export interface Event extends langium.AstNode {
     readonly $container: Statemachine;
     readonly $type: 'Event';
@@ -53,11 +54,13 @@ export function isEvent(item: unknown): item is Event {
     return reflection.isInstance(item, Event);
 }
 
+/** A description of the status of a system */
 export interface State extends langium.AstNode {
     readonly $container: Statemachine;
     readonly $type: 'State';
     actions: Array<langium.Reference<Command>>;
     name: string;
+    /** The transitions to other states that can take place from the current one */
     transitions: Array<Transition>;
 }
 
@@ -67,12 +70,17 @@ export function isState(item: unknown): item is State {
     return reflection.isInstance(item, State);
 }
 
+/** A textual represntation of a state machine */
 export interface Statemachine extends langium.AstNode {
     readonly $type: 'Statemachine';
     commands: Array<Command>;
+    /** The list of recognized event names */
     events: Array<Event>;
+    /** The starting state for the machine */
     init: langium.Reference<State>;
+    /** The name of the machine */
     name: string;
+    /** Definitions of available states */
     states: Array<State>;
 }
 
@@ -82,10 +90,13 @@ export function isStatemachine(item: unknown): item is Statemachine {
     return reflection.isInstance(item, Statemachine);
 }
 
+/** A change from one state to another */
 export interface Transition extends langium.AstNode {
     readonly $container: State;
     readonly $type: 'Transition';
+    /** The event triggering the transition */
     event: langium.Reference<Event>;
+    /** The target state */
     state: langium.Reference<State>;
 }
 

--- a/examples/statemachine/src/language-server/generated/grammar.ts
+++ b/examples/statemachine/src/language-server/generated/grammar.ts
@@ -33,7 +33,8 @@ export const StatemachineGrammar = (): Grammar => loadedStatemachineGrammar ?? (
                 "$ref": "#/rules@6"
               },
               "arguments": []
-            }
+            },
+            "$comment": "/** The name of the machine */"
           },
           {
             "$type": "Group",
@@ -53,7 +54,8 @@ export const StatemachineGrammar = (): Grammar => loadedStatemachineGrammar ?? (
                   },
                   "arguments": []
                 },
-                "cardinality": "+"
+                "cardinality": "+",
+                "$comment": "/** The list of recognized event names */"
               }
             ],
             "cardinality": "?"
@@ -95,7 +97,8 @@ export const StatemachineGrammar = (): Grammar => loadedStatemachineGrammar ?? (
                 "$ref": "#/rules@3"
               },
               "deprecatedSyntax": false
-            }
+            },
+            "$comment": "/** The starting state for the machine */"
           },
           {
             "$type": "Assignment",
@@ -108,7 +111,8 @@ export const StatemachineGrammar = (): Grammar => loadedStatemachineGrammar ?? (
               },
               "arguments": []
             },
-            "cardinality": "*"
+            "cardinality": "*",
+            "$comment": "/** Definitions of available states */"
           }
         ]
       },
@@ -116,7 +120,8 @@ export const StatemachineGrammar = (): Grammar => loadedStatemachineGrammar ?? (
       "fragment": false,
       "hiddenTokens": [],
       "parameters": [],
-      "wildcard": false
+      "wildcard": false,
+      "$comment": "/** A textual represntation of a state machine */"
     },
     {
       "$type": "ParserRule",
@@ -138,7 +143,8 @@ export const StatemachineGrammar = (): Grammar => loadedStatemachineGrammar ?? (
       "fragment": false,
       "hiddenTokens": [],
       "parameters": [],
-      "wildcard": false
+      "wildcard": false,
+      "$comment": "/** An event is the trigger for a transition */"
     },
     {
       "$type": "ParserRule",
@@ -226,7 +232,8 @@ export const StatemachineGrammar = (): Grammar => loadedStatemachineGrammar ?? (
               },
               "arguments": []
             },
-            "cardinality": "*"
+            "cardinality": "*",
+            "$comment": "/** The transitions to other states that can take place from the current one */"
           },
           {
             "$type": "Keyword",
@@ -239,7 +246,8 @@ export const StatemachineGrammar = (): Grammar => loadedStatemachineGrammar ?? (
       "fragment": false,
       "hiddenTokens": [],
       "parameters": [],
-      "wildcard": false
+      "wildcard": false,
+      "$comment": "/** A description of the status of a system */"
     },
     {
       "$type": "ParserRule",
@@ -257,7 +265,8 @@ export const StatemachineGrammar = (): Grammar => loadedStatemachineGrammar ?? (
                 "$ref": "#/rules@1"
               },
               "deprecatedSyntax": false
-            }
+            },
+            "$comment": "/** The event triggering the transition */"
           },
           {
             "$type": "Keyword",
@@ -273,16 +282,19 @@ export const StatemachineGrammar = (): Grammar => loadedStatemachineGrammar ?? (
                 "$ref": "#/rules@3"
               },
               "deprecatedSyntax": false
-            }
+            },
+            "$comment": "/** The target state */"
           }
-        ]
+        ],
+        "$comment": "/** The event triggering the transition */"
       },
       "definesHiddenTokens": false,
       "entry": false,
       "fragment": false,
       "hiddenTokens": [],
       "parameters": [],
-      "wildcard": false
+      "wildcard": false,
+      "$comment": "/** A change from one state to another */"
     },
     {
       "$type": "TerminalRule",

--- a/examples/statemachine/src/language-server/statemachine.langium
+++ b/examples/statemachine/src/language-server/statemachine.langium
@@ -1,26 +1,41 @@
 grammar Statemachine
 
+/** A textual represntation of a state machine */
 entry Statemachine:
-    'statemachine' name=ID
-    ('events' events+=Event+)?
+    'statemachine'
+    /** The name of the machine */
+    name=ID
+    ('events'
+        /** The list of recognized event names */
+        events+=Event+)?
     ('commands'    commands+=Command+)?
-    'initialState' init=[State]
+    'initialState'
+    /** The starting state for the machine */
+    init=[State]
+    /** Definitions of available states */
     states+=State*;
 
+/** An event is the trigger for a transition */
 Event:
     name=ID;
 
 Command:
     name=ID;
 
+/** A description of the status of a system */
 State:
     'state' name=ID
         ('actions' '{' actions+=[Command]+ '}')?
+        /** The transitions to other states that can take place from the current one */
         transitions+=Transition*
     'end';
 
+/** A change from one state to another */
 Transition:
-    event=[Event] '=>' state=[State];
+    /** The event triggering the transition */
+    event=[Event] '=>'
+    /** The target state */
+    state=[State];
 
 hidden terminal WS: /\s+/;
 terminal ID: /[_a-zA-Z][\w_]*/;

--- a/packages/langium-cli/src/generator/ast-generator.ts
+++ b/packages/langium-cli/src/generator/ast-generator.ts
@@ -13,7 +13,7 @@ import { generatedHeader } from './node-util.js';
 import { collectKeywords, collectTerminalRegexps } from './langium-util.js';
 
 export function generateAst(services: LangiumCoreServices, grammars: Grammar[], config: LangiumConfig): string {
-    const astTypes = collectAst(grammars, services.shared.workspace.LangiumDocuments);
+    const astTypes = collectAst(grammars, services.shared.workspace.LangiumDocuments, services.documentation.CommentProvider);
     const importFrom = config.langiumInternal ? `../../syntax-tree${config.importExtension}` : 'langium';
     /* eslint-disable @typescript-eslint/indent */
     const fileNode = expandToNode`

--- a/packages/langium-cli/src/generator/ast-generator.ts
+++ b/packages/langium-cli/src/generator/ast-generator.ts
@@ -13,7 +13,7 @@ import { generatedHeader } from './node-util.js';
 import { collectKeywords, collectTerminalRegexps } from './langium-util.js';
 
 export function generateAst(services: LangiumCoreServices, grammars: Grammar[], config: LangiumConfig): string {
-    const astTypes = collectAst(grammars, services.shared.workspace.LangiumDocuments, services.documentation.CommentProvider);
+    const astTypes = collectAst(grammars, services);
     const importFrom = config.langiumInternal ? `../../syntax-tree${config.importExtension}` : 'langium';
     /* eslint-disable @typescript-eslint/indent */
     const fileNode = expandToNode`

--- a/packages/langium-cli/src/generator/types-generator.ts
+++ b/packages/langium-cli/src/generator/types-generator.ts
@@ -9,7 +9,7 @@ import { collectAst, LangiumGrammarGrammar } from 'langium/grammar';
 import { collectKeywords } from './langium-util.js';
 
 export function generateTypesFile(services: LangiumCoreServices, grammars: Grammar[]): string {
-    const { unions, interfaces } = collectAst(grammars, services.shared.workspace.LangiumDocuments);
+    const { unions, interfaces } = collectAst(grammars, services.shared.workspace.LangiumDocuments, services.documentation.CommentProvider);
     const reservedWords = new Set(collectKeywords(LangiumGrammarGrammar()));
 
     const fileNode = joinToNode([

--- a/packages/langium-cli/src/generator/types-generator.ts
+++ b/packages/langium-cli/src/generator/types-generator.ts
@@ -9,7 +9,7 @@ import { collectAst, LangiumGrammarGrammar } from 'langium/grammar';
 import { collectKeywords } from './langium-util.js';
 
 export function generateTypesFile(services: LangiumCoreServices, grammars: Grammar[]): string {
-    const { unions, interfaces } = collectAst(grammars, services.shared.workspace.LangiumDocuments, services.documentation.CommentProvider);
+    const { unions, interfaces } = collectAst(grammars, services);
     const reservedWords = new Set(collectKeywords(LangiumGrammarGrammar()));
 
     const fileNode = joinToNode([

--- a/packages/langium/src/grammar/ast-reflection-interpreter.ts
+++ b/packages/langium/src/grammar/ast-reflection-interpreter.ts
@@ -5,7 +5,7 @@
  ******************************************************************************/
 
 import type { AstReflection, ReferenceInfo, TypeProperty, TypeMetaData } from '../syntax-tree.js';
-import type { LangiumDocuments } from '../workspace/documents.js';
+import type { LangiumCoreServices } from '../index.js';
 import type { Grammar } from '../languages/generated/ast.js';
 import type { AstTypes, Property } from './type-system/type-collector/types.js';
 import { AbstractAstReflection } from '../syntax-tree.js';
@@ -15,11 +15,11 @@ import { collectAst } from './type-system/ast-collector.js';
 import { collectTypeHierarchy, findReferenceTypes, isAstType, mergeTypesAndInterfaces } from './type-system/types-util.js';
 
 export function interpretAstReflection(astTypes: AstTypes): AstReflection;
-export function interpretAstReflection(grammar: Grammar, documents?: LangiumDocuments): AstReflection;
-export function interpretAstReflection(grammarOrTypes: Grammar | AstTypes, documents?: LangiumDocuments): AstReflection {
+export function interpretAstReflection(grammar: Grammar, services?: LangiumCoreServices): AstReflection;
+export function interpretAstReflection(grammarOrTypes: Grammar | AstTypes, services?: LangiumCoreServices): AstReflection {
     let collectedTypes: AstTypes;
     if (isGrammar(grammarOrTypes)) {
-        collectedTypes = collectAst(grammarOrTypes, documents);
+        collectedTypes = collectAst(grammarOrTypes, services);
     } else {
         collectedTypes = grammarOrTypes;
     }

--- a/packages/langium/src/grammar/type-system/ast-collector.ts
+++ b/packages/langium/src/grammar/type-system/ast-collector.ts
@@ -6,6 +6,7 @@
 
 import type { Grammar } from '../../languages/generated/ast.js';
 import type { LangiumDocuments } from '../../workspace/documents.js';
+import type { CommentProvider } from '../../documentation/comment-provider.js';
 import type { AstTypes, InterfaceType, PropertyType, TypeOption, UnionType } from './type-collector/types.js';
 import type { ValidationAstTypes } from './type-collector/all-types.js';
 import type { PlainAstTypes, PlainInterface, PlainUnion } from './type-collector/plain-types.js';
@@ -19,9 +20,10 @@ import { plainToTypes } from './type-collector/plain-types.js';
  *
  * @param grammars All grammars involved in the type generation process
  * @param documents Additional documents so that imports can be resolved as necessary
+ * @param commentProvider The comment provider service to pass along JSDoc comments to the generated AST
  */
-export function collectAst(grammars: Grammar | Grammar[], documents?: LangiumDocuments): AstTypes {
-    const { inferred, declared } = collectTypeResources(grammars, documents);
+export function collectAst(grammars: Grammar | Grammar[], documents?: LangiumDocuments, commentProvider?: CommentProvider): AstTypes {
+    const { inferred, declared } = collectTypeResources(grammars, documents, commentProvider);
     return createAstTypes(inferred, declared);
 }
 
@@ -31,9 +33,10 @@ export function collectAst(grammars: Grammar | Grammar[], documents?: LangiumDoc
  *
  * @param grammars All grammars involved in the validation process
  * @param documents Additional documents so that imports can be resolved as necessary
+ * @param commentProvider The comment provider service to pass along JSDoc comments to the generated AST
  */
-export function collectValidationAst(grammars: Grammar | Grammar[], documents?: LangiumDocuments): ValidationAstTypes {
-    const { inferred, declared, astResources } = collectTypeResources(grammars, documents);
+export function collectValidationAst(grammars: Grammar | Grammar[], documents?: LangiumDocuments, commentProvider?: CommentProvider): ValidationAstTypes {
+    const { inferred, declared, astResources } = collectTypeResources(grammars, documents, commentProvider);
 
     return {
         astResources,

--- a/packages/langium/src/grammar/type-system/ast-collector.ts
+++ b/packages/langium/src/grammar/type-system/ast-collector.ts
@@ -5,8 +5,7 @@
  ******************************************************************************/
 
 import type { Grammar } from '../../languages/generated/ast.js';
-import type { LangiumDocuments } from '../../workspace/documents.js';
-import type { CommentProvider } from '../../documentation/comment-provider.js';
+import type { LangiumCoreServices } from '../../index.js';
 import type { AstTypes, InterfaceType, PropertyType, TypeOption, UnionType } from './type-collector/types.js';
 import type { ValidationAstTypes } from './type-collector/all-types.js';
 import type { PlainAstTypes, PlainInterface, PlainUnion } from './type-collector/plain-types.js';
@@ -19,11 +18,10 @@ import { plainToTypes } from './type-collector/plain-types.js';
  * Collects all types for the generated AST. The types collector entry point.
  *
  * @param grammars All grammars involved in the type generation process
- * @param documents Additional documents so that imports can be resolved as necessary
- * @param commentProvider The comment provider service to pass along JSDoc comments to the generated AST
+ * @param services Langium core services to resolve imports as needed, and to pass along JSDoc comments to the generated AST
  */
-export function collectAst(grammars: Grammar | Grammar[], documents?: LangiumDocuments, commentProvider?: CommentProvider): AstTypes {
-    const { inferred, declared } = collectTypeResources(grammars, documents, commentProvider);
+export function collectAst(grammars: Grammar | Grammar[], services?: LangiumCoreServices): AstTypes {
+    const { inferred, declared } = collectTypeResources(grammars, services);
     return createAstTypes(inferred, declared);
 }
 
@@ -32,11 +30,10 @@ export function collectAst(grammars: Grammar | Grammar[], documents?: LangiumDoc
  * The validation process requires us to compare our inferred types with our declared types.
  *
  * @param grammars All grammars involved in the validation process
- * @param documents Additional documents so that imports can be resolved as necessary
- * @param commentProvider The comment provider service to pass along JSDoc comments to the generated AST
+ * @param services Langium core services to resolve imports as needed, and to pass along JSDoc comments to the generated AST
  */
-export function collectValidationAst(grammars: Grammar | Grammar[], documents?: LangiumDocuments, commentProvider?: CommentProvider): ValidationAstTypes {
-    const { inferred, declared, astResources } = collectTypeResources(grammars, documents, commentProvider);
+export function collectValidationAst(grammars: Grammar | Grammar[], services?: LangiumCoreServices): ValidationAstTypes {
+    const { inferred, declared, astResources } = collectTypeResources(grammars, services);
 
     return {
         astResources,

--- a/packages/langium/src/grammar/type-system/type-collector/all-types.ts
+++ b/packages/langium/src/grammar/type-system/type-collector/all-types.ts
@@ -6,7 +6,7 @@
 
 import type { ParserRule, Interface, Type, Grammar } from '../../../languages/generated/ast.js';
 import type { URI } from '../../../utils/uri-utils.js';
-import type { LangiumDocuments } from '../../../workspace/documents.js';
+import type { LangiumCoreServices } from '../../../index.js';
 import type { PlainAstTypes } from './plain-types.js';
 import type { AstTypes } from './types.js';
 import { collectInferredTypes } from './inferred-types.js';
@@ -15,7 +15,6 @@ import { getDocument } from '../../../utils/ast-utils.js';
 import { isParserRule } from '../../../languages/generated/ast.js';
 import { resolveImport } from '../../internal-grammar-util.js';
 import { isDataTypeRule } from '../../../utils/grammar-utils.js';
-import type { CommentProvider } from '../../../documentation/comment-provider.js';
 
 export interface AstResources {
     parserRules: ParserRule[]
@@ -36,10 +35,10 @@ export interface ValidationAstTypes {
     astResources: AstResources
 }
 
-export function collectTypeResources(grammars: Grammar | Grammar[], documents?: LangiumDocuments, commentProvider?: CommentProvider): TypeResources {
-    const astResources = collectAllAstResources(grammars, documents, undefined, undefined, commentProvider);
-    const declared = collectDeclaredTypes(astResources.interfaces, astResources.types, commentProvider);
-    const inferred = collectInferredTypes(astResources.parserRules, astResources.datatypeRules, declared, commentProvider);
+export function collectTypeResources(grammars: Grammar | Grammar[], services?: LangiumCoreServices): TypeResources {
+    const astResources = collectAllAstResources(grammars, undefined, undefined, services);
+    const declared = collectDeclaredTypes(astResources.interfaces, astResources.types, services);
+    const inferred = collectInferredTypes(astResources.parserRules, astResources.datatypeRules, declared, services);
 
     return {
         astResources,
@@ -50,8 +49,8 @@ export function collectTypeResources(grammars: Grammar | Grammar[], documents?: 
 
 ///////////////////////////////////////////////////////////////////////////////
 
-export function collectAllAstResources(grammars: Grammar | Grammar[], documents?: LangiumDocuments, visited: Set<URI> = new Set(),
-    astResources: AstResources = { parserRules: [], datatypeRules: [], interfaces: [], types: [] }, commentProvider?: CommentProvider): AstResources {
+export function collectAllAstResources(grammars: Grammar | Grammar[], visited: Set<URI> = new Set(),
+    astResources: AstResources = { parserRules: [], datatypeRules: [], interfaces: [], types: [] }, services?: LangiumCoreServices): AstResources {
 
     if (!Array.isArray(grammars)) grammars = [grammars];
     for (const grammar of grammars) {
@@ -72,9 +71,10 @@ export function collectAllAstResources(grammars: Grammar | Grammar[], documents?
         grammar.interfaces.forEach(e => astResources.interfaces.push(e));
         grammar.types.forEach(e => astResources.types.push(e));
 
+        const documents = services?.shared.workspace.LangiumDocuments;
         if (documents) {
             const importedGrammars = grammar.imports.map(e => resolveImport(documents, e)).filter((e): e is Grammar => e !== undefined);
-            collectAllAstResources(importedGrammars, documents, visited, astResources, commentProvider);
+            collectAllAstResources(importedGrammars, visited, astResources, services);
         }
     }
     return astResources;

--- a/packages/langium/src/grammar/type-system/type-collector/declared-types.ts
+++ b/packages/langium/src/grammar/type-system/type-collector/declared-types.ts
@@ -5,14 +5,15 @@
  ******************************************************************************/
 
 import type { Interface, Type, TypeDefinition, ValueLiteral } from '../../../languages/generated/ast.js';
-import type { CommentProvider } from '../../../documentation/comment-provider.js';
+import type { LangiumCoreServices } from '../../../index.js';
 import { isArrayLiteral, isBooleanLiteral } from '../../../languages/generated/ast.js';
 import type { PlainAstTypes, PlainInterface, PlainProperty, PlainPropertyDefaultValue, PlainPropertyType, PlainUnion } from './plain-types.js';
 import { isArrayType, isReferenceType, isUnionType, isSimpleType } from '../../../languages/generated/ast.js';
 import { getTypeNameWithoutError, isPrimitiveGrammarType } from '../../internal-grammar-util.js';
 import { getTypeName } from '../../../utils/grammar-utils.js';
 
-export function collectDeclaredTypes(interfaces: Interface[], unions: Type[], commentProvider?: CommentProvider): PlainAstTypes {
+export function collectDeclaredTypes(interfaces: Interface[], unions: Type[], services?: LangiumCoreServices): PlainAstTypes {
+    const commentProvider = services?.documentation.CommentProvider;
     const declaredTypes: PlainAstTypes = { unions: [], interfaces: [] };
 
     // add interfaces

--- a/packages/langium/src/grammar/type-system/type-collector/declared-types.ts
+++ b/packages/langium/src/grammar/type-system/type-collector/declared-types.ts
@@ -5,13 +5,14 @@
  ******************************************************************************/
 
 import type { Interface, Type, TypeDefinition, ValueLiteral } from '../../../languages/generated/ast.js';
+import type { CommentProvider } from '../../../documentation/comment-provider.js';
 import { isArrayLiteral, isBooleanLiteral } from '../../../languages/generated/ast.js';
 import type { PlainAstTypes, PlainInterface, PlainProperty, PlainPropertyDefaultValue, PlainPropertyType, PlainUnion } from './plain-types.js';
 import { isArrayType, isReferenceType, isUnionType, isSimpleType } from '../../../languages/generated/ast.js';
 import { getTypeNameWithoutError, isPrimitiveGrammarType } from '../../internal-grammar-util.js';
 import { getTypeName } from '../../../utils/grammar-utils.js';
 
-export function collectDeclaredTypes(interfaces: Interface[], unions: Type[]): PlainAstTypes {
+export function collectDeclaredTypes(interfaces: Interface[], unions: Type[], commentProvider?: CommentProvider): PlainAstTypes {
     const declaredTypes: PlainAstTypes = { unions: [], interfaces: [] };
 
     // add interfaces
@@ -22,7 +23,8 @@ export function collectDeclaredTypes(interfaces: Interface[], unions: Type[]): P
                 name: attribute.name,
                 optional: attribute.isOptional,
                 astNodes: new Set([attribute]),
-                type: typeDefinitionToPropertyType(attribute.type)
+                type: typeDefinitionToPropertyType(attribute.type),
+                comment: commentProvider?.getComment(attribute)
             };
             if (attribute.defaultValue) {
                 property.defaultValue = toPropertyDefaultValue(attribute.defaultValue);
@@ -41,7 +43,8 @@ export function collectDeclaredTypes(interfaces: Interface[], unions: Type[]): P
             abstract: false,
             properties: properties,
             superTypes: superTypes,
-            subTypes: new Set()
+            subTypes: new Set(),
+            comment: commentProvider?.getComment(type),
         };
         declaredTypes.interfaces.push(interfaceType);
     }
@@ -53,7 +56,8 @@ export function collectDeclaredTypes(interfaces: Interface[], unions: Type[]): P
             declared: true,
             type: typeDefinitionToPropertyType(union.type),
             superTypes: new Set(),
-            subTypes: new Set()
+            subTypes: new Set(),
+            comment: commentProvider?.getComment(union),
         };
         declaredTypes.unions.push(unionType);
     }

--- a/packages/langium/src/grammar/type-system/type-collector/plain-types.ts
+++ b/packages/langium/src/grammar/type-system/type-collector/plain-types.ts
@@ -23,6 +23,7 @@ export interface PlainInterface {
     properties: PlainProperty[];
     declared: boolean;
     abstract: boolean;
+    comment?: string;
 }
 
 export function isPlainInterface(type: PlainType): type is PlainInterface {
@@ -36,6 +37,7 @@ export interface PlainUnion {
     type: PlainPropertyType;
     declared: boolean;
     dataType?: string;
+    comment?: string;
 }
 
 export function isPlainUnion(type: PlainType): type is PlainUnion {
@@ -48,6 +50,7 @@ export interface PlainProperty {
     astNodes: Set<Assignment | Action | TypeAttribute>;
     type: PlainPropertyType;
     defaultValue?: PlainPropertyDefaultValue;
+    comment?: string;
 }
 
 export type PlainPropertyDefaultValue = string | number | boolean | PlainPropertyDefaultValue[];
@@ -113,13 +116,14 @@ export function plainToTypes(plain: PlainAstTypes): AstTypes {
     const interfaceTypes = new Map<string, InterfaceType>();
     const unionTypes = new Map<string, UnionType>();
     for (const interfaceValue of plain.interfaces) {
-        const type = new InterfaceType(interfaceValue.name, interfaceValue.declared, interfaceValue.abstract);
+        const type = new InterfaceType(interfaceValue.name, interfaceValue.declared, interfaceValue.abstract, interfaceValue.comment);
         interfaceTypes.set(interfaceValue.name, type);
     }
     for (const unionValue of plain.unions) {
         const type = new UnionType(unionValue.name, {
             declared: unionValue.declared,
-            dataType: unionValue.dataType
+            dataType: unionValue.dataType,
+            comment: unionValue.comment,
         });
         unionTypes.set(unionValue.name, type);
     }
@@ -157,7 +161,8 @@ function plainToProperty(property: PlainProperty, interfaces: Map<string, Interf
         name: property.name,
         optional: property.optional,
         astNodes: property.astNodes,
-        type: plainToPropertyType(property.type, undefined, interfaces, unions)
+        type: plainToPropertyType(property.type, undefined, interfaces, unions),
+        comment: property.comment,
     };
     if (property.defaultValue !== undefined) {
         prop.defaultValue = property.defaultValue;

--- a/packages/langium/src/grammar/validation/validation-resources-collector.ts
+++ b/packages/langium/src/grammar/validation/validation-resources-collector.ts
@@ -6,6 +6,7 @@
 
 import type { LangiumDocuments } from '../../workspace/documents.js';
 import type { AbstractElement, Action, Grammar, Interface, ParserRule, Type } from '../../languages/generated/ast.js';
+import type { CommentProvider } from '../../documentation/comment-provider.js';
 import type { AstResources, ValidationAstTypes } from '../type-system/type-collector/all-types.js';
 import type { TypeToValidationInfo, ValidationResources } from '../workspace/documents.js';
 import type { LangiumGrammarServices } from '../langium-grammar-module.js';
@@ -19,14 +20,16 @@ import { getActionType, getRuleTypeName } from '../../utils/grammar-utils.js';
 
 export class LangiumGrammarValidationResourcesCollector {
     private readonly documents: LangiumDocuments;
+    private readonly commentProvider: CommentProvider;
 
     constructor(services: LangiumGrammarServices) {
         this.documents = services.shared.workspace.LangiumDocuments;
+        this.commentProvider = services.documentation.CommentProvider;
     }
 
     collectValidationResources(grammar: Grammar): ValidationResources {
         try {
-            const typeResources = collectValidationAst(grammar, this.documents);
+            const typeResources = collectValidationAst(grammar, this.documents, this.commentProvider);
             return {
                 typeToValidationInfo: this.collectValidationInfo(typeResources),
                 typeToSuperProperties: this.collectSuperProperties(typeResources),

--- a/packages/langium/src/grammar/validation/validation-resources-collector.ts
+++ b/packages/langium/src/grammar/validation/validation-resources-collector.ts
@@ -4,9 +4,8 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import type { LangiumDocuments } from '../../workspace/documents.js';
+import type { LangiumCoreServices } from '../../index.js';
 import type { AbstractElement, Action, Grammar, Interface, ParserRule, Type } from '../../languages/generated/ast.js';
-import type { CommentProvider } from '../../documentation/comment-provider.js';
 import type { AstResources, ValidationAstTypes } from '../type-system/type-collector/all-types.js';
 import type { TypeToValidationInfo, ValidationResources } from '../workspace/documents.js';
 import type { LangiumGrammarServices } from '../langium-grammar-module.js';
@@ -19,17 +18,15 @@ import { collectValidationAst } from '../type-system/ast-collector.js';
 import { getActionType, getRuleTypeName } from '../../utils/grammar-utils.js';
 
 export class LangiumGrammarValidationResourcesCollector {
-    private readonly documents: LangiumDocuments;
-    private readonly commentProvider: CommentProvider;
+    private readonly services: LangiumCoreServices;
 
     constructor(services: LangiumGrammarServices) {
-        this.documents = services.shared.workspace.LangiumDocuments;
-        this.commentProvider = services.documentation.CommentProvider;
+        this.services = services;
     }
 
     collectValidationResources(grammar: Grammar): ValidationResources {
         try {
-            const typeResources = collectValidationAst(grammar, this.documents, this.commentProvider);
+            const typeResources = collectValidationAst(grammar, this.services);
             return {
                 typeToValidationInfo: this.collectValidationInfo(typeResources),
                 typeToSuperProperties: this.collectSuperProperties(typeResources),


### PR DESCRIPTION
I made an attempt at implementing #1673, but I'm not very satisfied with it. The basic functionality seems to work (check the example), in addition to custom interfaces and type definitions, but there should definitely be unit tests.

I think most of the functions in `type-collector` should be wrapped in classes to avoid explicitly passing `commentProvider` everywhere, especially if more metadata could be added in the future. Also for that reason, I'm not sure whether adding the `comment` field to most types (in the intermediate representation) is enough or whether they should be wrapped in something like `metadata?: { comment?: string }`.

While reviewing, special attention should be paid to `inferred-types.ts` since there are some parts I didn't understand, especially with Type Parts/Paths (yes, I'm not entirely sure why my code works 😁).

Closes #1673