### PR TITLE
Support infix operator rules

### DIFF
--- a/examples/arithmetics/src/language-server/arithmetics.langium
+++ b/examples/arithmetics/src/language-server/arithmetics.langium
@@ -20,19 +20,9 @@ Evaluation:
     expression=Expression ';';
 
 Expression:
-    Addition;
+    BinaryExpression;
 
-Addition infers Expression:
-    Multiplication ({infer BinaryExpression.left=current} operator=('+' | '-') right=Multiplication)*;
-
-Multiplication infers Expression:
-    Exponentiation ({infer BinaryExpression.left=current} operator=('*' | '/') right=Exponentiation)*;
-
-Exponentiation infers Expression:
-    Modulo ({infer BinaryExpression.left=current} operator='^' right=Modulo)*;
-
-Modulo infers Expression:
-    PrimaryExpression ({infer BinaryExpression.left=current} operator='%' right=PrimaryExpression)*;
+infix BinaryExpression on PrimaryExpression: '%' > '^' > '*' | '/' > '+' | '-';
 
 PrimaryExpression infers Expression:
     '(' Expression ')' |

--- a/examples/arithmetics/src/language-server/generated/grammar.ts
+++ b/examples/arithmetics/src/language-server/generated/grammar.ts
@@ -30,7 +30,7 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ?? (lo
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@12"
+                "$ref": "#/rules@9"
               },
               "arguments": []
             }
@@ -102,7 +102,7 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ?? (lo
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@12"
+                "$ref": "#/rules@9"
               },
               "arguments": []
             }
@@ -194,7 +194,7 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ?? (lo
         "terminal": {
           "$type": "RuleCall",
           "rule": {
-            "$ref": "#/rules@12"
+            "$ref": "#/rules@9"
           },
           "arguments": []
         }
@@ -255,270 +255,65 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ?? (lo
       "wildcard": false
     },
     {
-      "$type": "ParserRule",
-      "name": "Addition",
-      "inferredType": {
-        "$type": "InferredType",
-        "name": "Expression"
+      "$type": "InfixRule",
+      "name": "BinaryExpression",
+      "call": {
+        "$type": "RuleCall",
+        "rule": {
+          "$ref": "#/rules@7"
+        },
+        "arguments": []
       },
-      "definition": {
-        "$type": "Group",
-        "elements": [
+      "operators": {
+        "$type": "InfixRuleOperators",
+        "precedences": [
           {
-            "$type": "RuleCall",
-            "rule": {
-              "$ref": "#/rules@7"
-            },
-            "arguments": []
+            "$type": "InfixRuleOperatorList",
+            "operators": [
+              {
+                "$type": "Keyword",
+                "value": "%"
+              }
+            ]
           },
           {
-            "$type": "Group",
-            "elements": [
+            "$type": "InfixRuleOperatorList",
+            "operators": [
               {
-                "$type": "Action",
-                "inferredType": {
-                  "$type": "InferredType",
-                  "name": "BinaryExpression"
-                },
-                "feature": "left",
-                "operator": "="
-              },
-              {
-                "$type": "Assignment",
-                "feature": "operator",
-                "operator": "=",
-                "terminal": {
-                  "$type": "Alternatives",
-                  "elements": [
-                    {
-                      "$type": "Keyword",
-                      "value": "+"
-                    },
-                    {
-                      "$type": "Keyword",
-                      "value": "-"
-                    }
-                  ]
-                }
-              },
-              {
-                "$type": "Assignment",
-                "feature": "right",
-                "operator": "=",
-                "terminal": {
-                  "$type": "RuleCall",
-                  "rule": {
-                    "$ref": "#/rules@7"
-                  },
-                  "arguments": []
-                }
+                "$type": "Keyword",
+                "value": "^"
               }
-            ],
-            "cardinality": "*"
+            ]
+          },
+          {
+            "$type": "InfixRuleOperatorList",
+            "operators": [
+              {
+                "$type": "Keyword",
+                "value": "*"
+              },
+              {
+                "$type": "Keyword",
+                "value": "/"
+              }
+            ]
+          },
+          {
+            "$type": "InfixRuleOperatorList",
+            "operators": [
+              {
+                "$type": "Keyword",
+                "value": "+"
+              },
+              {
+                "$type": "Keyword",
+                "value": "-"
+              }
+            ]
           }
         ]
       },
-      "definesHiddenTokens": false,
-      "entry": false,
-      "fragment": false,
-      "hiddenTokens": [],
-      "parameters": [],
-      "wildcard": false
-    },
-    {
-      "$type": "ParserRule",
-      "name": "Multiplication",
-      "inferredType": {
-        "$type": "InferredType",
-        "name": "Expression"
-      },
-      "definition": {
-        "$type": "Group",
-        "elements": [
-          {
-            "$type": "RuleCall",
-            "rule": {
-              "$ref": "#/rules@8"
-            },
-            "arguments": []
-          },
-          {
-            "$type": "Group",
-            "elements": [
-              {
-                "$type": "Action",
-                "inferredType": {
-                  "$type": "InferredType",
-                  "name": "BinaryExpression"
-                },
-                "feature": "left",
-                "operator": "="
-              },
-              {
-                "$type": "Assignment",
-                "feature": "operator",
-                "operator": "=",
-                "terminal": {
-                  "$type": "Alternatives",
-                  "elements": [
-                    {
-                      "$type": "Keyword",
-                      "value": "*"
-                    },
-                    {
-                      "$type": "Keyword",
-                      "value": "/"
-                    }
-                  ]
-                }
-              },
-              {
-                "$type": "Assignment",
-                "feature": "right",
-                "operator": "=",
-                "terminal": {
-                  "$type": "RuleCall",
-                  "rule": {
-                    "$ref": "#/rules@8"
-                  },
-                  "arguments": []
-                }
-              }
-            ],
-            "cardinality": "*"
-          }
-        ]
-      },
-      "definesHiddenTokens": false,
-      "entry": false,
-      "fragment": false,
-      "hiddenTokens": [],
-      "parameters": [],
-      "wildcard": false
-    },
-    {
-      "$type": "ParserRule",
-      "name": "Exponentiation",
-      "inferredType": {
-        "$type": "InferredType",
-        "name": "Expression"
-      },
-      "definition": {
-        "$type": "Group",
-        "elements": [
-          {
-            "$type": "RuleCall",
-            "rule": {
-              "$ref": "#/rules@9"
-            },
-            "arguments": []
-          },
-          {
-            "$type": "Group",
-            "elements": [
-              {
-                "$type": "Action",
-                "inferredType": {
-                  "$type": "InferredType",
-                  "name": "BinaryExpression"
-                },
-                "feature": "left",
-                "operator": "="
-              },
-              {
-                "$type": "Assignment",
-                "feature": "operator",
-                "operator": "=",
-                "terminal": {
-                  "$type": "Keyword",
-                  "value": "^"
-                }
-              },
-              {
-                "$type": "Assignment",
-                "feature": "right",
-                "operator": "=",
-                "terminal": {
-                  "$type": "RuleCall",
-                  "rule": {
-                    "$ref": "#/rules@9"
-                  },
-                  "arguments": []
-                }
-              }
-            ],
-            "cardinality": "*"
-          }
-        ]
-      },
-      "definesHiddenTokens": false,
-      "entry": false,
-      "fragment": false,
-      "hiddenTokens": [],
-      "parameters": [],
-      "wildcard": false
-    },
-    {
-      "$type": "ParserRule",
-      "name": "Modulo",
-      "inferredType": {
-        "$type": "InferredType",
-        "name": "Expression"
-      },
-      "definition": {
-        "$type": "Group",
-        "elements": [
-          {
-            "$type": "RuleCall",
-            "rule": {
-              "$ref": "#/rules@10"
-            },
-            "arguments": []
-          },
-          {
-            "$type": "Group",
-            "elements": [
-              {
-                "$type": "Action",
-                "inferredType": {
-                  "$type": "InferredType",
-                  "name": "BinaryExpression"
-                },
-                "feature": "left",
-                "operator": "="
-              },
-              {
-                "$type": "Assignment",
-                "feature": "operator",
-                "operator": "=",
-                "terminal": {
-                  "$type": "Keyword",
-                  "value": "%"
-                }
-              },
-              {
-                "$type": "Assignment",
-                "feature": "right",
-                "operator": "=",
-                "terminal": {
-                  "$type": "RuleCall",
-                  "rule": {
-                    "$ref": "#/rules@10"
-                  },
-                  "arguments": []
-                }
-              }
-            ],
-            "cardinality": "*"
-          }
-        ]
-      },
-      "definesHiddenTokens": false,
-      "entry": false,
-      "fragment": false,
-      "hiddenTokens": [],
-      "parameters": [],
-      "wildcard": false
+      "parameters": []
     },
     {
       "$type": "ParserRule",
@@ -567,7 +362,7 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ?? (lo
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@13"
+                    "$ref": "#/rules@10"
                   },
                   "arguments": []
                 }

--- a/packages/langium-cli/src/generator/langium-util.ts
+++ b/packages/langium-cli/src/generator/langium-util.ts
@@ -29,7 +29,7 @@ export function collectKeywords(grammar: Grammar): string[] {
     const reachableRules = GrammarUtils.getAllReachableRules(grammar, false);
 
     for (const keyword of stream(reachableRules)
-        .filter(GrammarAST.isParserRule)
+        .filter(rule => GrammarAST.isParserRule(rule) || GrammarAST.isInfixRule(rule))
         .flatMap(rule => AstUtils.streamAllContents(rule).filter(GrammarAST.isKeyword))) {
         keywords.add(keyword.value);
     }

--- a/packages/langium-vscode/data/langium.tmLanguage.json
+++ b/packages/langium-vscode/data/langium.tmLanguage.json
@@ -13,7 +13,7 @@
         },
         {
             "name": "keyword.control.langium",
-            "match": "\\b(current|entry|extends|fragment|grammar|hidden|import|infer|infers|interface|returns|terminal|type|with)\\b"
+            "match": "\\b(current|entry|extends|fragment|grammar|hidden|import|infer|infers|infix|interface|returns|terminal|type|with|on)\\b"
         },
         {
             "name": "constant.language.langium",

--- a/packages/langium/src/grammar/generated/grammar.ts
+++ b/packages/langium/src/grammar/generated/grammar.ts
@@ -38,7 +38,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@63"
+                    "$ref": "#/rules@66"
                   },
                   "arguments": []
                 }
@@ -62,7 +62,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                       "terminal": {
                         "$type": "RuleCall",
                         "rule": {
-                          "$ref": "#/rules@63"
+                          "$ref": "#/rules@66"
                         },
                         "arguments": []
                       },
@@ -88,7 +88,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                           "terminal": {
                             "$type": "RuleCall",
                             "rule": {
-                              "$ref": "#/rules@63"
+                              "$ref": "#/rules@66"
                             },
                             "arguments": []
                           },
@@ -132,7 +132,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                           "terminal": {
                             "$type": "RuleCall",
                             "rule": {
-                              "$ref": "#/rules@63"
+                              "$ref": "#/rules@66"
                             },
                             "arguments": []
                           },
@@ -158,7 +158,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                               "terminal": {
                                 "$type": "RuleCall",
                                 "rule": {
-                                  "$ref": "#/rules@63"
+                                  "$ref": "#/rules@66"
                                 },
                                 "arguments": []
                               },
@@ -261,7 +261,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@63"
+                "$ref": "#/rules@66"
               },
               "arguments": []
             }
@@ -285,7 +285,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                   "terminal": {
                     "$type": "RuleCall",
                     "rule": {
-                      "$ref": "#/rules@63"
+                      "$ref": "#/rules@66"
                     },
                     "arguments": []
                   },
@@ -311,7 +311,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                       "terminal": {
                         "$type": "RuleCall",
                         "rule": {
-                          "$ref": "#/rules@63"
+                          "$ref": "#/rules@66"
                         },
                         "arguments": []
                       },
@@ -372,7 +372,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@62"
+                "$ref": "#/rules@65"
               },
               "arguments": []
             }
@@ -492,7 +492,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
         "terminal": {
           "$type": "RuleCall",
           "rule": {
-            "$ref": "#/rules@64"
+            "$ref": "#/rules@67"
           },
           "arguments": []
         }
@@ -514,7 +514,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
         "terminal": {
           "$type": "RuleCall",
           "rule": {
-            "$ref": "#/rules@65"
+            "$ref": "#/rules@68"
           },
           "arguments": []
         }
@@ -855,7 +855,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                       "terminal": {
                         "$type": "RuleCall",
                         "rule": {
-                          "$ref": "#/rules@63"
+                          "$ref": "#/rules@66"
                         },
                         "arguments": []
                       },
@@ -881,7 +881,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$ref": "#/rules@64"
+                        "$ref": "#/rules@67"
                       },
                       "arguments": []
                     }
@@ -952,7 +952,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@63"
+                "$ref": "#/rules@66"
               },
               "arguments": []
             }
@@ -1003,7 +1003,14 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@50"
+              "$ref": "#/rules@53"
+            },
+            "arguments": []
+          },
+          {
+            "$type": "RuleCall",
+            "rule": {
+              "$ref": "#/rules@18"
             },
             "arguments": []
           }
@@ -1033,7 +1040,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@64"
+                "$ref": "#/rules@67"
               },
               "arguments": []
             }
@@ -1085,7 +1092,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@19"
+              "$ref": "#/rules@22"
             },
             "arguments": []
           },
@@ -1123,7 +1130,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                           "terminal": {
                             "$type": "RuleCall",
                             "rule": {
-                              "$ref": "#/rules@63"
+                              "$ref": "#/rules@66"
                             },
                             "arguments": []
                           },
@@ -1153,7 +1160,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@18"
+                    "$ref": "#/rules@21"
                   },
                   "arguments": [
                     {
@@ -1201,7 +1208,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                       "terminal": {
                         "$type": "RuleCall",
                         "rule": {
-                          "$ref": "#/rules@63"
+                          "$ref": "#/rules@66"
                         },
                         "arguments": []
                       },
@@ -1227,7 +1234,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                           "terminal": {
                             "$type": "RuleCall",
                             "rule": {
-                              "$ref": "#/rules@63"
+                              "$ref": "#/rules@66"
                             },
                             "arguments": []
                           },
@@ -1258,7 +1265,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@21"
+                "$ref": "#/rules@24"
               },
               "arguments": []
             }
@@ -1266,6 +1273,166 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "Keyword",
             "value": ";"
+          }
+        ]
+      },
+      "definesHiddenTokens": false,
+      "entry": false,
+      "fragment": false,
+      "hiddenTokens": [],
+      "parameters": [],
+      "wildcard": false
+    },
+    {
+      "$type": "ParserRule",
+      "name": "InfixRule",
+      "definition": {
+        "$type": "Group",
+        "elements": [
+          {
+            "$type": "Keyword",
+            "value": "infix"
+          },
+          {
+            "$type": "RuleCall",
+            "rule": {
+              "$ref": "#/rules@22"
+            },
+            "arguments": []
+          },
+          {
+            "$type": "Keyword",
+            "value": "on"
+          },
+          {
+            "$type": "Assignment",
+            "feature": "call",
+            "operator": "=",
+            "terminal": {
+              "$type": "RuleCall",
+              "rule": {
+                "$ref": "#/rules@34"
+              },
+              "arguments": []
+            }
+          },
+          {
+            "$type": "Keyword",
+            "value": ":"
+          },
+          {
+            "$type": "Assignment",
+            "feature": "operators",
+            "operator": "=",
+            "terminal": {
+              "$type": "RuleCall",
+              "rule": {
+                "$ref": "#/rules@19"
+              },
+              "arguments": []
+            }
+          },
+          {
+            "$type": "Keyword",
+            "value": ";"
+          }
+        ]
+      },
+      "definesHiddenTokens": false,
+      "entry": false,
+      "fragment": false,
+      "hiddenTokens": [],
+      "parameters": [],
+      "wildcard": false
+    },
+    {
+      "$type": "ParserRule",
+      "name": "InfixRuleOperators",
+      "definition": {
+        "$type": "Group",
+        "elements": [
+          {
+            "$type": "Assignment",
+            "feature": "precedences",
+            "operator": "+=",
+            "terminal": {
+              "$type": "RuleCall",
+              "rule": {
+                "$ref": "#/rules@20"
+              },
+              "arguments": []
+            }
+          },
+          {
+            "$type": "Group",
+            "elements": [
+              {
+                "$type": "Keyword",
+                "value": ">"
+              },
+              {
+                "$type": "Assignment",
+                "feature": "precedences",
+                "operator": "+=",
+                "terminal": {
+                  "$type": "RuleCall",
+                  "rule": {
+                    "$ref": "#/rules@20"
+                  },
+                  "arguments": []
+                }
+              }
+            ],
+            "cardinality": "*"
+          }
+        ]
+      },
+      "definesHiddenTokens": false,
+      "entry": false,
+      "fragment": false,
+      "hiddenTokens": [],
+      "parameters": [],
+      "wildcard": false
+    },
+    {
+      "$type": "ParserRule",
+      "name": "InfixRuleOperatorList",
+      "definition": {
+        "$type": "Group",
+        "elements": [
+          {
+            "$type": "Assignment",
+            "feature": "operators",
+            "operator": "+=",
+            "terminal": {
+              "$type": "RuleCall",
+              "rule": {
+                "$ref": "#/rules@33"
+              },
+              "arguments": []
+            }
+          },
+          {
+            "$type": "Group",
+            "elements": [
+              {
+                "$type": "Keyword",
+                "value": "|"
+              },
+              {
+                "$type": "Assignment",
+                "feature": "operators",
+                "operator": "+=",
+                "terminal": {
+                  "$type": "RuleCall",
+                  "rule": {
+                    "$ref": "#/rules@33"
+                  },
+                  "arguments": []
+                }
+              }
+            ],
+            "cardinality": "*"
           }
         ]
       },
@@ -1296,7 +1463,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "guardCondition": {
                   "$type": "ParameterReference",
                   "parameter": {
-                    "$ref": "#/rules@18/parameters@0"
+                    "$ref": "#/rules@21/parameters@0"
                   }
                 },
                 "elements": [
@@ -1313,7 +1480,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                   "value": {
                     "$type": "ParameterReference",
                     "parameter": {
-                      "$ref": "#/rules@18/parameters@0"
+                      "$ref": "#/rules@21/parameters@0"
                     }
                   }
                 },
@@ -1333,7 +1500,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@63"
+                "$ref": "#/rules@66"
               },
               "arguments": []
             }
@@ -1360,7 +1527,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@63"
+                "$ref": "#/rules@66"
               },
               "arguments": []
             }
@@ -1382,7 +1549,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$ref": "#/rules@20"
+                        "$ref": "#/rules@23"
                       },
                       "arguments": []
                     }
@@ -1401,7 +1568,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                         "terminal": {
                           "$type": "RuleCall",
                           "rule": {
-                            "$ref": "#/rules@20"
+                            "$ref": "#/rules@23"
                           },
                           "arguments": []
                         }
@@ -1437,7 +1604,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
         "terminal": {
           "$type": "RuleCall",
           "rule": {
-            "$ref": "#/rules@63"
+            "$ref": "#/rules@66"
           },
           "arguments": []
         }
@@ -1462,7 +1629,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@22"
+              "$ref": "#/rules@25"
             },
             "arguments": []
           },
@@ -1492,7 +1659,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$ref": "#/rules@22"
+                        "$ref": "#/rules@25"
                       },
                       "arguments": []
                     }
@@ -1525,7 +1692,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@23"
+              "$ref": "#/rules@26"
             },
             "arguments": []
           },
@@ -1550,7 +1717,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@33"
+                    "$ref": "#/rules@36"
                   },
                   "arguments": []
                 }
@@ -1566,7 +1733,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@25"
+                    "$ref": "#/rules@28"
                   },
                   "arguments": []
                 },
@@ -1596,7 +1763,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@24"
+              "$ref": "#/rules@27"
             },
             "arguments": []
           },
@@ -1626,7 +1793,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$ref": "#/rules@24"
+                        "$ref": "#/rules@27"
                       },
                       "arguments": []
                     }
@@ -1659,7 +1826,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@25"
+              "$ref": "#/rules@28"
             },
             "arguments": []
           },
@@ -1682,7 +1849,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@25"
+                    "$ref": "#/rules@28"
                   },
                   "arguments": []
                 },
@@ -1713,14 +1880,14 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@26"
+              "$ref": "#/rules@29"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@27"
+              "$ref": "#/rules@30"
             },
             "arguments": []
           }
@@ -1749,14 +1916,14 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
               {
                 "$type": "RuleCall",
                 "rule": {
-                  "$ref": "#/rules@41"
+                  "$ref": "#/rules@44"
                 },
                 "arguments": []
               },
               {
                 "$type": "RuleCall",
                 "rule": {
-                  "$ref": "#/rules@28"
+                  "$ref": "#/rules@31"
                 },
                 "arguments": []
               }
@@ -1830,7 +1997,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                   "terminal": {
                     "$type": "RuleCall",
                     "rule": {
-                      "$ref": "#/rules@63"
+                      "$ref": "#/rules@66"
                     },
                     "arguments": []
                   },
@@ -1844,7 +2011,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@18"
+                    "$ref": "#/rules@21"
                   },
                   "arguments": [
                     {
@@ -1874,7 +2041,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@62"
+                    "$ref": "#/rules@65"
                   },
                   "arguments": []
                 }
@@ -1930,49 +2097,49 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@30"
+              "$ref": "#/rules@33"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@31"
+              "$ref": "#/rules@34"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@47"
+              "$ref": "#/rules@50"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@39"
+              "$ref": "#/rules@42"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@40"
+              "$ref": "#/rules@43"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@48"
+              "$ref": "#/rules@51"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@29"
+              "$ref": "#/rules@32"
             },
             "arguments": []
           }
@@ -2021,7 +2188,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
         "terminal": {
           "$type": "RuleCall",
           "rule": {
-            "$ref": "#/rules@64"
+            "$ref": "#/rules@67"
           },
           "arguments": []
         }
@@ -2051,7 +2218,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
               "terminal": {
                 "$type": "RuleCall",
                 "rule": {
-                  "$ref": "#/rules@63"
+                  "$ref": "#/rules@66"
                 },
                 "arguments": []
               },
@@ -2072,7 +2239,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@32"
+                    "$ref": "#/rules@35"
                   },
                   "arguments": []
                 }
@@ -2091,7 +2258,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$ref": "#/rules@32"
+                        "$ref": "#/rules@35"
                       },
                       "arguments": []
                     }
@@ -2131,12 +2298,12 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "CrossReference",
                   "type": {
-                    "$ref": "#/rules@20"
+                    "$ref": "#/rules@23"
                   },
                   "terminal": {
                     "$type": "RuleCall",
                     "rule": {
-                      "$ref": "#/rules@63"
+                      "$ref": "#/rules@66"
                     },
                     "arguments": []
                   },
@@ -2162,7 +2329,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@33"
+                "$ref": "#/rules@36"
               },
               "arguments": []
             }
@@ -2189,7 +2356,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@34"
+              "$ref": "#/rules@37"
             },
             "arguments": []
           },
@@ -2216,7 +2383,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@34"
+                    "$ref": "#/rules@37"
                   },
                   "arguments": []
                 }
@@ -2246,7 +2413,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@35"
+              "$ref": "#/rules@38"
             },
             "arguments": []
           },
@@ -2273,7 +2440,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@35"
+                    "$ref": "#/rules@38"
                   },
                   "arguments": []
                 }
@@ -2303,7 +2470,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@36"
+              "$ref": "#/rules@39"
             },
             "arguments": []
           },
@@ -2328,7 +2495,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@35"
+                    "$ref": "#/rules@38"
                   },
                   "arguments": []
                 }
@@ -2357,14 +2524,14 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@38"
+              "$ref": "#/rules@41"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@37"
+              "$ref": "#/rules@40"
             },
             "arguments": []
           },
@@ -2401,7 +2568,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@33"
+              "$ref": "#/rules@36"
             },
             "arguments": []
           },
@@ -2428,12 +2595,12 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
         "terminal": {
           "$type": "CrossReference",
           "type": {
-            "$ref": "#/rules@20"
+            "$ref": "#/rules@23"
           },
           "terminal": {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@63"
+              "$ref": "#/rules@66"
             },
             "arguments": []
           },
@@ -2477,7 +2644,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@64"
+                "$ref": "#/rules@67"
               },
               "arguments": []
             }
@@ -2526,7 +2693,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
               "terminal": {
                 "$type": "RuleCall",
                 "rule": {
-                  "$ref": "#/rules@63"
+                  "$ref": "#/rules@66"
                 },
                 "arguments": []
               },
@@ -2547,7 +2714,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@32"
+                    "$ref": "#/rules@35"
                   },
                   "arguments": []
                 }
@@ -2566,7 +2733,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$ref": "#/rules@32"
+                        "$ref": "#/rules@35"
                       },
                       "arguments": []
                     }
@@ -2628,7 +2795,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@62"
+                "$ref": "#/rules@65"
               },
               "arguments": []
             }
@@ -2662,7 +2829,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@42"
+                "$ref": "#/rules@45"
               },
               "arguments": []
             }
@@ -2689,28 +2856,28 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@30"
+              "$ref": "#/rules@33"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@31"
+              "$ref": "#/rules@34"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@43"
+              "$ref": "#/rules@46"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@45"
+              "$ref": "#/rules@48"
             },
             "arguments": []
           }
@@ -2740,7 +2907,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@44"
+              "$ref": "#/rules@47"
             },
             "arguments": []
           },
@@ -2770,7 +2937,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@42"
+              "$ref": "#/rules@45"
             },
             "arguments": []
           },
@@ -2800,7 +2967,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$ref": "#/rules@42"
+                        "$ref": "#/rules@45"
                       },
                       "arguments": []
                     }
@@ -2881,7 +3048,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@46"
+                    "$ref": "#/rules@49"
                   },
                   "arguments": []
                 }
@@ -2915,14 +3082,14 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@30"
+              "$ref": "#/rules@33"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@31"
+              "$ref": "#/rules@34"
             },
             "arguments": []
           }
@@ -2952,7 +3119,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@21"
+              "$ref": "#/rules@24"
             },
             "arguments": []
           },
@@ -3003,7 +3170,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@21"
+                "$ref": "#/rules@24"
               },
               "arguments": []
             }
@@ -3041,7 +3208,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@63"
+                "$ref": "#/rules@66"
               },
               "arguments": []
             }
@@ -3097,7 +3264,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$ref": "#/rules@63"
+                        "$ref": "#/rules@66"
                       },
                       "arguments": []
                     }
@@ -3114,7 +3281,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$ref": "#/rules@63"
+                        "$ref": "#/rules@66"
                       },
                       "arguments": []
                     }
@@ -3133,7 +3300,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                         "terminal": {
                           "$type": "RuleCall",
                           "rule": {
-                            "$ref": "#/rules@49"
+                            "$ref": "#/rules@52"
                           },
                           "arguments": []
                         }
@@ -3156,7 +3323,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@51"
+                "$ref": "#/rules@54"
               },
               "arguments": []
             }
@@ -3187,7 +3354,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@52"
+              "$ref": "#/rules@55"
             },
             "arguments": []
           },
@@ -3214,7 +3381,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@52"
+                    "$ref": "#/rules@55"
                   },
                   "arguments": []
                 }
@@ -3244,7 +3411,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@53"
+              "$ref": "#/rules@56"
             },
             "arguments": []
           },
@@ -3267,7 +3434,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@53"
+                    "$ref": "#/rules@56"
                   },
                   "arguments": []
                 },
@@ -3298,7 +3465,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@54"
+              "$ref": "#/rules@57"
             },
             "arguments": []
           },
@@ -3347,35 +3514,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@61"
-            },
-            "arguments": []
-          },
-          {
-            "$type": "RuleCall",
-            "rule": {
-              "$ref": "#/rules@56"
-            },
-            "arguments": []
-          },
-          {
-            "$type": "RuleCall",
-            "rule": {
-              "$ref": "#/rules@55"
-            },
-            "arguments": []
-          },
-          {
-            "$type": "RuleCall",
-            "rule": {
-              "$ref": "#/rules@57"
-            },
-            "arguments": []
-          },
-          {
-            "$type": "RuleCall",
-            "rule": {
-              "$ref": "#/rules@58"
+              "$ref": "#/rules@64"
             },
             "arguments": []
           },
@@ -3389,7 +3528,35 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
+              "$ref": "#/rules@58"
+            },
+            "arguments": []
+          },
+          {
+            "$type": "RuleCall",
+            "rule": {
               "$ref": "#/rules@60"
+            },
+            "arguments": []
+          },
+          {
+            "$type": "RuleCall",
+            "rule": {
+              "$ref": "#/rules@61"
+            },
+            "arguments": []
+          },
+          {
+            "$type": "RuleCall",
+            "rule": {
+              "$ref": "#/rules@62"
+            },
+            "arguments": []
+          },
+          {
+            "$type": "RuleCall",
+            "rule": {
+              "$ref": "#/rules@63"
             },
             "arguments": []
           }
@@ -3446,7 +3613,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@51"
+              "$ref": "#/rules@54"
             },
             "arguments": []
           },
@@ -3487,12 +3654,12 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "CrossReference",
               "type": {
-                "$ref": "#/rules@50"
+                "$ref": "#/rules@53"
               },
               "terminal": {
                 "$type": "RuleCall",
                 "rule": {
-                  "$ref": "#/rules@63"
+                  "$ref": "#/rules@66"
                 },
                 "arguments": []
               },
@@ -3536,7 +3703,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@54"
+                "$ref": "#/rules@57"
               },
               "arguments": []
             }
@@ -3578,7 +3745,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@54"
+                "$ref": "#/rules@57"
               },
               "arguments": []
             }
@@ -3616,7 +3783,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@66"
+                "$ref": "#/rules@69"
               },
               "arguments": []
             }
@@ -3684,7 +3851,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@30"
+                "$ref": "#/rules@33"
               },
               "arguments": []
             }
@@ -3703,7 +3870,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@30"
+                    "$ref": "#/rules@33"
                   },
                   "arguments": []
                 }
@@ -3801,7 +3968,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@63"
+              "$ref": "#/rules@66"
             },
             "arguments": []
           }
@@ -3922,6 +4089,12 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "$type": "SimpleType",
             "typeRef": {
               "$ref": "#/rules@18"
+            }
+          },
+          {
+            "$type": "SimpleType",
+            "typeRef": {
+              "$ref": "#/rules@21"
             }
           }
         ]

--- a/packages/langium/src/grammar/internal-grammar-util.ts
+++ b/packages/langium/src/grammar/internal-grammar-util.ts
@@ -143,6 +143,9 @@ export function extractAssignments(element: ast.AbstractElement): ast.Assignment
     } else if (ast.isAlternatives(element) || ast.isGroup(element) || ast.isUnorderedGroup(element)) {
         return element.elements.flatMap(e => extractAssignments(e));
     } else if (ast.isRuleCall(element) && element.rule.ref) {
+        if (ast.isInfixRule(element.rule.ref)) {
+            return [];
+        }
         return extractAssignments(element.rule.ref.definition);
     }
     return [];

--- a/packages/langium/src/grammar/langium-grammar.langium
+++ b/packages/langium/src/grammar/langium-grammar.langium
@@ -56,13 +56,13 @@ SimpleType infers TypeDefinition:
 PrimitiveType returns string:
     'string' | 'number' | 'boolean' | 'Date' | 'bigint';
 
-type AbstractType = Interface | Type | ParserRule | InferredType;
+type AbstractType = Interface | Type | ParserRule | InfixRule | InferredType;
 
 Type:
     'type' name=ID '=' type=TypeDefinition ';'?;
 
 AbstractRule:
-    ParserRule | TerminalRule;
+    ParserRule | TerminalRule | InfixRule;
 
 GrammarImport:
     'import' path=STRING ';'?;
@@ -73,6 +73,12 @@ ParserRule:
     (wildcard?='*' | ('returns' (returnType=[AbstractType:ID] | dataType=PrimitiveType)) | inferredType=InferredType<false>)?
     (definesHiddenTokens?='hidden' '(' (hiddenTokens+=[AbstractRule:ID] (',' hiddenTokens+=[AbstractRule:ID])*)? ')')? ':'
     definition=Alternatives ';';
+
+InfixRule: 'infix' RuleNameAndParams 'on' call=RuleCall ':' operators=InfixRuleOperators ';';
+
+InfixRuleOperators: precedences+=InfixRuleOperatorList ('>' precedences+=InfixRuleOperatorList)*;
+
+InfixRuleOperatorList: operators+=Keyword ('|' operators+=Keyword)*;
 
 InferredType<imperative>:
     (<imperative> 'infer' | <!imperative> 'infers') name=ID;

--- a/packages/langium/src/grammar/lsp/grammar-semantic-tokens.ts
+++ b/packages/langium/src/grammar/lsp/grammar-semantic-tokens.ts
@@ -8,7 +8,7 @@ import type { AstNode } from '../../syntax-tree.js';
 import type { SemanticTokenAcceptor } from '../../lsp/semantic-token-provider.js';
 import { SemanticTokenTypes } from 'vscode-languageserver';
 import { AbstractSemanticTokenProvider } from '../../lsp/semantic-token-provider.js';
-import { isAction, isAssignment, isParameter, isParameterReference, isReturnType, isRuleCall, isSimpleType, isTypeAttribute } from '../../languages/generated/ast.js';
+import { isAction, isAssignment, isInfixRule, isParameter, isParameterReference, isReturnType, isRuleCall, isSimpleType, isTypeAttribute } from '../../languages/generated/ast.js';
 
 export class LangiumGrammarSemanticTokenProvider extends AbstractSemanticTokenProvider {
 
@@ -54,7 +54,7 @@ export class LangiumGrammarSemanticTokenProvider extends AbstractSemanticTokenPr
                 type: SemanticTokenTypes.parameter
             });
         } else if (isRuleCall(node)) {
-            if (node.rule.ref?.fragment) {
+            if (!isInfixRule(node.rule.ref) && node.rule.ref?.fragment) {
                 acceptor({
                     node,
                     property: 'rule',

--- a/packages/langium/src/grammar/type-system/type-collector/all-types.ts
+++ b/packages/langium/src/grammar/type-system/type-collector/all-types.ts
@@ -4,7 +4,7 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import type { ParserRule, Interface, Type, Grammar } from '../../../languages/generated/ast.js';
+import type { ParserRule, Interface, Type, Grammar, InfixRule } from '../../../languages/generated/ast.js';
 import type { URI } from '../../../utils/uri-utils.js';
 import type { LangiumDocuments } from '../../../workspace/documents.js';
 import type { PlainAstTypes } from './plain-types.js';
@@ -12,12 +12,13 @@ import type { AstTypes } from './types.js';
 import { collectInferredTypes } from './inferred-types.js';
 import { collectDeclaredTypes } from './declared-types.js';
 import { getDocument } from '../../../utils/ast-utils.js';
-import { isParserRule } from '../../../languages/generated/ast.js';
+import { isInfixRule, isParserRule } from '../../../languages/generated/ast.js';
 import { resolveImport } from '../../internal-grammar-util.js';
 import { isDataTypeRule } from '../../../utils/grammar-utils.js';
 
 export interface AstResources {
     parserRules: ParserRule[]
+    infixRules: InfixRule[]
     datatypeRules: ParserRule[]
     interfaces: Interface[]
     types: Type[]
@@ -38,7 +39,7 @@ export interface ValidationAstTypes {
 export function collectTypeResources(grammars: Grammar | Grammar[], documents?: LangiumDocuments): TypeResources {
     const astResources = collectAllAstResources(grammars, documents);
     const declared = collectDeclaredTypes(astResources.interfaces, astResources.types);
-    const inferred = collectInferredTypes(astResources.parserRules, astResources.datatypeRules, declared);
+    const inferred = collectInferredTypes(astResources.parserRules, astResources.datatypeRules, astResources.infixRules, declared);
 
     return {
         astResources,
@@ -50,7 +51,7 @@ export function collectTypeResources(grammars: Grammar | Grammar[], documents?: 
 ///////////////////////////////////////////////////////////////////////////////
 
 export function collectAllAstResources(grammars: Grammar | Grammar[], documents?: LangiumDocuments, visited: Set<URI> = new Set(),
-    astResources: AstResources = { parserRules: [], datatypeRules: [], interfaces: [], types: [] }): AstResources {
+    astResources: AstResources = { parserRules: [], infixRules: [], datatypeRules: [], interfaces: [], types: [] }): AstResources {
 
     if (!Array.isArray(grammars)) grammars = [grammars];
     for (const grammar of grammars) {
@@ -66,6 +67,8 @@ export function collectAllAstResources(grammars: Grammar | Grammar[], documents?
                 } else {
                     astResources.parserRules.push(rule);
                 }
+            } else if (isInfixRule(rule)) {
+                astResources.infixRules.push(rule);
             }
         }
         grammar.interfaces.forEach(e => astResources.interfaces.push(e));

--- a/packages/langium/src/grammar/type-system/type-collector/inferred-types.ts
+++ b/packages/langium/src/grammar/type-system/type-collector/inferred-types.ts
@@ -4,14 +4,14 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import type { ParserRule, Action, AbstractElement, Assignment, RuleCall } from '../../../languages/generated/ast.js';
+import type { ParserRule, Action, AbstractElement, Assignment, RuleCall, InfixRule, TypeAttribute } from '../../../languages/generated/ast.js';
 import type { PlainAstTypes, PlainInterface, PlainProperty, PlainPropertyType, PlainUnion } from './plain-types.js';
 import { isNamed } from '../../../references/name-provider.js';
 import { MultiMap } from '../../../utils/collections.js';
-import { isAlternatives, isKeyword, isParserRule, isAction, isGroup, isUnorderedGroup, isAssignment, isRuleCall, isCrossReference, isTerminalRule } from '../../../languages/generated/ast.js';
+import { isAlternatives, isKeyword, isParserRule, isAction, isGroup, isUnorderedGroup, isAssignment, isRuleCall, isCrossReference, isTerminalRule, isInfixRule } from '../../../languages/generated/ast.js';
 import { getTypeNameWithoutError, isPrimitiveGrammarType } from '../../internal-grammar-util.js';
 import { mergePropertyTypes } from './plain-types.js';
-import { isOptionalCardinality, terminalRegex, getRuleTypeName } from '../../../utils/grammar-utils.js';
+import { isOptionalCardinality, terminalRegex, getRuleTypeName, getTypeName } from '../../../utils/grammar-utils.js';
 
 interface TypePart {
     name?: string
@@ -250,7 +250,7 @@ function copyProperty(value: PlainProperty): PlainProperty {
     };
 }
 
-export function collectInferredTypes(parserRules: ParserRule[], datatypeRules: ParserRule[], declared: PlainAstTypes): PlainAstTypes {
+export function collectInferredTypes(parserRules: ParserRule[], datatypeRules: ParserRule[], infixRules: InfixRule[], declared: PlainAstTypes): PlainAstTypes {
     // extract interfaces and types from parser rules
     const allTypes: TypePath[] = [];
     const context: TypeCollectionContext = {
@@ -259,7 +259,7 @@ export function collectInferredTypes(parserRules: ParserRule[], datatypeRules: P
     for (const rule of parserRules) {
         allTypes.push(...getRuleTypes(context, rule));
     }
-    const interfaces = calculateInterfaces(allTypes);
+    const interfaces = calculateInterfaces(allTypes, calculateInfixInterfaces(infixRules));
     const unions = buildSuperUnions(interfaces);
     const astTypes = extractUnions(interfaces, unions, declared);
 
@@ -276,6 +276,57 @@ export function collectInferredTypes(parserRules: ParserRule[], datatypeRules: P
         });
     }
     return astTypes;
+}
+
+function calculateInfixInterfaces(rules: InfixRule[]): PlainInterface[] {
+    const interfaces: PlainInterface[] = [];
+    for (const rule of rules) {
+        const on = rule.call.rule.ref;
+        let onName = on?.name;
+        if (isParserRule(on)) {
+            onName = getTypeName(on);
+        }
+        if (onName && rule.name) {
+            const operators = rule.operators.precedences
+                .flatMap(e => e.operators).map(e => e.value).sort();
+            const expressionProperty = {
+                astNodes: new Set<Assignment | Action | TypeAttribute>(),
+                optional: false,
+                type: {
+                    value: onName
+                }
+            };
+            const interfaceType: PlainInterface = {
+                name: rule.name,
+                declared: false,
+                abstract: false,
+                properties: [
+                    {
+                        ...expressionProperty,
+                        name: 'left'
+                    },
+                    {
+                        ...expressionProperty,
+                        name: 'right'
+                    },
+                    {
+                        name: 'operator',
+                        astNodes: new Set(),
+                        optional: false,
+                        type: {
+                            types: operators.map(operator => ({
+                                string: operator
+                            }))
+                        }
+                    }
+                ],
+                subTypes: new Set(),
+                superTypes: new Set()
+            };
+            interfaces.push(interfaceType);
+        }
+    }
+    return interfaces;
 }
 
 function getDataRuleType(rule: ParserRule): PlainPropertyType {
@@ -500,7 +551,7 @@ function addRuleCall(graph: TypeGraph, current: TypePart, ruleCall: RuleCall): v
         } else {
             current.properties.push(...properties);
         }
-    } else if (isParserRule(rule)) {
+    } else if (isParserRule(rule) || isInfixRule(rule)) {
         current.ruleCalls.push(getRuleTypeName(rule));
     }
 }
@@ -524,8 +575,8 @@ function getFragmentProperties(fragment: ParserRule, context: TypeCollectionCont
  * @param alternatives The type branches that will be squashed in interfaces.
  * @returns Interfaces.
  */
-function calculateInterfaces(alternatives: TypePath[]): PlainInterface[] {
-    const interfaces = new Map<string, PlainInterface>();
+function calculateInterfaces(alternatives: TypePath[], otherInterfaces: PlainInterface[]): PlainInterface[] {
+    const interfaces = new Map<string, PlainInterface>(otherInterfaces.map(e => [e.name, e]));
     const ruleCallAlternatives: TypeAlternative[] = [];
     const flattened = alternatives.length > 0
         ? flattenTypes(alternatives, alternatives[0].current).map(e => e.alt)

--- a/packages/langium/src/grammar/validation/validator.ts
+++ b/packages/langium/src/grammar/validation/validator.ts
@@ -446,8 +446,13 @@ export class LangiumGrammarValidator {
             }
             // If the element is a direct rule call
             // We need to check whether the element consumes anything
-            if (ast.isRuleCall(element) && element.rule.ref?.definition) {
-                return consumesAnything(element.rule.ref.definition);
+            if (ast.isRuleCall(element)) {
+                if (ast.isInfixRule(element.rule.ref)) {
+                    // Infix rules always at least consume their operators
+                    return true;
+                } else if (element.rule.ref?.definition) {
+                    return consumesAnything(element.rule.ref.definition);
+                }
             }
             // Else, assert that we consume something.
             return true;
@@ -740,7 +745,7 @@ export class LangiumGrammarValidator {
         };
         const ref = call.rule.ref;
         // Parsing an unassigned terminal rule is fine.
-        if (!ref || ast.isTerminalRule(ref)) {
+        if (!ref || ast.isTerminalRule(ref) || ast.isInfixRule(ref)) {
             return;
         }
         // Fragment or data type rules are fine too.
@@ -1093,6 +1098,9 @@ export class LangiumGrammarValidator {
 }
 
 function isEmptyRule(rule: ast.AbstractRule): boolean {
+    if (ast.isInfixRule(rule)) {
+        return false;
+    }
     return !rule.definition || !rule.definition.$cstNode || rule.definition.$cstNode.length === 0;
 }
 

--- a/packages/langium/src/languages/generated/ast.ts
+++ b/packages/langium/src/languages/generated/ast.ts
@@ -59,8 +59,10 @@ export type LangiumGrammarKeywordNames =
     | "import"
     | "infer"
     | "infers"
+    | "infix"
     | "interface"
     | "number"
+    | "on"
     | "returns"
     | "string"
     | "terminal"
@@ -73,7 +75,7 @@ export type LangiumGrammarKeywordNames =
 
 export type LangiumGrammarTokenNames = LangiumGrammarTerminalNames | LangiumGrammarKeywordNames;
 
-export type AbstractRule = ParserRule | TerminalRule;
+export type AbstractRule = InfixRule | ParserRule | TerminalRule;
 
 export const AbstractRule = 'AbstractRule';
 
@@ -81,7 +83,7 @@ export function isAbstractRule(item: unknown): item is AbstractRule {
     return reflection.isInstance(item, AbstractRule);
 }
 
-export type AbstractType = InferredType | Interface | ParserRule | Type;
+export type AbstractType = InferredType | InfixRule | Interface | ParserRule | Type;
 
 export const AbstractType = 'AbstractType';
 
@@ -242,6 +244,45 @@ export function isInferredType(item: unknown): item is InferredType {
     return reflection.isInstance(item, InferredType);
 }
 
+export interface InfixRule extends AstNode {
+    readonly $container: Grammar;
+    readonly $type: 'InfixRule';
+    call: RuleCall;
+    name: string;
+    operators: InfixRuleOperators;
+    parameters: Array<Parameter>;
+}
+
+export const InfixRule = 'InfixRule';
+
+export function isInfixRule(item: unknown): item is InfixRule {
+    return reflection.isInstance(item, InfixRule);
+}
+
+export interface InfixRuleOperatorList extends AstNode {
+    readonly $container: InfixRuleOperators;
+    readonly $type: 'InfixRuleOperatorList';
+    operators: Array<Keyword>;
+}
+
+export const InfixRuleOperatorList = 'InfixRuleOperatorList';
+
+export function isInfixRuleOperatorList(item: unknown): item is InfixRuleOperatorList {
+    return reflection.isInstance(item, InfixRuleOperatorList);
+}
+
+export interface InfixRuleOperators extends AstNode {
+    readonly $container: InfixRule;
+    readonly $type: 'InfixRuleOperators';
+    precedences: Array<InfixRuleOperatorList>;
+}
+
+export const InfixRuleOperators = 'InfixRuleOperators';
+
+export function isInfixRuleOperators(item: unknown): item is InfixRuleOperators {
+    return reflection.isInstance(item, InfixRuleOperators);
+}
+
 export interface Interface extends AstNode {
     readonly $container: Grammar;
     readonly $type: 'Interface';
@@ -295,7 +336,7 @@ export function isNumberLiteral(item: unknown): item is NumberLiteral {
 }
 
 export interface Parameter extends AstNode {
-    readonly $container: ParserRule;
+    readonly $container: InfixRule | ParserRule;
     readonly $type: 'Parameter';
     name: string;
 }
@@ -532,7 +573,7 @@ export function isGroup(item: unknown): item is Group {
 }
 
 export interface Keyword extends AbstractElement {
-    readonly $container: CharacterRange;
+    readonly $container: CharacterRange | InfixRuleOperatorList;
     readonly $type: 'Keyword';
     value: string;
 }
@@ -566,6 +607,7 @@ export function isRegexToken(item: unknown): item is RegexToken {
 }
 
 export interface RuleCall extends AbstractElement {
+    readonly $container: InfixRule;
     readonly $type: 'RuleCall';
     arguments: Array<NamedArgument>;
     rule: Reference<AbstractRule>;
@@ -662,6 +704,9 @@ export type LangiumGrammarAstType = {
     GrammarImport: GrammarImport
     Group: Group
     InferredType: InferredType
+    InfixRule: InfixRule
+    InfixRuleOperatorList: InfixRuleOperatorList
+    InfixRuleOperators: InfixRuleOperators
     Interface: Interface
     Keyword: Keyword
     NamedArgument: NamedArgument
@@ -694,7 +739,7 @@ export type LangiumGrammarAstType = {
 export class LangiumGrammarAstReflection extends AbstractAstReflection {
 
     getAllTypes(): string[] {
-        return [AbstractElement, AbstractRule, AbstractType, Action, Alternatives, ArrayLiteral, ArrayType, Assignment, BooleanLiteral, CharacterRange, Condition, Conjunction, CrossReference, Disjunction, EndOfFile, Grammar, GrammarImport, Group, InferredType, Interface, Keyword, NamedArgument, NegatedToken, Negation, NumberLiteral, Parameter, ParameterReference, ParserRule, ReferenceType, RegexToken, ReturnType, RuleCall, SimpleType, StringLiteral, TerminalAlternatives, TerminalGroup, TerminalRule, TerminalRuleCall, Type, TypeAttribute, TypeDefinition, UnionType, UnorderedGroup, UntilToken, ValueLiteral, Wildcard];
+        return [AbstractElement, AbstractRule, AbstractType, Action, Alternatives, ArrayLiteral, ArrayType, Assignment, BooleanLiteral, CharacterRange, Condition, Conjunction, CrossReference, Disjunction, EndOfFile, Grammar, GrammarImport, Group, InferredType, InfixRule, InfixRuleOperatorList, InfixRuleOperators, Interface, Keyword, NamedArgument, NegatedToken, Negation, NumberLiteral, Parameter, ParameterReference, ParserRule, ReferenceType, RegexToken, ReturnType, RuleCall, SimpleType, StringLiteral, TerminalAlternatives, TerminalGroup, TerminalRule, TerminalRuleCall, Type, TypeAttribute, TypeDefinition, UnionType, UnorderedGroup, UntilToken, ValueLiteral, Wildcard];
     }
 
     protected override computeIsSubtype(subtype: string, supertype: string): boolean {
@@ -743,6 +788,7 @@ export class LangiumGrammarAstReflection extends AbstractAstReflection {
             case Type: {
                 return this.isSubtype(AbstractType, supertype);
             }
+            case InfixRule:
             case ParserRule: {
                 return this.isSubtype(AbstractRule, supertype) || this.isSubtype(AbstractType, supertype);
             }
@@ -868,6 +914,33 @@ export class LangiumGrammarAstReflection extends AbstractAstReflection {
                     name: InferredType,
                     properties: [
                         { name: 'name' }
+                    ]
+                };
+            }
+            case InfixRule: {
+                return {
+                    name: InfixRule,
+                    properties: [
+                        { name: 'call' },
+                        { name: 'name' },
+                        { name: 'operators' },
+                        { name: 'parameters', defaultValue: [] }
+                    ]
+                };
+            }
+            case InfixRuleOperatorList: {
+                return {
+                    name: InfixRuleOperatorList,
+                    properties: [
+                        { name: 'operators', defaultValue: [] }
+                    ]
+                };
+            }
+            case InfixRuleOperators: {
+                return {
+                    name: InfixRuleOperators,
+                    properties: [
+                        { name: 'precedences', defaultValue: [] }
                     ]
                 };
             }

--- a/packages/langium/src/lsp/completion/follow-element-computation.ts
+++ b/packages/langium/src/lsp/completion/follow-element-computation.ts
@@ -176,6 +176,20 @@ function findFirstFeaturesInternal(options: { next: NextFeature, cardinalities: 
         };
         return findFirstFeaturesInternal({ next: ruleCallNext, cardinalities, visited, plus })
             .map(e => modifyCardinality(e, feature.cardinality, cardinalities));
+    } else if (ast.isRuleCall(feature) && ast.isInfixRule(feature.rule.ref)) {
+        const rule = feature.rule.ref;
+        const call = rule.call.rule.ref;
+        if (!ast.isParserRule(call)) {
+            console.error('Failed to resolve reference to ' + rule.call.rule.$refText);
+            return [];
+        }
+        const ruleCallNext = {
+            feature: call.definition,
+            type: getExplicitRuleType(call) ?? call.name,
+            property: 'parts'
+        };
+        return findFirstFeaturesInternal({ next: ruleCallNext, cardinalities, visited, plus })
+            .map(e => modifyCardinality(e, feature.cardinality, cardinalities));
     } else {
         return [next];
     }

--- a/packages/langium/src/parser/langium-parser.ts
+++ b/packages/langium/src/parser/langium-parser.ts
@@ -6,16 +6,17 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import type { DSLMethodOpts, ILexingError, IOrAlt, IParserErrorMessageProvider, IRecognitionException, IToken, TokenType, TokenVocabulary } from 'chevrotain';
-import type { AbstractElement, Action, Assignment, ParserRule } from '../languages/generated/ast.js';
+import type { AbstractElement, Action, Assignment, InfixRule, ParserRule } from '../languages/generated/ast.js';
+import { isInfixRule } from '../languages/generated/ast.js';
 import type { Linker } from '../references/linker.js';
 import type { LangiumCoreServices } from '../services.js';
-import type { AstNode, AstReflection, CompositeCstNode, CstNode } from '../syntax-tree.js';
+import type { AstNode, AstReflection, CompositeCstNode, CstNode, Mutable } from '../syntax-tree.js';
 import type { Lexer, LexerResult } from './lexer.js';
 import type { IParserConfig } from './parser-config.js';
 import type { ValueConverter } from './value-converter.js';
 import { defaultParserErrorProvider, EmbeddedActionsParser, LLkLookaheadStrategy } from 'chevrotain';
 import { LLStarLookaheadStrategy } from 'chevrotain-allstar';
-import { isAssignment, isCrossReference, isKeyword } from '../languages/generated/ast.js';
+import { isAssignment, isCrossReference, isKeyword, isParserRule } from '../languages/generated/ast.js';
 import { getExplicitRuleType, isDataTypeRule } from '../utils/grammar-utils.js';
 import { assignMandatoryProperties, getContainerOfType, linkContentToContainer } from '../utils/ast-utils.js';
 import { CstNodeBuilder } from './cst-node-builder.js';
@@ -36,6 +37,13 @@ interface DataTypeNode {
     $type: symbol
     /** Used as a storage for all parsed terminals, keywords and sub-datatype rules */
     value: string
+}
+
+interface InfixElement {
+    $type: string;
+    $cstNode: CompositeCstNode;
+    parts: AstNode[];
+    operators: string[];
 }
 
 function isDataTypeNode(node: { $type: string | symbol | undefined }): node is DataTypeNode {
@@ -63,7 +71,7 @@ export interface BaseParser {
     /**
      * Adds a new parser rule to the parser
      */
-    rule(rule: ParserRule, impl: RuleImpl): RuleResult;
+    rule(rule: ParserRule | InfixRule, impl: RuleImpl): RuleResult;
     /**
      * Returns the executable rule function for the specified rule name
      */
@@ -159,7 +167,7 @@ export abstract class AbstractLangiumParser implements BaseParser {
         this.wrapper.wrapAtLeastOne(idx, callback);
     }
 
-    abstract rule(rule: ParserRule, impl: RuleImpl): RuleResult;
+    abstract rule(rule: ParserRule | InfixRule, impl: RuleImpl): RuleResult;
     abstract consume(idx: number, tokenType: TokenType, feature: AbstractElement): void;
     abstract subrule(idx: number, rule: RuleResult, fragment: boolean, feature: AbstractElement, args: Args): void;
     abstract action($type: string, action: Action): void;
@@ -198,6 +206,7 @@ export class LangiumParser extends AbstractLangiumParser {
     private lexerResult?: LexerResult;
     private stack: any[] = [];
     private assignmentMap = new Map<AbstractElement, AssignmentElement | undefined>();
+    private operatorPrecedence = new Map<string, Map<string, number>>();
 
     private get current(): any {
         return this.stack[this.stack.length - 1];
@@ -210,18 +219,36 @@ export class LangiumParser extends AbstractLangiumParser {
         this.astReflection = services.shared.AstReflection;
     }
 
-    rule(rule: ParserRule, impl: RuleImpl): RuleResult {
+    rule(rule: ParserRule | InfixRule, impl: RuleImpl): RuleResult {
         const type = this.computeRuleType(rule);
-        const ruleMethod = this.wrapper.DEFINE_RULE(withRuleSuffix(rule.name), this.startImplementation(type, impl).bind(this));
+        const isInfix = isInfixRule(rule);
+        if (isInfix) {
+            this.registerPrecedenceMap(rule);
+        }
+        const ruleMethod = this.wrapper.DEFINE_RULE(withRuleSuffix(rule.name), this.startImplementation(type, isInfix, impl).bind(this));
         this.allRules.set(rule.name, ruleMethod);
-        if (rule.entry) {
+        if (isParserRule(rule) && rule.entry) {
             this.mainRule = ruleMethod;
         }
         return ruleMethod;
     }
 
-    private computeRuleType(rule: ParserRule): string | symbol | undefined {
-        if (rule.fragment) {
+    private registerPrecedenceMap(rule: InfixRule): void {
+        const name = rule.name;
+        const map = new Map<string, number>();
+        for (let i = 0; i < rule.operators.precedences.length; i++) {
+            const precedence = rule.operators.precedences[i];
+            for (const keyword of precedence.operators) {
+                map.set(keyword.value, i);
+            }
+        }
+        this.operatorPrecedence.set(name, map);
+    }
+
+    private computeRuleType(rule: ParserRule | InfixRule): string | symbol | undefined {
+        if (isInfixRule(rule)) {
+            return rule.name;
+        } else if (rule.fragment) {
             return undefined;
         } else if (isDataTypeRule(rule)) {
             return DatatypeSymbol;
@@ -243,6 +270,7 @@ export class LangiumParser extends AbstractLangiumParser {
         this.nodeBuilder.addHiddenNodes(lexerResult.hidden);
         this.unorderedGroups.clear();
         this.lexerResult = undefined;
+        linkContentToContainer(result, true);
         return {
             value: result,
             lexerErrors: lexerResult.errors,
@@ -251,7 +279,7 @@ export class LangiumParser extends AbstractLangiumParser {
         };
     }
 
-    private startImplementation($type: string | symbol | undefined, implementation: RuleImpl): RuleImpl {
+    private startImplementation($type: string | symbol | undefined, infix: boolean, implementation: RuleImpl): RuleImpl {
         return (args) => {
             // Only create a new AST node in case the calling rule is not a fragment rule
             const createNode = !this.isRecording() && $type !== undefined;
@@ -260,6 +288,8 @@ export class LangiumParser extends AbstractLangiumParser {
                 this.stack.push(node);
                 if ($type === DatatypeSymbol) {
                     node.value = '';
+                } else if (infix) {
+                    node.$infix = true;
                 }
             }
             let result: unknown;
@@ -379,16 +409,63 @@ export class LangiumParser extends AbstractLangiumParser {
         if (this.isRecording()) {
             return undefined;
         }
-        const obj = this.current;
-        linkContentToContainer(obj);
+        const obj = this.stack.pop();
         this.nodeBuilder.construct(obj);
-        this.stack.pop();
-        if (isDataTypeNode(obj)) {
+        if ('$infix' in obj) {
+            return this.constructInfix(obj, this.operatorPrecedence.get(obj.$type)!);
+        } else if (isDataTypeNode(obj)) {
             return this.converter.convert(obj.value, obj.$cstNode);
         } else {
             assignMandatoryProperties(this.astReflection, obj);
         }
         return obj;
+    }
+
+    private constructInfix(obj: InfixElement, precedence: Map<string, number>): any {
+        if (obj.parts.length === 1) {
+            // Captured just a single, non-binary expression
+            // Simply return the expression as is.
+            return obj.parts[0];
+        }
+        let expression = {
+            $type: obj.$type,
+            left: obj.parts[0],
+            operator: obj.operators[0],
+            right: obj.parts[1]
+        };
+        let lastPrecedence = precedence.get(expression.operator) ?? 0;
+        for (let i = 1; i < obj.operators.length; i++) {
+            const op = obj.operators[i];
+            const next = obj.parts[i + 1];
+            const currentPrecedence = precedence.get(op) ?? 0;
+            if (currentPrecedence <= lastPrecedence) {
+                // If the current precendence is higher (i.e. the rank is lower)
+                // We simply create a new node and append the previous expression to the left
+                expression = {
+                    $type: obj.$type,
+                    left: expression,
+                    operator: op,
+                    right: next
+                };
+            } else {
+                // If the precedence is lower, we need to rewrite the previous node
+                // For that, we move the previous right node to the left side of the new node
+                const rewrite = {
+                    $type: obj.$type,
+                    left: expression.right,
+                    operator: op,
+                    right: next
+                };
+                // This new node now becomes the right side of the previous node
+                expression.right = rewrite;
+            }
+            lastPrecedence = currentPrecedence;
+        }
+        // In theory, we could rebuild the CST for the infix expression
+        // However, there is no real benefit for it, and it might be costly (performance-wise)
+        // We might want to revisit this decision in the future.
+        (expression as Mutable<AstNode>).$cstNode = obj.$cstNode;
+        return expression;
     }
 
     private getAssignment(feature: AbstractElement): AssignmentElement {

--- a/packages/langium/src/parser/token-builder.ts
+++ b/packages/langium/src/parser/token-builder.ts
@@ -8,7 +8,7 @@ import type { CustomPatternMatcherFunc, ILexingError, TokenPattern, TokenType, T
 import type { AbstractRule, Grammar, Keyword, TerminalRule } from '../languages/generated/ast.js';
 import type { Stream } from '../utils/stream.js';
 import { Lexer } from 'chevrotain';
-import { isKeyword, isParserRule, isTerminalRule } from '../languages/generated/ast.js';
+import { isInfixRule, isKeyword, isParserRule, isTerminalRule } from '../languages/generated/ast.js';
 import { streamAllContents } from '../utils/ast-utils.js';
 import { getAllReachableRules, terminalRegex } from '../utils/grammar-utils.js';
 import { getCaseInsensitivePattern, isWhitespace, partialMatches } from '../utils/regexp-utils.js';
@@ -123,7 +123,7 @@ export class DefaultTokenBuilder implements TokenBuilder {
     protected buildKeywordTokens(rules: Stream<AbstractRule>, terminalTokens: TokenType[], options?: TokenBuilderOptions): TokenType[] {
         return rules
             // We filter by parser rules, since keywords in terminal rules get transformed into regex and are not actual tokens
-            .filter(isParserRule)
+            .filter(rule => isParserRule(rule) || isInfixRule(rule))
             .flatMap(rule => streamAllContents(rule).filter(isKeyword))
             .distinct(e => e.value).toArray()
             // Sort keywords by descending length

--- a/packages/langium/src/utils/ast-utils.ts
+++ b/packages/langium/src/utils/ast-utils.ts
@@ -16,7 +16,7 @@ import { inRange } from './cst-utils.js';
  * Link the `$container` and other related properties of every AST node that is directly contained
  * in the given `node`.
  */
-export function linkContentToContainer(node: AstNode): void {
+export function linkContentToContainer(node: AstNode, deep = false): void {
     for (const [name, value] of Object.entries(node)) {
         if (!name.startsWith('$')) {
             if (Array.isArray(value)) {
@@ -25,11 +25,17 @@ export function linkContentToContainer(node: AstNode): void {
                         (item as Mutable<AstNode>).$container = node;
                         (item as Mutable<AstNode>).$containerProperty = name;
                         (item as Mutable<AstNode>).$containerIndex = index;
+                        if (deep) {
+                            linkContentToContainer(item, deep);
+                        }
                     }
                 });
             } else if (isAstNode(value)) {
                 (value as Mutable<AstNode>).$container = node;
                 (value as Mutable<AstNode>).$containerProperty = name;
+                if (deep) {
+                    linkContentToContainer(value, deep);
+                }
             }
         }
     }
@@ -298,6 +304,6 @@ export function copyAstNode<T extends AstNode = AstNode>(node: T, buildReference
         }
     }
 
-    linkContentToContainer(copy);
+    linkContentToContainer(copy, true);
     return copy as unknown as T;
 }

--- a/packages/langium/src/utils/grammar-utils.ts
+++ b/packages/langium/src/utils/grammar-utils.ts
@@ -344,6 +344,9 @@ function isDataTypeRuleInternal(rule: ast.ParserRule, visited: Set<ast.ParserRul
             if (ast.isParserRule(node.rule.ref) && !isDataTypeRuleInternal(node.rule.ref, visited)) {
                 return false;
             }
+            if (ast.isInfixRule(node.rule.ref)) {
+                return false;
+            }
         } else if (ast.isAssignment(node)) {
             return false;
         } else if (ast.isAction(node)) {
@@ -389,7 +392,16 @@ function isDataTypeInternal(type: ast.TypeDefinition, visited: Set<ast.TypeDefin
     }
 }
 
-export function getExplicitRuleType(rule: ast.ParserRule): string | undefined {
+export function getExplicitRuleType(rule: ast.AbstractRule): string | undefined {
+    if (ast.isInfixRule(rule)) {
+        const call = rule.call.rule.ref;
+        if (call) {
+            return getExplicitRuleType(call);
+        }
+        return undefined;
+    } else if (ast.isTerminalRule(rule)) {
+        return undefined;
+    }
     if (rule.inferredType) {
         return rule.inferredType.name;
     } else if (rule.dataType) {
@@ -443,6 +455,8 @@ export function getActionType(action: ast.Action): string | undefined {
 export function getRuleTypeName(rule: ast.AbstractRule): string {
     if (ast.isTerminalRule(rule)) {
         return rule.type?.name ?? 'string';
+    } else if (ast.isInfixRule(rule)) {
+        return rule.name;
     } else {
         return isDataTypeRule(rule) ? rule.name : getExplicitRuleType(rule) ?? rule.name;
     }
@@ -458,6 +472,8 @@ export function getRuleTypeName(rule: ast.AbstractRule): string {
 export function getRuleType(rule: ast.AbstractRule): string {
     if (ast.isTerminalRule(rule)) {
         return rule.type?.name ?? 'string';
+    } else if (ast.isInfixRule(rule)) {
+        return rule.name;
     } else {
         return getExplicitRuleType(rule) ?? rule.name;
     }

--- a/packages/langium/test/grammar/grammar-validator.test.ts
+++ b/packages/langium/test/grammar/grammar-validator.test.ts
@@ -1282,12 +1282,14 @@ describe('Cross-reference to type union is only valid if all alternatives are AS
         `);
 
         const grammar = validationResult.document.parseResult.value;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const rules = grammar.rules as any;
         expectError(validationResult, /Data type rules for cross-references must be of type string./, {
-            node: (((grammar.rules[0].definition as GrammarTypes.Group).elements[0] as GrammarTypes.Assignment).terminal as GrammarTypes.CrossReference).terminal as GrammarTypes.RuleCall,
+            node: rules[0].definition.elements[0].terminal.terminal,
             property: 'rule'
         });
         expectError(validationResult, /Terminal rules for cross-references must be of type string./, {
-            node: (((grammar.rules[0].definition as GrammarTypes.Group).elements[1] as GrammarTypes.Assignment).terminal as GrammarTypes.CrossReference).terminal as GrammarTypes.RuleCall,
+            node: rules[0].definition.elements[1].terminal.terminal,
             property: 'rule'
         });
     });

--- a/packages/langium/test/parser/langium-parser-builder.test.ts
+++ b/packages/langium/test/parser/langium-parser-builder.test.ts
@@ -995,7 +995,7 @@ describe('Handling hidden nodes', () => {
         const doc = await parser("Test returns string: /** comment 1 */ 'A' | /** comment 2 */  'B' | /** comment 3 */ 'C';");
         expect(doc).toBeDefined();
         const value = doc.parseResult.value as Grammar;
-        const ruleDef = value.rules[0].definition as GrammarAST.Alternatives;
+        const ruleDef = (value.rules[0] as GrammarAST.ParserRule).definition as GrammarAST.Alternatives;
         const a = ruleDef.elements[0];
         const commentNode = CstUtils.findCommentNode(a.$cstNode, ['ML_COMMENT']);
         expect(commentNode).toBeDefined();
@@ -1144,6 +1144,33 @@ describe('Parsing with lookbehind tokens', () => {
         expect(invalidResult.lexerErrors).toHaveLength(1);
         expect(invalidResult.parserErrors).toHaveLength(1);
     }
+});
+
+describe('Parsing infix expressions', async () => {
+
+    const parser = await parserFromGrammar(`
+        grammar test
+        entry Main: Expression;
+        infix Expression on Number: '%' > '*' | '/' > '+' | '-';
+        Primary: Number | '(' Expression ')';
+        Number: value=NUM;
+        terminal NUM: /[0-9]+/;
+        hidden terminal WS: /\\s+/;
+        `
+    );
+
+    test('Simple binary expression structure', async () => {
+        const validResult = parser.parse('4 * 5 + 6') as ParseResult<GenericAstNode>;
+        expect(validResult.value).toBeDefined();
+        expect(validResult.value.operator).toBe('*');
+        const left = validResult.value.left as GenericAstNode;
+        expect(left.value).toBe('4');
+        const right = validResult.value.right as GenericAstNode;
+        expect(right.operator).toBe('+');
+        expect((right.left as GenericAstNode).value).toBe('5');
+        expect((right.right as GenericAstNode).value).toBe('6');
+    });
+
 });
 
 async function parserFromGrammar(grammar: string): Promise<LangiumParser> {


### PR DESCRIPTION
Closes https://github.com/eclipse-langium/langium/issues/1065

Adds support for a special infix operator syntax that aims to improve Langium on multiple fronts:
1. Improves readability/maintainability of Langium grammars
2. Simplify specifying precedence for infix binary expressions
3. Improves performance by parsing the binary expression in a flat list - the parser will automatically transform the resulting object into a tree structure.

Note that the same AST node is constructed as if you were to write the parser rules manually. Also note that this PR assumes that all binary operators are left-associative (i.e. `A + B + C` is parsed as `(A + B) + C`). We can revisit this decision in case we find a case for right-associative grammar rules. Note that this only requires changes in the tree restructuring routine.