### PR TITLE
allow user defined validation categories

### DIFF
--- a/packages/langium/src/test/langium-test.ts
+++ b/packages/langium/src/test/langium-test.ts
@@ -556,10 +556,11 @@ export type ValidationHelperOptions = ParseHelperOptions & { failOnParsingErrors
 export function validationHelper<T extends AstNode = AstNode>(services: LangiumCoreServices): (input: string, options?: ValidationHelperOptions) => Promise<ValidationResult<T>> {
     const parse = parseHelper<T>(services);
     return async (input, options) => {
-        const document = await parse(input, {
+        const parseOptions: ValidationHelperOptions = {
             ...(options ?? {}),
-            validation: true
-        });
+        };
+        parseOptions.validation = parseOptions.validation ?? true;
+        const document = await parse(input, parseOptions);
         const result = {
             document,
             diagnostics: document.diagnostics ?? [],

--- a/packages/langium/src/test/langium-test.ts
+++ b/packages/langium/src/test/langium-test.ts
@@ -559,7 +559,7 @@ export function validationHelper<T extends AstNode = AstNode>(services: LangiumC
         const parseOptions: ValidationHelperOptions = {
             ...(options ?? {}),
         };
-        parseOptions.validation = parseOptions.validation ?? true;
+        parseOptions.validation ??= true;
         const document = await parse(input, parseOptions);
         const result = {
             document,

--- a/packages/langium/src/validation/validation-registry.ts
+++ b/packages/langium/src/validation/validation-registry.ts
@@ -113,7 +113,7 @@ export type ValidationChecks<T> = {
  * to you to schedule these checks: after the fast checks are done, or after saving a document,
  * or with an explicit command, etc.
  */
-export type ValidationCategory = 'fast' | 'slow' | 'built-in' | string;
+export type ValidationCategory = 'fast' | 'slow' | 'built-in' | (string & {});
 
 export namespace ValidationCategory {
     export const all: readonly ValidationCategory[] = ['fast', 'slow', 'built-in'];

--- a/packages/langium/src/validation/validation-registry.ts
+++ b/packages/langium/src/validation/validation-registry.ts
@@ -98,6 +98,8 @@ export type ValidationChecks<T> = {
 }
 
 /**
+ * There are 3 pre-defined categories: `fast`, `slow` and `built-in`.
+ *
  * `fast` checks can be executed after every document change (i.e. as the user is typing). If a check
  * is too slow it can delay the response to document changes, yielding bad user experience. By marking
  * it as `slow`, it will be skipped for normal as-you-type validation. Then it's up to you when to
@@ -106,8 +108,12 @@ export type ValidationChecks<T> = {
  *
  * `built-in` checks are errors produced by the lexer, the parser, or the linker. They cannot be used
  * for custom validation checks.
+ *
+ * You can also provide user-defined categories. These check will be skipped by default. Then it's up
+ * to you to schedule these checks: after the fast checks are done, or after saving a document,
+ * or with an explicit command, etc.
  */
-export type ValidationCategory = 'fast' | 'slow' | 'built-in'
+export type ValidationCategory = 'fast' | 'slow' | 'built-in' | string;
 
 export namespace ValidationCategory {
     export const all: readonly ValidationCategory[] = ['fast', 'slow', 'built-in'];

--- a/packages/langium/src/validation/validation-registry.ts
+++ b/packages/langium/src/validation/validation-registry.ts
@@ -113,6 +113,7 @@ export type ValidationChecks<T> = {
  * to you to schedule these checks: after the fast checks are done, or after saving a document,
  * or with an explicit command, etc.
  */
+// eslint-disable-next-line @typescript-eslint/ban-types
 export type ValidationCategory = 'fast' | 'slow' | 'built-in' | (string & {});
 
 export namespace ValidationCategory {


### PR DESCRIPTION
Langium provides by default 3 pre-defined validation categories: `fast`, `slow` and `built-in`.

This PR allow to register custom/user categories, see #1834.

It is the user responsibility to trigger these checks.