### PR TITLE
provide hover documentation on keywords

### DIFF
--- a/packages/langium/src/lsp/hover-provider.ts
+++ b/packages/langium/src/lsp/hover-provider.ts
@@ -14,6 +14,9 @@ import type { MaybePromise } from '../utils/promise-utils.js';
 import type { LangiumDocument } from '../workspace/documents.js';
 import type { DocumentationProvider } from '../documentation/documentation-provider.js';
 import { findDeclarationNodeAtOffset } from '../utils/cst-utils.js';
+import { isKeyword } from '../languages/generated/ast.js';
+import { createLangiumGrammarServices } from '../grammar/langium-grammar-module.js';
+import { EmptyFileSystem } from '../workspace/file-system-provider.js';
 
 /**
  * Language-specific service for handling hover requests.
@@ -32,10 +35,12 @@ export abstract class AstNodeHoverProvider implements HoverProvider {
 
     protected readonly references: References;
     protected readonly grammarConfig: GrammarConfig;
+    protected readonly grammarDocumentationProvider: DocumentationProvider;
 
     constructor(services: LangiumServices) {
         this.references = services.references.References;
         this.grammarConfig = services.parser.GrammarConfig;
+        this.grammarDocumentationProvider = createLangiumGrammarServices(EmptyFileSystem).grammar.documentation.DocumentationProvider;
     }
 
     getHoverContent(document: LangiumDocument, params: HoverParams): MaybePromise<Hover | undefined> {
@@ -48,6 +53,11 @@ export abstract class AstNodeHoverProvider implements HoverProvider {
                 if (targetNode) {
                     return this.getAstNodeHoverContent(targetNode);
                 }
+
+                // Add support for documentation on keywords
+                if (isKeyword(cstNode.grammarSource)) {
+                    return this.getGrammarAstNodeHoverContent(cstNode.grammarSource);
+                }
             }
         }
         return undefined;
@@ -55,6 +65,19 @@ export abstract class AstNodeHoverProvider implements HoverProvider {
 
     protected abstract getAstNodeHoverContent(node: AstNode): MaybePromise<Hover | undefined>;
 
+    protected  getGrammarAstNodeHoverContent(node: AstNode): MaybePromise<Hover | undefined> {
+        const content = this.grammarDocumentationProvider.getDocumentation(node);
+
+        if (content) {
+            return {
+                contents: {
+                    kind: 'markdown',
+                    value: content
+                }
+            };
+        }
+        return undefined;
+    }
 }
 
 export class MultilineCommentHoverProvider extends AstNodeHoverProvider {


### PR DESCRIPTION
Few months ago I posted #1603 to provide hover on keywords.

It was not working when the user ML_COMMENT rule was different from the Langium grammar (`'/*'->'*/'`).

This PR solves this limitation and enable by default hover on keywords.

The documentation prefixing a keyword in the grammar will be available when hovering on these keywords in the user language.

in grammar:
```
entry Element: 
    /** documentation of the element keyword */ 
    'element' name=ID ;
```

in the user language:
```
element a_name
```
The hover information on `element` keyword will be `documentation of the element keyword ` .

