### PR TITLE
avoid names collisions between ast and langium

### DIFF
--- a/examples/arithmetics/src/language-server/generated/ast.ts
+++ b/examples/arithmetics/src/language-server/generated/ast.ts
@@ -4,8 +4,7 @@
  ******************************************************************************/
 
 /* eslint-disable */
-import type { AstNode, Reference, ReferenceInfo, TypeMetaData } from 'langium';
-import { AbstractAstReflection } from 'langium';
+import * as langium from 'langium';
 
 export const ArithmeticsTerminals = {
     WS: /\s+/,
@@ -58,7 +57,7 @@ export function isStatement(item: unknown): item is Statement {
     return reflection.isInstance(item, Statement);
 }
 
-export interface BinaryExpression extends AstNode {
+export interface BinaryExpression extends langium.AstNode {
     readonly $container: BinaryExpression | Definition | Evaluation | FunctionCall;
     readonly $type: 'BinaryExpression';
     left: Expression;
@@ -72,7 +71,7 @@ export function isBinaryExpression(item: unknown): item is BinaryExpression {
     return reflection.isInstance(item, BinaryExpression);
 }
 
-export interface DeclaredParameter extends AstNode {
+export interface DeclaredParameter extends langium.AstNode {
     readonly $container: Definition;
     readonly $type: 'DeclaredParameter';
     name: string;
@@ -84,7 +83,7 @@ export function isDeclaredParameter(item: unknown): item is DeclaredParameter {
     return reflection.isInstance(item, DeclaredParameter);
 }
 
-export interface Definition extends AstNode {
+export interface Definition extends langium.AstNode {
     readonly $container: Module;
     readonly $type: 'Definition';
     args: Array<DeclaredParameter>;
@@ -98,7 +97,7 @@ export function isDefinition(item: unknown): item is Definition {
     return reflection.isInstance(item, Definition);
 }
 
-export interface Evaluation extends AstNode {
+export interface Evaluation extends langium.AstNode {
     readonly $container: Module;
     readonly $type: 'Evaluation';
     expression: Expression;
@@ -110,11 +109,11 @@ export function isEvaluation(item: unknown): item is Evaluation {
     return reflection.isInstance(item, Evaluation);
 }
 
-export interface FunctionCall extends AstNode {
+export interface FunctionCall extends langium.AstNode {
     readonly $container: BinaryExpression | Definition | Evaluation | FunctionCall;
     readonly $type: 'FunctionCall';
     args: Array<Expression>;
-    func: Reference<AbstractDefinition>;
+    func: langium.Reference<AbstractDefinition>;
 }
 
 export const FunctionCall = 'FunctionCall';
@@ -123,7 +122,7 @@ export function isFunctionCall(item: unknown): item is FunctionCall {
     return reflection.isInstance(item, FunctionCall);
 }
 
-export interface Module extends AstNode {
+export interface Module extends langium.AstNode {
     readonly $type: 'Module';
     name: string;
     statements: Array<Statement>;
@@ -135,7 +134,7 @@ export function isModule(item: unknown): item is Module {
     return reflection.isInstance(item, Module);
 }
 
-export interface NumberLiteral extends AstNode {
+export interface NumberLiteral extends langium.AstNode {
     readonly $container: BinaryExpression | Definition | Evaluation | FunctionCall;
     readonly $type: 'NumberLiteral';
     value: number;
@@ -160,7 +159,7 @@ export type ArithmeticsAstType = {
     Statement: Statement
 }
 
-export class ArithmeticsAstReflection extends AbstractAstReflection {
+export class ArithmeticsAstReflection extends langium.AbstractAstReflection {
 
     getAllTypes(): string[] {
         return [AbstractDefinition, BinaryExpression, DeclaredParameter, Definition, Evaluation, Expression, FunctionCall, Module, NumberLiteral, Statement];
@@ -188,7 +187,7 @@ export class ArithmeticsAstReflection extends AbstractAstReflection {
         }
     }
 
-    getReferenceType(refInfo: ReferenceInfo): string {
+    getReferenceType(refInfo: langium.ReferenceInfo): string {
         const referenceId = `${refInfo.container.$type}:${refInfo.property}`;
         switch (referenceId) {
             case 'FunctionCall:func': {
@@ -200,7 +199,7 @@ export class ArithmeticsAstReflection extends AbstractAstReflection {
         }
     }
 
-    getTypeMetaData(type: string): TypeMetaData {
+    getTypeMetaData(type: string): langium.TypeMetaData {
         switch (type) {
             case BinaryExpression: {
                 return {

--- a/examples/domainmodel/src/language-server/generated/ast.ts
+++ b/examples/domainmodel/src/language-server/generated/ast.ts
@@ -4,8 +4,7 @@
  ******************************************************************************/
 
 /* eslint-disable */
-import type { AstNode, Reference, ReferenceInfo, TypeMetaData } from 'langium';
-import { AbstractAstReflection } from 'langium';
+import * as langium from 'langium';
 
 export const DomainModelTerminals = {
     WS: /\s+/,
@@ -51,7 +50,7 @@ export function isType(item: unknown): item is Type {
     return reflection.isInstance(item, Type);
 }
 
-export interface DataType extends AstNode {
+export interface DataType extends langium.AstNode {
     readonly $container: Domainmodel | PackageDeclaration;
     readonly $type: 'DataType';
     name: string;
@@ -63,7 +62,7 @@ export function isDataType(item: unknown): item is DataType {
     return reflection.isInstance(item, DataType);
 }
 
-export interface Domainmodel extends AstNode {
+export interface Domainmodel extends langium.AstNode {
     readonly $type: 'Domainmodel';
     elements: Array<AbstractElement>;
 }
@@ -74,12 +73,12 @@ export function isDomainmodel(item: unknown): item is Domainmodel {
     return reflection.isInstance(item, Domainmodel);
 }
 
-export interface Entity extends AstNode {
+export interface Entity extends langium.AstNode {
     readonly $container: Domainmodel | PackageDeclaration;
     readonly $type: 'Entity';
     features: Array<Feature>;
     name: string;
-    superType?: Reference<Entity>;
+    superType?: langium.Reference<Entity>;
 }
 
 export const Entity = 'Entity';
@@ -88,12 +87,12 @@ export function isEntity(item: unknown): item is Entity {
     return reflection.isInstance(item, Entity);
 }
 
-export interface Feature extends AstNode {
+export interface Feature extends langium.AstNode {
     readonly $container: Entity;
     readonly $type: 'Feature';
     many: boolean;
     name: string;
-    type: Reference<Type>;
+    type: langium.Reference<Type>;
 }
 
 export const Feature = 'Feature';
@@ -102,7 +101,7 @@ export function isFeature(item: unknown): item is Feature {
     return reflection.isInstance(item, Feature);
 }
 
-export interface PackageDeclaration extends AstNode {
+export interface PackageDeclaration extends langium.AstNode {
     readonly $container: Domainmodel | PackageDeclaration;
     readonly $type: 'PackageDeclaration';
     elements: Array<AbstractElement>;
@@ -125,7 +124,7 @@ export type DomainModelAstType = {
     Type: Type
 }
 
-export class DomainModelAstReflection extends AbstractAstReflection {
+export class DomainModelAstReflection extends langium.AbstractAstReflection {
 
     getAllTypes(): string[] {
         return [AbstractElement, DataType, Domainmodel, Entity, Feature, PackageDeclaration, Type];
@@ -147,7 +146,7 @@ export class DomainModelAstReflection extends AbstractAstReflection {
         }
     }
 
-    getReferenceType(refInfo: ReferenceInfo): string {
+    getReferenceType(refInfo: langium.ReferenceInfo): string {
         const referenceId = `${refInfo.container.$type}:${refInfo.property}`;
         switch (referenceId) {
             case 'Entity:superType': {
@@ -162,7 +161,7 @@ export class DomainModelAstReflection extends AbstractAstReflection {
         }
     }
 
-    getTypeMetaData(type: string): TypeMetaData {
+    getTypeMetaData(type: string): langium.TypeMetaData {
         switch (type) {
             case DataType: {
                 return {

--- a/examples/requirements/src/language-server/generated/ast.ts
+++ b/examples/requirements/src/language-server/generated/ast.ts
@@ -4,8 +4,7 @@
  ******************************************************************************/
 
 /* eslint-disable */
-import type { AstNode, Reference, ReferenceInfo, TypeMetaData } from 'langium';
-import { AbstractAstReflection } from 'langium';
+import * as langium from 'langium';
 
 export const RequirementsAndTestsTerminals = {
     WS: /\s+/,
@@ -32,7 +31,7 @@ export type RequirementsAndTestsKeywordNames =
 
 export type RequirementsAndTestsTokenNames = RequirementsAndTestsTerminalNames | RequirementsAndTestsKeywordNames;
 
-export interface Contact extends AstNode {
+export interface Contact extends langium.AstNode {
     readonly $container: RequirementModel | TestModel;
     readonly $type: 'Contact';
     user_name: string;
@@ -44,7 +43,7 @@ export function isContact(item: unknown): item is Contact {
     return reflection.isInstance(item, Contact);
 }
 
-export interface Environment extends AstNode {
+export interface Environment extends langium.AstNode {
     readonly $container: RequirementModel;
     readonly $type: 'Environment';
     description: string;
@@ -57,10 +56,10 @@ export function isEnvironment(item: unknown): item is Environment {
     return reflection.isInstance(item, Environment);
 }
 
-export interface Requirement extends AstNode {
+export interface Requirement extends langium.AstNode {
     readonly $container: RequirementModel;
     readonly $type: 'Requirement';
-    environments: Array<Reference<Environment>>;
+    environments: Array<langium.Reference<Environment>>;
     name: string;
     text: string;
 }
@@ -71,7 +70,7 @@ export function isRequirement(item: unknown): item is Requirement {
     return reflection.isInstance(item, Requirement);
 }
 
-export interface RequirementModel extends AstNode {
+export interface RequirementModel extends langium.AstNode {
     readonly $type: 'RequirementModel';
     contact?: Contact;
     environments: Array<Environment>;
@@ -84,12 +83,12 @@ export function isRequirementModel(item: unknown): item is RequirementModel {
     return reflection.isInstance(item, RequirementModel);
 }
 
-export interface Test extends AstNode {
+export interface Test extends langium.AstNode {
     readonly $container: TestModel;
     readonly $type: 'Test';
-    environments: Array<Reference<Environment>>;
+    environments: Array<langium.Reference<Environment>>;
     name: string;
-    requirements: Array<Reference<Requirement>>;
+    requirements: Array<langium.Reference<Requirement>>;
     testFile?: string;
 }
 
@@ -99,7 +98,7 @@ export function isTest(item: unknown): item is Test {
     return reflection.isInstance(item, Test);
 }
 
-export interface TestModel extends AstNode {
+export interface TestModel extends langium.AstNode {
     readonly $type: 'TestModel';
     contact?: Contact;
     tests: Array<Test>;
@@ -120,7 +119,7 @@ export type RequirementsAndTestsAstType = {
     TestModel: TestModel
 }
 
-export class RequirementsAndTestsAstReflection extends AbstractAstReflection {
+export class RequirementsAndTestsAstReflection extends langium.AbstractAstReflection {
 
     getAllTypes(): string[] {
         return [Contact, Environment, Requirement, RequirementModel, Test, TestModel];
@@ -134,7 +133,7 @@ export class RequirementsAndTestsAstReflection extends AbstractAstReflection {
         }
     }
 
-    getReferenceType(refInfo: ReferenceInfo): string {
+    getReferenceType(refInfo: langium.ReferenceInfo): string {
         const referenceId = `${refInfo.container.$type}:${refInfo.property}`;
         switch (referenceId) {
             case 'Requirement:environments':
@@ -150,7 +149,7 @@ export class RequirementsAndTestsAstReflection extends AbstractAstReflection {
         }
     }
 
-    getTypeMetaData(type: string): TypeMetaData {
+    getTypeMetaData(type: string): langium.TypeMetaData {
         switch (type) {
             case Contact: {
                 return {

--- a/examples/statemachine/src/language-server/generated/ast.ts
+++ b/examples/statemachine/src/language-server/generated/ast.ts
@@ -4,8 +4,7 @@
  ******************************************************************************/
 
 /* eslint-disable */
-import type { AstNode, Reference, ReferenceInfo, TypeMetaData } from 'langium';
-import { AbstractAstReflection } from 'langium';
+import * as langium from 'langium';
 
 export const StatemachineTerminals = {
     WS: /\s+/,
@@ -30,7 +29,7 @@ export type StatemachineKeywordNames =
 
 export type StatemachineTokenNames = StatemachineTerminalNames | StatemachineKeywordNames;
 
-export interface Command extends AstNode {
+export interface Command extends langium.AstNode {
     readonly $container: Statemachine;
     readonly $type: 'Command';
     name: string;
@@ -42,7 +41,7 @@ export function isCommand(item: unknown): item is Command {
     return reflection.isInstance(item, Command);
 }
 
-export interface Event extends AstNode {
+export interface Event extends langium.AstNode {
     readonly $container: Statemachine;
     readonly $type: 'Event';
     name: string;
@@ -54,10 +53,10 @@ export function isEvent(item: unknown): item is Event {
     return reflection.isInstance(item, Event);
 }
 
-export interface State extends AstNode {
+export interface State extends langium.AstNode {
     readonly $container: Statemachine;
     readonly $type: 'State';
-    actions: Array<Reference<Command>>;
+    actions: Array<langium.Reference<Command>>;
     name: string;
     transitions: Array<Transition>;
 }
@@ -68,11 +67,11 @@ export function isState(item: unknown): item is State {
     return reflection.isInstance(item, State);
 }
 
-export interface Statemachine extends AstNode {
+export interface Statemachine extends langium.AstNode {
     readonly $type: 'Statemachine';
     commands: Array<Command>;
     events: Array<Event>;
-    init: Reference<State>;
+    init: langium.Reference<State>;
     name: string;
     states: Array<State>;
 }
@@ -83,11 +82,11 @@ export function isStatemachine(item: unknown): item is Statemachine {
     return reflection.isInstance(item, Statemachine);
 }
 
-export interface Transition extends AstNode {
+export interface Transition extends langium.AstNode {
     readonly $container: State;
     readonly $type: 'Transition';
-    event: Reference<Event>;
-    state: Reference<State>;
+    event: langium.Reference<Event>;
+    state: langium.Reference<State>;
 }
 
 export const Transition = 'Transition';
@@ -104,7 +103,7 @@ export type StatemachineAstType = {
     Transition: Transition
 }
 
-export class StatemachineAstReflection extends AbstractAstReflection {
+export class StatemachineAstReflection extends langium.AbstractAstReflection {
 
     getAllTypes(): string[] {
         return [Command, Event, State, Statemachine, Transition];
@@ -118,7 +117,7 @@ export class StatemachineAstReflection extends AbstractAstReflection {
         }
     }
 
-    getReferenceType(refInfo: ReferenceInfo): string {
+    getReferenceType(refInfo: langium.ReferenceInfo): string {
         const referenceId = `${refInfo.container.$type}:${refInfo.property}`;
         switch (referenceId) {
             case 'State:actions': {
@@ -137,7 +136,7 @@ export class StatemachineAstReflection extends AbstractAstReflection {
         }
     }
 
-    getTypeMetaData(type: string): TypeMetaData {
+    getTypeMetaData(type: string): langium.TypeMetaData {
         switch (type) {
             case Command: {
                 return {

--- a/packages/langium-cli/test/generator/ast-generator.test.ts
+++ b/packages/langium-cli/test/generator/ast-generator.test.ts
@@ -174,7 +174,7 @@ describe('Ast generator', () => {
 
         hidden terminal WS: /\\s+/;
     `, expandToString`
-        export interface Test extends AstNode {
+        export interface Test extends langium.AstNode {
             readonly $type: 'Test';
             value: '\\\'test\\\'';
         }
@@ -216,7 +216,7 @@ describe('Ast generator', () => {
             return typeof item === 'number';
         }
 
-        export interface Node extends AstNode {
+        export interface Node extends langium.AstNode {
             readonly $type: 'Node';
             num: A;
         }
@@ -243,7 +243,7 @@ describe('Ast generator', () => {
             return typeof item === 'number';
         }
 
-        export interface Node extends AstNode {
+        export interface Node extends langium.AstNode {
             readonly $type: 'Node';
             num: Array<A>;
         }
@@ -376,7 +376,7 @@ describe('Ast generator', () => {
         hidden terminal WS: /\\s+/;
         terminal ID: /[_a-zA-Z][\\w_]*/;
     `, expandToString`
-        getTypeMetaData(type: string): TypeMetaData {
+        getTypeMetaData(type: string): langium.TypeMetaData {
                 switch (type) {
                     case IAmArray: {
                         return {
@@ -418,7 +418,7 @@ describe('Ast generator', () => {
         hidden terminal WS: /\\s+/;
         terminal ID: /[_a-zA-Z][\\w_]*/;
     `, expandToString`
-        getTypeMetaData(type: string): TypeMetaData {
+        getTypeMetaData(type: string): langium.TypeMetaData {
                 switch (type) {
                     case Test: {
                         return {

--- a/packages/langium/src/grammar/type-system/type-collector/types.ts
+++ b/packages/langium/src/grammar/type-system/type-collector/types.ts
@@ -220,7 +220,7 @@ export class InterfaceType {
 
     toAstTypesString(reflectionInfo: boolean): string {
         const interfaceSuperTypes = this.interfaceSuperTypes.map(e => e.name);
-        const superTypes = interfaceSuperTypes.length > 0 ? distinctAndSorted([...interfaceSuperTypes]) : ['AstNode'];
+        const superTypes = interfaceSuperTypes.length > 0 ? distinctAndSorted([...interfaceSuperTypes]) : ['langium.AstNode'];
         const interfaceNode = expandToNode`
             export interface ${this.name} extends ${superTypes.join(', ')} {
         `.appendNewLine();
@@ -379,7 +379,7 @@ export function propertyTypeToString(type?: PropertyType, mode: 'AstType' | 'Dec
     }
     if (isReferenceType(type)) {
         const refType = propertyTypeToString(type.referenceType, mode);
-        return mode === 'AstType' ? `Reference<${refType}>` : `@${typeParenthesis(type.referenceType, refType)}`;
+        return mode === 'AstType' ? `langium.Reference<${refType}>` : `@${typeParenthesis(type.referenceType, refType)}`;
     } else if (isArrayType(type)) {
         const arrayType = propertyTypeToString(type.elementType, mode);
         return mode === 'AstType' ? `Array<${arrayType}>` : `${type.elementType ? typeParenthesis(type.elementType, arrayType) : 'unknown'}[]`;

--- a/packages/langium/src/grammar/validation/validator.ts
+++ b/packages/langium/src/grammar/validation/validator.ts
@@ -1168,7 +1168,8 @@ const reservedNames = new Set([
     'Date',
     'Intl',
     'eval',
-    'undefined'
+    'undefined',
+    'langium'
 ]);
 
 function checkTypeUnionContainsOnlyParseRules(type: ast.UnionType): string[] {

--- a/packages/langium/src/languages/generated/ast.ts
+++ b/packages/langium/src/languages/generated/ast.ts
@@ -4,8 +4,7 @@
  ******************************************************************************/
 
 /* eslint-disable */
-import type { AstNode, Reference, ReferenceInfo, TypeMetaData } from '../../syntax-tree.js';
-import { AbstractAstReflection } from '../../syntax-tree.js';
+import * as langium from '../../syntax-tree.js';
 
 export const LangiumGrammarTerminals = {
     ID: /\^?[_a-zA-Z][\w_]*/,
@@ -125,7 +124,7 @@ export function isValueLiteral(item: unknown): item is ValueLiteral {
     return reflection.isInstance(item, ValueLiteral);
 }
 
-export interface AbstractElement extends AstNode {
+export interface AbstractElement extends langium.AstNode {
     readonly $type: 'AbstractElement' | 'Action' | 'Alternatives' | 'Assignment' | 'CharacterRange' | 'CrossReference' | 'EndOfFile' | 'Group' | 'Keyword' | 'NegatedToken' | 'RegexToken' | 'RuleCall' | 'TerminalAlternatives' | 'TerminalGroup' | 'TerminalRuleCall' | 'UnorderedGroup' | 'UntilToken' | 'Wildcard';
     cardinality?: '*' | '+' | '?';
     lookahead?: '?!' | '?<!' | '?<=' | '?=';
@@ -137,7 +136,7 @@ export function isAbstractElement(item: unknown): item is AbstractElement {
     return reflection.isInstance(item, AbstractElement);
 }
 
-export interface ArrayLiteral extends AstNode {
+export interface ArrayLiteral extends langium.AstNode {
     readonly $container: ArrayLiteral | TypeAttribute;
     readonly $type: 'ArrayLiteral';
     elements: Array<ValueLiteral>;
@@ -149,7 +148,7 @@ export function isArrayLiteral(item: unknown): item is ArrayLiteral {
     return reflection.isInstance(item, ArrayLiteral);
 }
 
-export interface ArrayType extends AstNode {
+export interface ArrayType extends langium.AstNode {
     readonly $container: ArrayType | ReferenceType | Type | TypeAttribute | UnionType;
     readonly $type: 'ArrayType';
     elementType: TypeDefinition;
@@ -161,7 +160,7 @@ export function isArrayType(item: unknown): item is ArrayType {
     return reflection.isInstance(item, ArrayType);
 }
 
-export interface BooleanLiteral extends AstNode {
+export interface BooleanLiteral extends langium.AstNode {
     readonly $container: ArrayLiteral | Conjunction | Disjunction | Group | NamedArgument | Negation | TypeAttribute;
     readonly $type: 'BooleanLiteral';
     true: boolean;
@@ -173,7 +172,7 @@ export function isBooleanLiteral(item: unknown): item is BooleanLiteral {
     return reflection.isInstance(item, BooleanLiteral);
 }
 
-export interface Conjunction extends AstNode {
+export interface Conjunction extends langium.AstNode {
     readonly $container: Conjunction | Disjunction | Group | NamedArgument | Negation;
     readonly $type: 'Conjunction';
     left: Condition;
@@ -186,7 +185,7 @@ export function isConjunction(item: unknown): item is Conjunction {
     return reflection.isInstance(item, Conjunction);
 }
 
-export interface Disjunction extends AstNode {
+export interface Disjunction extends langium.AstNode {
     readonly $container: Conjunction | Disjunction | Group | NamedArgument | Negation;
     readonly $type: 'Disjunction';
     left: Condition;
@@ -199,17 +198,17 @@ export function isDisjunction(item: unknown): item is Disjunction {
     return reflection.isInstance(item, Disjunction);
 }
 
-export interface Grammar extends AstNode {
+export interface Grammar extends langium.AstNode {
     readonly $type: 'Grammar';
     definesHiddenTokens: boolean;
-    hiddenTokens: Array<Reference<AbstractRule>>;
+    hiddenTokens: Array<langium.Reference<AbstractRule>>;
     imports: Array<GrammarImport>;
     interfaces: Array<Interface>;
     isDeclared: boolean;
     name?: string;
     rules: Array<AbstractRule>;
     types: Array<Type>;
-    usedGrammars: Array<Reference<Grammar>>;
+    usedGrammars: Array<langium.Reference<Grammar>>;
 }
 
 export const Grammar = 'Grammar';
@@ -218,7 +217,7 @@ export function isGrammar(item: unknown): item is Grammar {
     return reflection.isInstance(item, Grammar);
 }
 
-export interface GrammarImport extends AstNode {
+export interface GrammarImport extends langium.AstNode {
     readonly $container: Grammar;
     readonly $type: 'GrammarImport';
     path: string;
@@ -230,7 +229,7 @@ export function isGrammarImport(item: unknown): item is GrammarImport {
     return reflection.isInstance(item, GrammarImport);
 }
 
-export interface InferredType extends AstNode {
+export interface InferredType extends langium.AstNode {
     readonly $container: Action | ParserRule;
     readonly $type: 'InferredType';
     name: string;
@@ -242,12 +241,12 @@ export function isInferredType(item: unknown): item is InferredType {
     return reflection.isInstance(item, InferredType);
 }
 
-export interface Interface extends AstNode {
+export interface Interface extends langium.AstNode {
     readonly $container: Grammar;
     readonly $type: 'Interface';
     attributes: Array<TypeAttribute>;
     name: string;
-    superTypes: Array<Reference<AbstractType>>;
+    superTypes: Array<langium.Reference<AbstractType>>;
 }
 
 export const Interface = 'Interface';
@@ -256,11 +255,11 @@ export function isInterface(item: unknown): item is Interface {
     return reflection.isInstance(item, Interface);
 }
 
-export interface NamedArgument extends AstNode {
+export interface NamedArgument extends langium.AstNode {
     readonly $container: RuleCall;
     readonly $type: 'NamedArgument';
     calledByName: boolean;
-    parameter?: Reference<Parameter>;
+    parameter?: langium.Reference<Parameter>;
     value: Condition;
 }
 
@@ -270,7 +269,7 @@ export function isNamedArgument(item: unknown): item is NamedArgument {
     return reflection.isInstance(item, NamedArgument);
 }
 
-export interface Negation extends AstNode {
+export interface Negation extends langium.AstNode {
     readonly $container: Conjunction | Disjunction | Group | NamedArgument | Negation;
     readonly $type: 'Negation';
     value: Condition;
@@ -282,7 +281,7 @@ export function isNegation(item: unknown): item is Negation {
     return reflection.isInstance(item, Negation);
 }
 
-export interface NumberLiteral extends AstNode {
+export interface NumberLiteral extends langium.AstNode {
     readonly $container: ArrayLiteral | TypeAttribute;
     readonly $type: 'NumberLiteral';
     value: number;
@@ -294,7 +293,7 @@ export function isNumberLiteral(item: unknown): item is NumberLiteral {
     return reflection.isInstance(item, NumberLiteral);
 }
 
-export interface Parameter extends AstNode {
+export interface Parameter extends langium.AstNode {
     readonly $container: ParserRule;
     readonly $type: 'Parameter';
     name: string;
@@ -306,10 +305,10 @@ export function isParameter(item: unknown): item is Parameter {
     return reflection.isInstance(item, Parameter);
 }
 
-export interface ParameterReference extends AstNode {
+export interface ParameterReference extends langium.AstNode {
     readonly $container: Conjunction | Disjunction | Group | NamedArgument | Negation;
     readonly $type: 'ParameterReference';
-    parameter: Reference<Parameter>;
+    parameter: langium.Reference<Parameter>;
 }
 
 export const ParameterReference = 'ParameterReference';
@@ -318,7 +317,7 @@ export function isParameterReference(item: unknown): item is ParameterReference 
     return reflection.isInstance(item, ParameterReference);
 }
 
-export interface ParserRule extends AstNode {
+export interface ParserRule extends langium.AstNode {
     readonly $container: Grammar;
     readonly $type: 'ParserRule';
     dataType?: PrimitiveType;
@@ -326,11 +325,11 @@ export interface ParserRule extends AstNode {
     definition: AbstractElement;
     entry: boolean;
     fragment: boolean;
-    hiddenTokens: Array<Reference<AbstractRule>>;
+    hiddenTokens: Array<langium.Reference<AbstractRule>>;
     inferredType?: InferredType;
     name: string;
     parameters: Array<Parameter>;
-    returnType?: Reference<AbstractType>;
+    returnType?: langium.Reference<AbstractType>;
     wildcard: boolean;
 }
 
@@ -340,7 +339,7 @@ export function isParserRule(item: unknown): item is ParserRule {
     return reflection.isInstance(item, ParserRule);
 }
 
-export interface ReferenceType extends AstNode {
+export interface ReferenceType extends langium.AstNode {
     readonly $container: ArrayType | ReferenceType | Type | TypeAttribute | UnionType;
     readonly $type: 'ReferenceType';
     referenceType: TypeDefinition;
@@ -352,7 +351,7 @@ export function isReferenceType(item: unknown): item is ReferenceType {
     return reflection.isInstance(item, ReferenceType);
 }
 
-export interface ReturnType extends AstNode {
+export interface ReturnType extends langium.AstNode {
     readonly $container: TerminalRule;
     readonly $type: 'ReturnType';
     name: PrimitiveType | string;
@@ -364,12 +363,12 @@ export function isReturnType(item: unknown): item is ReturnType {
     return reflection.isInstance(item, ReturnType);
 }
 
-export interface SimpleType extends AstNode {
+export interface SimpleType extends langium.AstNode {
     readonly $container: ArrayType | ReferenceType | Type | TypeAttribute | UnionType;
     readonly $type: 'SimpleType';
     primitiveType?: PrimitiveType;
     stringType?: string;
-    typeRef?: Reference<AbstractType>;
+    typeRef?: langium.Reference<AbstractType>;
 }
 
 export const SimpleType = 'SimpleType';
@@ -378,7 +377,7 @@ export function isSimpleType(item: unknown): item is SimpleType {
     return reflection.isInstance(item, SimpleType);
 }
 
-export interface StringLiteral extends AstNode {
+export interface StringLiteral extends langium.AstNode {
     readonly $container: ArrayLiteral | TypeAttribute;
     readonly $type: 'StringLiteral';
     value: string;
@@ -390,7 +389,7 @@ export function isStringLiteral(item: unknown): item is StringLiteral {
     return reflection.isInstance(item, StringLiteral);
 }
 
-export interface TerminalRule extends AstNode {
+export interface TerminalRule extends langium.AstNode {
     readonly $container: Grammar;
     readonly $type: 'TerminalRule';
     definition: AbstractElement;
@@ -406,7 +405,7 @@ export function isTerminalRule(item: unknown): item is TerminalRule {
     return reflection.isInstance(item, TerminalRule);
 }
 
-export interface Type extends AstNode {
+export interface Type extends langium.AstNode {
     readonly $container: Grammar;
     readonly $type: 'Type';
     name: string;
@@ -419,7 +418,7 @@ export function isType(item: unknown): item is Type {
     return reflection.isInstance(item, Type);
 }
 
-export interface TypeAttribute extends AstNode {
+export interface TypeAttribute extends langium.AstNode {
     readonly $container: Interface;
     readonly $type: 'TypeAttribute';
     defaultValue?: ValueLiteral;
@@ -434,7 +433,7 @@ export function isTypeAttribute(item: unknown): item is TypeAttribute {
     return reflection.isInstance(item, TypeAttribute);
 }
 
-export interface UnionType extends AstNode {
+export interface UnionType extends langium.AstNode {
     readonly $container: ArrayType | ReferenceType | Type | TypeAttribute | UnionType;
     readonly $type: 'UnionType';
     types: Array<TypeDefinition>;
@@ -451,7 +450,7 @@ export interface Action extends AbstractElement {
     feature?: FeatureName;
     inferredType?: InferredType;
     operator?: '+=' | '=';
-    type?: Reference<AbstractType>;
+    type?: langium.Reference<AbstractType>;
 }
 
 export const Action = 'Action';
@@ -500,7 +499,7 @@ export interface CrossReference extends AbstractElement {
     readonly $type: 'CrossReference';
     deprecatedSyntax: boolean;
     terminal?: AbstractElement;
-    type: Reference<AbstractType>;
+    type: langium.Reference<AbstractType>;
 }
 
 export const CrossReference = 'CrossReference';
@@ -568,7 +567,7 @@ export function isRegexToken(item: unknown): item is RegexToken {
 export interface RuleCall extends AbstractElement {
     readonly $type: 'RuleCall';
     arguments: Array<NamedArgument>;
-    rule: Reference<AbstractRule>;
+    rule: langium.Reference<AbstractRule>;
 }
 
 export const RuleCall = 'RuleCall';
@@ -601,7 +600,7 @@ export function isTerminalGroup(item: unknown): item is TerminalGroup {
 
 export interface TerminalRuleCall extends AbstractElement {
     readonly $type: 'TerminalRuleCall';
-    rule: Reference<TerminalRule>;
+    rule: langium.Reference<TerminalRule>;
 }
 
 export const TerminalRuleCall = 'TerminalRuleCall';
@@ -691,7 +690,7 @@ export type LangiumGrammarAstType = {
     Wildcard: Wildcard
 }
 
-export class LangiumGrammarAstReflection extends AbstractAstReflection {
+export class LangiumGrammarAstReflection extends langium.AbstractAstReflection {
 
     getAllTypes(): string[] {
         return [AbstractElement, AbstractRule, AbstractType, Action, Alternatives, ArrayLiteral, ArrayType, Assignment, BooleanLiteral, CharacterRange, Condition, Conjunction, CrossReference, Disjunction, EndOfFile, Grammar, GrammarImport, Group, InferredType, Interface, Keyword, NamedArgument, NegatedToken, Negation, NumberLiteral, Parameter, ParameterReference, ParserRule, ReferenceType, RegexToken, ReturnType, RuleCall, SimpleType, StringLiteral, TerminalAlternatives, TerminalGroup, TerminalRule, TerminalRuleCall, Type, TypeAttribute, TypeDefinition, UnionType, UnorderedGroup, UntilToken, ValueLiteral, Wildcard];
@@ -755,7 +754,7 @@ export class LangiumGrammarAstReflection extends AbstractAstReflection {
         }
     }
 
-    getReferenceType(refInfo: ReferenceInfo): string {
+    getReferenceType(refInfo: langium.ReferenceInfo): string {
         const referenceId = `${refInfo.container.$type}:${refInfo.property}`;
         switch (referenceId) {
             case 'Action:type':
@@ -786,7 +785,7 @@ export class LangiumGrammarAstReflection extends AbstractAstReflection {
         }
     }
 
-    getTypeMetaData(type: string): TypeMetaData {
+    getTypeMetaData(type: string): langium.TypeMetaData {
         switch (type) {
             case AbstractElement: {
                 return {

--- a/packages/langium/test/grammar/type-system/inferred-types.test.ts
+++ b/packages/langium/test/grammar/type-system/inferred-types.test.ts
@@ -24,19 +24,19 @@ describe('Inferred types', () => {
             terminal ID returns string: /string/;
             terminal NUMBER returns number: /number/;
         `, expandToString`
-            export interface A extends AstNode {
+            export interface A extends langium.AstNode {
                 readonly $type: 'A';
                 name: string;
                 value?: number;
             }
-            export interface B extends AstNode {
+            export interface B extends langium.AstNode {
                 readonly $type: 'B';
                 name: FQN;
                 values: Array<number>;
             }
-            export interface C extends AstNode {
+            export interface C extends langium.AstNode {
                 readonly $type: 'C';
-                ref: Reference<A>;
+                ref: langium.Reference<A>;
             }
             export type FQN = string;
         `);
@@ -53,11 +53,11 @@ describe('Inferred types', () => {
             terminal ID returns string: /string/;
             terminal NUMBER returns number: /number/;
         `, expandToString`
-            export interface D extends AstNode {
+            export interface D extends langium.AstNode {
                 readonly $type: 'A' | 'B' | 'D';
                 name: string;
             }
-            export interface E extends AstNode {
+            export interface E extends langium.AstNode {
                 readonly $type: 'E';
                 name?: string;
                 value?: number;
@@ -79,7 +79,7 @@ describe('Inferred types', () => {
             A<G>: a=ID (<G> b=ID);
             terminal ID returns string: /string/;
         `, expandToString`
-            export interface A extends AstNode {
+            export interface A extends langium.AstNode {
                 readonly $type: 'A';
                 a: string;
                 b?: string;
@@ -92,7 +92,7 @@ describe('Inferred types', () => {
             A: a=ID ({infer B} b=ID ({infer C} c=ID)?)? d=ID;
             terminal ID returns string: /string/;
         `, expandToString`
-            export interface A extends AstNode {
+            export interface A extends langium.AstNode {
                 readonly $type: 'A' | 'B' | 'C';
                 a: string;
                 d: string;
@@ -116,7 +116,7 @@ describe('Inferred types', () => {
             B: a=ID;
             terminal ID returns string: /string/;
         `, expandToString`
-            export interface B extends AstNode {
+            export interface B extends langium.AstNode {
                 readonly $container: B;
                 readonly $type: 'B';
                 a?: string;
@@ -132,7 +132,7 @@ describe('Inferred types', () => {
             A: value=ID ({infer A.item=current} value=ID)*;
             terminal ID returns string: /string/;
         `, expandToString`
-            export interface A extends AstNode {
+            export interface A extends langium.AstNode {
                 readonly $container: A;
                 readonly $type: 'A';
                 item?: A;
@@ -146,22 +146,22 @@ describe('Inferred types', () => {
             A: ({infer X} x=ID | {infer Y} y=ID | {infer Z} z=ID) {infer B.front=current} back=ID;
             terminal ID returns string: /string/;
         `, expandToString`
-            export interface B extends AstNode {
+            export interface B extends langium.AstNode {
                 readonly $type: 'B';
                 back: string;
                 front: X | Y | Z;
             }
-            export interface X extends AstNode {
+            export interface X extends langium.AstNode {
                 readonly $container: B;
                 readonly $type: 'X';
                 x: string;
             }
-            export interface Y extends AstNode {
+            export interface Y extends langium.AstNode {
                 readonly $container: B;
                 readonly $type: 'Y';
                 y: string;
             }
-            export interface Z extends AstNode {
+            export interface Z extends langium.AstNode {
                 readonly $container: B;
                 readonly $type: 'Z';
                 z: string;
@@ -176,7 +176,7 @@ describe('Inferred types', () => {
             B infers A: A {infer B} b=ID;
             terminal ID returns string: /string/;
         `, expandToString`
-            export interface A extends AstNode {
+            export interface A extends langium.AstNode {
                 readonly $type: 'A' | 'B';
                 a: string;
             }
@@ -211,27 +211,27 @@ describe('Inferred types', () => {
         
             terminal ID returns string: /string/;
         `, expandToString`
-            export interface Access extends AstNode {
+            export interface Access extends langium.AstNode {
                 readonly $type: 'Access';
                 member: string;
                 receiver?: Ref;
             }
-            export interface FirstBranch extends AstNode {
+            export interface FirstBranch extends langium.AstNode {
                 readonly $type: 'FirstBranch';
                 first: string;
                 value: IdRule;
             }
-            export interface IdRule extends AstNode {
+            export interface IdRule extends langium.AstNode {
                 readonly $container: FirstBranch | SecondBranch;
                 readonly $type: 'IdRule';
                 name: string;
             }
-            export interface Ref extends AstNode {
+            export interface Ref extends langium.AstNode {
                 readonly $container: Access;
                 readonly $type: 'Ref';
                 ref: string;
             }
-            export interface SecondBranch extends AstNode {
+            export interface SecondBranch extends langium.AstNode {
                 readonly $type: 'SecondBranch';
                 second: string;
                 value: IdRule;
@@ -250,7 +250,7 @@ describe('Inferred types', () => {
 
             terminal ID returns string: /string/;
         `, expandToString`
-            export interface X extends AstNode {
+            export interface X extends langium.AstNode {
                 readonly $type: 'X';
                 a: string;
                 b?: string;
@@ -269,15 +269,15 @@ describe('Inferred types', () => {
 
             terminal ID returns string: /string/;
         `, expandToString`
-            export interface A extends AstNode {
+            export interface A extends langium.AstNode {
                 readonly $type: 'A';
                 a: string;
             }
-            export interface B extends AstNode {
+            export interface B extends langium.AstNode {
                 readonly $type: 'B';
                 b: string;
             }
-            export interface C extends AstNode {
+            export interface C extends langium.AstNode {
                 readonly $container: C;
                 readonly $type: 'C' | 'Y';
                 item: Y;
@@ -328,7 +328,7 @@ describe('Inferred types', () => {
             entry X: id=ID ({infer Y} 'a' | {infer Z} 'b');
             terminal ID: /[a-zA-Z_][a-zA-Z0-9_]*/;
         `, expandToString`
-            export interface X extends AstNode {
+            export interface X extends langium.AstNode {
                 readonly $type: 'X' | 'Y' | 'Z';
                 id: string;
             }
@@ -346,11 +346,11 @@ describe('Inferred types', () => {
             entry X: {infer Y} value='Y' | Z;
             Z: value='Z';
         `, expandToString`
-            export interface Y extends AstNode {
+            export interface Y extends langium.AstNode {
                 readonly $type: 'Y';
                 value: 'Y';
             }
-            export interface Z extends AstNode {
+            export interface Z extends langium.AstNode {
                 readonly $type: 'Z';
                 value: 'Z';
             }
@@ -366,10 +366,10 @@ describe('inferred types that are used by the grammar', () => {
             hidden terminal WS: /\\s+/;
             terminal ID: /[a-zA-Z_][a-zA-Z0-9_]*/;
         `, expandToString`
-            export interface B extends AstNode {
+            export interface B extends langium.AstNode {
                 readonly $type: 'B';
                 name: string;
-                otherA?: Reference<B>;
+                otherA?: langium.Reference<B>;
             }
         `);
     });
@@ -384,7 +384,7 @@ describe('inferred and declared types', () => {
         
             interface X { }
         `, expandToString`
-            export interface X extends AstNode {
+            export interface X extends langium.AstNode {
                 readonly $type: 'X' | 'Y' | 'Z';
             }
             export interface Y extends X {
@@ -463,17 +463,17 @@ describe('expression rules with inferred and declared interfaces', () => {
     // we should fix the issue another way
     async function checkTypes(grammar: string): Promise<void> {
         await expectTypes(grammar, expandToString`
-            export interface BooleanLiteral extends AstNode {
+            export interface BooleanLiteral extends langium.AstNode {
                 readonly $container: MemberAccess;
                 readonly $type: 'BooleanLiteral';
                 value: boolean;
             }
-            export interface MemberAccess extends AstNode {
+            export interface MemberAccess extends langium.AstNode {
                 readonly $type: 'MemberAccess' | 'SuperMemberAccess';
-                member: Reference<Symbol>;
+                member: langium.Reference<Symbol>;
                 receiver: PrimaryExpression;
             }
-            export interface Symbol extends AstNode {
+            export interface Symbol extends langium.AstNode {
                 readonly $type: 'Symbol';
             }
             export interface SuperMemberAccess extends MemberAccess {
@@ -497,19 +497,19 @@ describe('types of `$container` and `$type` are correct', () => {
             interface D { a: A }
             interface E { b: B }
         `, expandToString`
-            export interface A extends AstNode {
+            export interface A extends langium.AstNode {
                 readonly $type: 'A' | 'C';
                 strA: string;
             }
-            export interface B extends AstNode {
+            export interface B extends langium.AstNode {
                 readonly $type: 'B' | 'C';
                 strB: string;
             }
-            export interface D extends AstNode {
+            export interface D extends langium.AstNode {
                 readonly $type: 'D';
                 a: A;
             }
-            export interface E extends AstNode {
+            export interface E extends langium.AstNode {
                 readonly $type: 'E';
                 b: B;
             }
@@ -530,19 +530,19 @@ describe('types of `$container` and `$type` are correct', () => {
             D: a=A;
             E: b=B;
         `, expandToString`
-            export interface A extends AstNode {
+            export interface A extends langium.AstNode {
                 readonly $type: 'A' | 'C';
                 strA: string;
             }
-            export interface B extends AstNode {
+            export interface B extends langium.AstNode {
                 readonly $type: 'B' | 'C';
                 strB: string;
             }
-            export interface D extends AstNode {
+            export interface D extends langium.AstNode {
                 readonly $type: 'D';
                 a: A;
             }
-            export interface E extends AstNode {
+            export interface E extends langium.AstNode {
                 readonly $type: 'E';
                 b: B;
             }
@@ -562,16 +562,16 @@ describe('types of `$container` and `$type` are correct', () => {
             D: 'D' a=A;
             E: 'E' b=B;
         `, expandToString`
-            export interface C extends AstNode {
+            export interface C extends langium.AstNode {
                 readonly $container: D | E;
                 readonly $type: 'C';
                 strC: string;
             }
-            export interface D extends AstNode {
+            export interface D extends langium.AstNode {
                 readonly $type: 'D';
                 a: A;
             }
-            export interface E extends AstNode {
+            export interface E extends langium.AstNode {
                 readonly $type: 'E';
                 b: B;
             }
@@ -591,29 +591,29 @@ describe('types of `$container` and `$type` are correct', () => {
             interface G { a: A }
             interface H { b: B }
         `, expandToString`
-            export interface A extends AstNode {
+            export interface A extends langium.AstNode {
                 readonly $container: E | F | G;
                 readonly $type: 'A' | 'C' | 'D';
                 strA: string;
             }
-            export interface B extends AstNode {
+            export interface B extends langium.AstNode {
                 readonly $container: E | F | H;
                 readonly $type: 'B' | 'C' | 'D';
                 strB: string;
             }
-            export interface E extends AstNode {
+            export interface E extends langium.AstNode {
                 readonly $type: 'E';
                 c: C;
             }
-            export interface F extends AstNode {
+            export interface F extends langium.AstNode {
                 readonly $type: 'F';
                 d: D;
             }
-            export interface G extends AstNode {
+            export interface G extends langium.AstNode {
                 readonly $type: 'G';
                 a: A;
             }
-            export interface H extends AstNode {
+            export interface H extends langium.AstNode {
                 readonly $type: 'H';
                 b: B;
             }
@@ -644,27 +644,27 @@ describe('types of `$container` and `$type` are correct', () => {
             interface G { a: A }
             interface H { b: B }
         `, expandToString`
-            export interface A extends AstNode {
+            export interface A extends langium.AstNode {
                 readonly $type: 'A' | 'C' | 'D' | 'X';
                 strA: string;
             }
-            export interface B extends AstNode {
+            export interface B extends langium.AstNode {
                 readonly $type: 'B' | 'C' | 'D' | 'X';
                 strB: string;
             }
-            export interface E extends AstNode {
+            export interface E extends langium.AstNode {
                 readonly $type: 'E';
                 c: C;
             }
-            export interface F extends AstNode {
+            export interface F extends langium.AstNode {
                 readonly $type: 'F';
                 d: D;
             }
-            export interface G extends AstNode {
+            export interface G extends langium.AstNode {
                 readonly $type: 'G';
                 a: A;
             }
-            export interface H extends AstNode {
+            export interface H extends langium.AstNode {
                 readonly $type: 'H';
                 b: B;
             }
@@ -697,19 +697,19 @@ describe('types of `$container` and `$type` are correct', () => {
             E: 'E' b=B;
             terminal ID: /[a-zA-Z_][a-zA-Z0-9_]*/;
         `, expandToString`
-            export interface A extends AstNode {
+            export interface A extends langium.AstNode {
                 readonly $type: 'A' | 'C';
                 strA: string;
             }
-            export interface B extends AstNode {
+            export interface B extends langium.AstNode {
                 readonly $type: 'B' | 'C';
                 strB: string;
             }
-            export interface D extends AstNode {
+            export interface D extends langium.AstNode {
                 readonly $type: 'D';
                 a: A;
             }
-            export interface E extends AstNode {
+            export interface E extends langium.AstNode {
                 readonly $type: 'E';
                 b: B;
             }
@@ -725,7 +725,7 @@ describe('types of `$container` and `$type` are correct', () => {
             interface A {}
             interface B extends A {}
         `, expandToString`
-            export interface A extends AstNode {
+            export interface A extends langium.AstNode {
                 readonly $type: 'A' | 'B';
             }
             export interface B extends A {
@@ -742,7 +742,7 @@ describe('types of `$container` and `$type` are correct', () => {
             interface X extends B {}
             interface Y extends B {}
         `, expandToString`
-            export interface A extends AstNode {
+            export interface A extends langium.AstNode {
                 readonly $type: 'A' | 'B' | 'C' | 'X' | 'Y';
             }
             export interface B extends A {
@@ -766,10 +766,10 @@ describe('types of `$container` and `$type` are correct', () => {
             interface B {}
             interface C extends B, A {}
         `, expandToString`
-            export interface A extends AstNode {
+            export interface A extends langium.AstNode {
                 readonly $type: 'A' | 'C';
             }
-            export interface B extends AstNode {
+            export interface B extends langium.AstNode {
                 readonly $type: 'B' | 'C';
             }
             export interface C extends A, B {
@@ -789,7 +789,7 @@ describe('types of `$container` and `$type` are correct', () => {
             interface G extends D {}
             interface H extends A {}
         `, expandToString`
-            export interface A extends AstNode {
+            export interface A extends langium.AstNode {
                 readonly $type: 'A' | 'B' | 'C' | 'D' | 'E' | 'F' | 'G' | 'H';
             }
             export interface B extends A {
@@ -818,7 +818,7 @@ describe('types of `$container` and `$type` are correct', () => {
 
     test('Should merge types of array properties', async () => {
         const expected = expandToString`
-            export interface A extends AstNode {
+            export interface A extends langium.AstNode {
                 readonly $type: 'A';
                 values: Array<number | string>;
             }


### PR DESCRIPTION
Closes https://github.com/eclipse-langium/langium/issues/1591

Using type names such as AstNode, Reference, ReferenceInfo or TypeMetaData in the Langium grammar generate file ast.ts with names collision between the generated ast and Langium.

This PR, in the generated ast, import langium types in the `langium` namespace: `import * as langium from 'langium'`.

The `langium` name is also added to `reservedNames` in the grammar validator.