### PR TITLE
Alternative implementation of comment generation

### DIFF
--- a/examples/statemachine/src/language-server/generated/ast.ts
+++ b/examples/statemachine/src/language-server/generated/ast.ts
@@ -42,6 +42,7 @@ export function isCommand(item: unknown): item is Command {
     return reflection.isInstance(item, Command);
 }
 
+/** An event is the trigger for a transition */
 export interface Event extends AstNode {
     readonly $container: Statemachine;
     readonly $type: 'Event';
@@ -54,11 +55,13 @@ export function isEvent(item: unknown): item is Event {
     return reflection.isInstance(item, Event);
 }
 
+/** A description of the status of a system */
 export interface State extends AstNode {
     readonly $container: Statemachine;
     readonly $type: 'State';
     actions: Array<Reference<Command>>;
     name: string;
+    /** The transitions to other states that can take place from the current one */
     transitions: Array<Transition>;
 }
 
@@ -68,12 +71,18 @@ export function isState(item: unknown): item is State {
     return reflection.isInstance(item, State);
 }
 
+/** A textual represntation of a state machine */
 export interface Statemachine extends AstNode {
     readonly $type: 'Statemachine';
     commands: Array<Command>;
+    /** The list of recognized event names */
+    /* A block comment that is not documentation */
     events: Array<Event>;
+    /** The starting state for the machine */
     init: Reference<State>;
+    /** The name of the machine */
     name: string;
+    /** Definitions of available states */
     states: Array<State>;
 }
 
@@ -83,10 +92,13 @@ export function isStatemachine(item: unknown): item is Statemachine {
     return reflection.isInstance(item, Statemachine);
 }
 
+/** A change from one state to another */
 export interface Transition extends AstNode {
     readonly $container: State;
     readonly $type: 'Transition';
+    /** The event triggering the transition */
     event: Reference<Event>;
+    /** The target state */
     state: Reference<State>;
 }
 

--- a/examples/statemachine/src/language-server/generated/grammar.ts
+++ b/examples/statemachine/src/language-server/generated/grammar.ts
@@ -21,7 +21,8 @@ export const StatemachineGrammar = (): Grammar => loadedStatemachineGrammar ?? (
         "elements": [
           {
             "$type": "Keyword",
-            "value": "statemachine"
+            "value": "statemachine",
+            "$comment": "/** The name of the machine */"
           },
           {
             "$type": "Assignment",
@@ -33,14 +34,16 @@ export const StatemachineGrammar = (): Grammar => loadedStatemachineGrammar ?? (
                 "$ref": "#/rules@6"
               },
               "arguments": []
-            }
+            },
+            "$comment": "/** The name of the machine */"
           },
           {
             "$type": "Group",
             "elements": [
               {
                 "$type": "Keyword",
-                "value": "events"
+                "value": "events",
+                "$comment": "/** The list of recognized event names */"
               },
               {
                 "$type": "Assignment",
@@ -53,10 +56,12 @@ export const StatemachineGrammar = (): Grammar => loadedStatemachineGrammar ?? (
                   },
                   "arguments": []
                 },
-                "cardinality": "+"
+                "cardinality": "+",
+                "$comment": "/* A block comment that is not documentation */"
               }
             ],
-            "cardinality": "?"
+            "cardinality": "?",
+            "$comment": "/** The list of recognized event names */"
           },
           {
             "$type": "Group",
@@ -83,7 +88,8 @@ export const StatemachineGrammar = (): Grammar => loadedStatemachineGrammar ?? (
           },
           {
             "$type": "Keyword",
-            "value": "initialState"
+            "value": "initialState",
+            "$comment": "/** The starting state for the machine */"
           },
           {
             "$type": "Assignment",
@@ -95,7 +101,8 @@ export const StatemachineGrammar = (): Grammar => loadedStatemachineGrammar ?? (
                 "$ref": "#/rules@3"
               },
               "deprecatedSyntax": false
-            }
+            },
+            "$comment": "/** The starting state for the machine */"
           },
           {
             "$type": "Assignment",
@@ -108,15 +115,18 @@ export const StatemachineGrammar = (): Grammar => loadedStatemachineGrammar ?? (
               },
               "arguments": []
             },
-            "cardinality": "*"
+            "cardinality": "*",
+            "$comment": "/** Definitions of available states */"
           }
-        ]
+        ],
+        "$comment": "/** The name of the machine */"
       },
       "definesHiddenTokens": false,
       "fragment": false,
       "hiddenTokens": [],
       "parameters": [],
-      "wildcard": false
+      "wildcard": false,
+      "$comment": "/** A textual represntation of a state machine */"
     },
     {
       "$type": "ParserRule",
@@ -138,7 +148,8 @@ export const StatemachineGrammar = (): Grammar => loadedStatemachineGrammar ?? (
       "fragment": false,
       "hiddenTokens": [],
       "parameters": [],
-      "wildcard": false
+      "wildcard": false,
+      "$comment": "/** An event is the trigger for a transition */"
     },
     {
       "$type": "ParserRule",
@@ -226,7 +237,8 @@ export const StatemachineGrammar = (): Grammar => loadedStatemachineGrammar ?? (
               },
               "arguments": []
             },
-            "cardinality": "*"
+            "cardinality": "*",
+            "$comment": "/** The transitions to other states that can take place from the current one */"
           },
           {
             "$type": "Keyword",
@@ -239,7 +251,8 @@ export const StatemachineGrammar = (): Grammar => loadedStatemachineGrammar ?? (
       "fragment": false,
       "hiddenTokens": [],
       "parameters": [],
-      "wildcard": false
+      "wildcard": false,
+      "$comment": "/** A description of the status of a system */"
     },
     {
       "$type": "ParserRule",
@@ -257,7 +270,8 @@ export const StatemachineGrammar = (): Grammar => loadedStatemachineGrammar ?? (
                 "$ref": "#/rules@1"
               },
               "deprecatedSyntax": false
-            }
+            },
+            "$comment": "/** The event triggering the transition */"
           },
           {
             "$type": "Keyword",
@@ -273,16 +287,19 @@ export const StatemachineGrammar = (): Grammar => loadedStatemachineGrammar ?? (
                 "$ref": "#/rules@3"
               },
               "deprecatedSyntax": false
-            }
+            },
+            "$comment": "/** The target state */"
           }
-        ]
+        ],
+        "$comment": "/** The event triggering the transition */"
       },
       "definesHiddenTokens": false,
       "entry": false,
       "fragment": false,
       "hiddenTokens": [],
       "parameters": [],
-      "wildcard": false
+      "wildcard": false,
+      "$comment": "/** A change from one state to another */"
     },
     {
       "$type": "TerminalRule",

--- a/examples/statemachine/src/language-server/statemachine.langium
+++ b/examples/statemachine/src/language-server/statemachine.langium
@@ -1,26 +1,41 @@
 grammar Statemachine
 
+/** A textual represntation of a state machine */
 entry Statemachine:
+    /** The name of the machine */
     'statemachine' name=ID
-    ('events' events+=Event+)?
-    ('commands'    commands+=Command+)?
+    /** The list of recognized event names */
+    ('events'
+    /* A block comment that is not documentation */
+    events+=Event+)?
+    ('commands' commands+=Command+)?
+    /** The starting state for the machine */
     'initialState' init=[State]
+    /** Definitions of available states */
     states+=State*;
 
+/** An event is the trigger for a transition */
 Event:
-    name=ID;
+    name=ID; // no comment should be generated for this property
 
+// The preceding comment should not be associated with this rule
 Command:
     name=ID;
 
+/** A description of the status of a system */
 State:
     'state' name=ID
         ('actions' '{' actions+=[Command]+ '}')?
+        /** The transitions to other states that can take place from the current one */
         transitions+=Transition*
     'end';
 
+/** A change from one state to another */
 Transition:
-    event=[Event] '=>' state=[State];
+    /** The event triggering the transition */
+    event=[Event] '=>'
+    /** The target state */
+    state=[State];
 
 hidden terminal WS: /\s+/;
 terminal ID: /[_a-zA-Z][\w_]*/;

--- a/packages/langium-cli/src/generator/ast-generator.ts
+++ b/packages/langium-cli/src/generator/ast-generator.ts
@@ -13,6 +13,7 @@ import { generatedHeader } from './node-util.js';
 import { collectKeywords, collectTerminalRegexps } from './langium-util.js';
 
 export function generateAst(services: LangiumCoreServices, grammars: Grammar[], config: LangiumConfig): string {
+    const commentProvider = services.documentation.CommentProvider;
     const astTypes = collectAst(grammars, services.shared.workspace.LangiumDocuments);
     const crossRef = grammars.some(grammar => hasCrossReferences(grammar));
     const importFrom = config.langiumInternal ? `../../syntax-tree${config.importExtension}` : 'langium';
@@ -26,8 +27,8 @@ export function generateAst(services: LangiumCoreServices, grammars: Grammar[], 
 
         ${generateTerminalConstants(grammars, config)}
 
-        ${joinToNode(astTypes.unions, union => union.toAstTypesString(isAstType(union.type)), { appendNewLineIfNotEmpty: true })}
-        ${joinToNode(astTypes.interfaces, iFace => iFace.toAstTypesString(true), { appendNewLineIfNotEmpty: true })}
+        ${joinToNode(astTypes.unions, union => union.toAstTypesString(isAstType(union.type), commentProvider), { appendNewLineIfNotEmpty: true })}
+        ${joinToNode(astTypes.interfaces, iFace => iFace.toAstTypesString(true, commentProvider), { appendNewLineIfNotEmpty: true })}
         ${
             astTypes.unions = astTypes.unions.filter(e => isAstType(e.type)),
             generateAstReflection(config, astTypes)

--- a/packages/langium/src/documentation/comment-provider.ts
+++ b/packages/langium/src/documentation/comment-provider.ts
@@ -22,6 +22,13 @@ export interface CommentProvider {
     getComment(node: AstNode): string | undefined;
 
     /**
+     * Returns the comment associated with the specified offset.
+     * @param node The AST node to get the comment for.
+     * @returns The comment associated with the specified offset or `undefined` if there is no comment.
+     */
+    getCommentByOffset(offset?: number): string | undefined;
+
+    /**
      * Registers the documentation comment of a token.
      * @param token The token
      */
@@ -38,7 +45,10 @@ export class DefaultCommentProvider implements CommentProvider {
         if(isAstNodeWithComment(node)) {
             return node.$comment;
         }
-        return this.offsetToComment.get(node.$cstNode?.offset ?? -1);
+        return this.getCommentByOffset(node.$cstNode?.offset);
+    }
+    getCommentByOffset(offset: number = -1): string | undefined {
+        return this.offsetToComment.get(offset);
     }
     registerComment(token: IToken) {
         const [hiddenTokens] = <[Array<IToken>, boolean]>token.payload;

--- a/packages/langium/src/grammar/type-system/type-collector/declared-types.ts
+++ b/packages/langium/src/grammar/type-system/type-collector/declared-types.ts
@@ -22,7 +22,8 @@ export function collectDeclaredTypes(interfaces: Interface[], unions: Type[]): P
                 name: attribute.name,
                 optional: attribute.isOptional,
                 astNodes: new Set([attribute]),
-                type: typeDefinitionToPropertyType(attribute.type)
+                type: typeDefinitionToPropertyType(attribute.type),
+                offset: attribute.$cstNode?.offset,
             };
             if (attribute.defaultValue) {
                 property.defaultValue = toPropertyDefaultValue(attribute.defaultValue);
@@ -41,7 +42,8 @@ export function collectDeclaredTypes(interfaces: Interface[], unions: Type[]): P
             abstract: false,
             properties: properties,
             superTypes: superTypes,
-            subTypes: new Set()
+            subTypes: new Set(),
+            offset: type.$cstNode?.offset,
         };
         declaredTypes.interfaces.push(interfaceType);
     }
@@ -53,7 +55,8 @@ export function collectDeclaredTypes(interfaces: Interface[], unions: Type[]): P
             declared: true,
             type: typeDefinitionToPropertyType(union.type),
             superTypes: new Set(),
-            subTypes: new Set()
+            subTypes: new Set(),
+            offset: union.$cstNode?.offset
         };
         declaredTypes.unions.push(unionType);
     }

--- a/packages/langium/src/grammar/type-system/type-collector/plain-types.ts
+++ b/packages/langium/src/grammar/type-system/type-collector/plain-types.ts
@@ -23,6 +23,7 @@ export interface PlainInterface {
     properties: PlainProperty[];
     declared: boolean;
     abstract: boolean;
+    offset?: number; // used as identifier
 }
 
 export function isPlainInterface(type: PlainType): type is PlainInterface {
@@ -36,6 +37,7 @@ export interface PlainUnion {
     type: PlainPropertyType;
     declared: boolean;
     dataType?: string;
+    offset?: number; // used as identifier
 }
 
 export function isPlainUnion(type: PlainType): type is PlainUnion {
@@ -48,6 +50,7 @@ export interface PlainProperty {
     astNodes: Set<Assignment | Action | TypeAttribute>;
     type: PlainPropertyType;
     defaultValue?: PlainPropertyDefaultValue;
+    offset?: number; // used as identifier
 }
 
 export type PlainPropertyDefaultValue = string | number | boolean | PlainPropertyDefaultValue[];
@@ -113,14 +116,14 @@ export function plainToTypes(plain: PlainAstTypes): AstTypes {
     const interfaceTypes = new Map<string, InterfaceType>();
     const unionTypes = new Map<string, UnionType>();
     for (const interfaceValue of plain.interfaces) {
-        const type = new InterfaceType(interfaceValue.name, interfaceValue.declared, interfaceValue.abstract);
+        const type = new InterfaceType(interfaceValue.name, interfaceValue.declared, interfaceValue.abstract, interfaceValue.offset);
         interfaceTypes.set(interfaceValue.name, type);
     }
     for (const unionValue of plain.unions) {
         const type = new UnionType(unionValue.name, {
             declared: unionValue.declared,
             dataType: unionValue.dataType
-        });
+        }, unionValue.offset);
         unionTypes.set(unionValue.name, type);
     }
     for (const interfaceValue of plain.interfaces) {
@@ -157,7 +160,8 @@ function plainToProperty(property: PlainProperty, interfaces: Map<string, Interf
         name: property.name,
         optional: property.optional,
         astNodes: property.astNodes,
-        type: plainToPropertyType(property.type, undefined, interfaces, unions)
+        type: plainToPropertyType(property.type, undefined, interfaces, unions),
+        offset: property.offset,
     };
     if (property.defaultValue !== undefined) {
         prop.defaultValue = property.defaultValue;

--- a/packages/langium/src/grammar/type-system/type-collector/types.ts
+++ b/packages/langium/src/grammar/type-system/type-collector/types.ts
@@ -126,9 +126,10 @@ export class UnionType {
     }
 
     toAstTypesString(reflectionInfo: boolean, commentProvider?: CommentProvider): string {
-        const comment = commentProvider?.getCommentByOffset(this.offset);
-        const unionNode = expandToNode`${comment ?? ''}`
-            .appendNewLineIfNotEmpty()
+        const unionNode = expandToNode``;
+        const comments = commentProvider?.getComments(this.offset) ?? [];
+        comments.forEach((comment) => unionNode.append(comment).appendNewLine());
+        unionNode
             .append(`export type ${this.name} = ${propertyTypeToString(this.type, 'AstType')};`)
             .appendNewLine();
 
@@ -146,12 +147,13 @@ export class UnionType {
     }
 
     toDeclaredTypesString(reservedWords: Set<string>, commentProvider?: CommentProvider): string {
-        const comment = commentProvider?.getCommentByOffset(this.offset);
-        return toString(expandToNode`${comment ?? ''}`
-            .appendNewLineIfNotEmpty()
+        const unionNode = expandToNode``;
+        const comments = commentProvider?.getComments(this.offset) ?? [];
+        comments.forEach((comment) => unionNode.append(comment).appendNewLine());
+        unionNode
             .append(`type ${escapeReservedWords(this.name, reservedWords)} = ${propertyTypeToString(this.type, 'DeclaredType')};`)
-            .appendNewLine()
-        );
+            .appendNewLine();
+        return toString(unionNode);
     }
 }
 
@@ -232,9 +234,10 @@ export class InterfaceType {
     toAstTypesString(reflectionInfo: boolean, commentProvider?: CommentProvider): string {
         const interfaceSuperTypes = this.interfaceSuperTypes.map(e => e.name);
         const superTypes = interfaceSuperTypes.length > 0 ? distinctAndSorted([...interfaceSuperTypes]) : ['AstNode'];
-        const comment = commentProvider?.getCommentByOffset(this.offset);
-        const interfaceNode = expandToNode`${comment ?? ''}`
-            .appendNewLineIfNotEmpty()
+        const interfaceNode = expandToNode``;
+        const comments = commentProvider?.getComments(this.offset) ?? [];
+        comments.forEach((comment) => interfaceNode.append(comment).appendNewLine());
+        interfaceNode
             .append(`export interface ${this.name} extends ${superTypes.join(', ')} {`)
             .appendNewLine();
 
@@ -429,10 +432,10 @@ function pushProperties(
         const name = mode === 'AstType' ? property.name : escapeReservedWords(property.name, reserved);
         const optional = property.optional && !isMandatoryPropertyType(property.type);
         const propType = propertyTypeToString(property.type, mode);
-        const comment = commentProvider?.getCommentByOffset(property.offset);
-        return expandToNode`${comment ?? ''}`
-            .appendNewLineIfNotEmpty()
-            .append(`${name}${optional ? '?' : ''}: ${propType};`);
+        const propertyNode = expandToNode``;
+        const comments = commentProvider?.getComments(property.offset) ?? [];
+        comments.forEach((comment) => propertyNode.append(comment).appendNewLine());
+        return propertyNode.append(`${name}${optional ? '?' : ''}: ${propType};`);
     }
 
     return joinToNode(

--- a/packages/langium/src/parser/langium-parser.ts
+++ b/packages/langium/src/parser/langium-parser.ts
@@ -20,6 +20,7 @@ import { getExplicitRuleType, isDataTypeRule } from '../utils/grammar-utils.js';
 import { assignMandatoryProperties, getContainerOfType, linkContentToContainer } from '../utils/ast-utils.js';
 import { CstNodeBuilder } from './cst-node-builder.js';
 import type { LexingReport } from './token-builder.js';
+import type { CommentProvider } from '../documentation/comment-provider.js';
 
 export type ParseResult<T = AstNode> = {
     value: T,
@@ -195,6 +196,7 @@ export class LangiumParser extends AbstractLangiumParser {
     private readonly converter: ValueConverter;
     private readonly astReflection: AstReflection;
     private readonly nodeBuilder = new CstNodeBuilder();
+    private readonly commentProvider: CommentProvider;
     private stack: any[] = [];
     private assignmentMap = new Map<AbstractElement, AssignmentElement | undefined>();
 
@@ -207,6 +209,7 @@ export class LangiumParser extends AbstractLangiumParser {
         this.linker = services.references.Linker;
         this.converter = services.parser.ValueConverter;
         this.astReflection = services.shared.AstReflection;
+        this.commentProvider = services.documentation.CommentProvider;
     }
 
     rule(rule: ParserRule, impl: RuleImpl): RuleResult {
@@ -244,6 +247,7 @@ export class LangiumParser extends AbstractLangiumParser {
             }
             prev.push(hidden[j++]);
         }
+        tokens.forEach((token) => this.commentProvider.registerComment(token));
     }
 
     parse<T extends AstNode = AstNode>(input: string, options: ParserOptions = {}): ParseResult<T> {


### PR DESCRIPTION
Alternative implementation of #1835.

Noteworthy changes:

- add `offset` property in transformed types, to identify the original CST node
- add `getComments` and `registerComments` methods to `CommentProvider` interface
- modify `toAstTypesString` method of `UnionType` and `InterfaceType` to generate comments
- modify `DefaultCommentProvider` class:
  - implement registration of comments from tokens
  - reimplement `getComment` to use the new `getComments` method
  - (optional) the `findCommentNode` function is no longer necessary, so it can be removed
- modify `LangiumParser` class:
  - add `commentProvider` member to hold the comment provider instance
  - add `preprocessTokens` method to perform the association of comments with tokens
  - remove the `extractHiddenTokens`, as it is no longer necessary
  - update the `parse` and `consume` methods to use the new changes

Other important notes:

- The previous implementation of hidden token extraction had a time complexity of $O(n \cdot m)$, as it iterated over hidden tokens for each non-hidden token. The new implementation has linear complexity in the number of non-hidden tokens.
- Multiple block comments are preserved for each `ID` token, which makes it possible to add comments to multiple rule assignments; the only caveat is that only the last JSDoc comment is displayed in Intellisense.
- It would be interesting to test the performance of langium-cli on grammars with a large number of rules. Below is a sample test that can be inlcuded in [ast-generator.test.ts].
   <details>
   <summary>Spoiler</summary>

   ```ts
    test('should parse the grammar in a reasonable amount of time', { timeout: 100 }, async () => {
        const ruleCount = 1000;
        const grammar = `
            grammar TestGrammar
            entry Test: Test0;
            ${Array(ruleCount).fill(null).map((_, i) => `
                /** Test rule ${i} */
                Test${i}: name=ID;
            `).join('')}
            hidden terminal WS: /\\s+/;
            terminal ID: /[_a-zA-Z][\\w_]*/;
        `;
        const { value } = (await parse(grammar)).parseResult;
        expect(value.rules).toHaveLength(ruleCount + 3);
    });
   ```

   </details>

[ast-generator.test.ts]: https://github.com/eclipse-langium/langium/blob/main/packages/langium-cli/test/generator/ast-generator.test.ts