### PR TITLE
add an option to generate optional properties in ast

### DIFF
--- a/packages/langium-cli/langium-config-schema.json
+++ b/packages/langium-cli/langium-config-schema.json
@@ -171,6 +171,10 @@
         "langiumInternal": {
             "description": "A flag to determine whether langium uses itself to bootstrap",
             "type": "boolean"
+        },
+        "optionalProperties": {
+            "description": "Use optional properties in generated ast (except for boolean and arrays properties)",
+            "type": "boolean"
         }
     },
     "required": [

--- a/packages/langium-cli/src/generator/ast-generator.ts
+++ b/packages/langium-cli/src/generator/ast-generator.ts
@@ -16,6 +16,7 @@ export function generateAst(services: LangiumCoreServices, grammars: Grammar[], 
     const astTypes = collectAst(grammars, services.shared.workspace.LangiumDocuments);
     const crossRef = grammars.some(grammar => hasCrossReferences(grammar));
     const importFrom = config.langiumInternal ? `../../syntax-tree${config.importExtension}` : 'langium';
+
     /* eslint-disable @typescript-eslint/indent */
     const fileNode = expandToNode`
         ${generatedHeader}
@@ -27,7 +28,7 @@ export function generateAst(services: LangiumCoreServices, grammars: Grammar[], 
         ${generateTerminalConstants(grammars, config)}
 
         ${joinToNode(astTypes.unions, union => union.toAstTypesString(isAstType(union.type)), { appendNewLineIfNotEmpty: true })}
-        ${joinToNode(astTypes.interfaces, iFace => iFace.toAstTypesString(true), { appendNewLineIfNotEmpty: true })}
+        ${joinToNode(astTypes.interfaces, iFace => iFace.toAstTypesString(true, config.optionalProperties), { appendNewLineIfNotEmpty: true })}
         ${
             astTypes.unions = astTypes.unions.filter(e => isAstType(e.type)),
             generateAstReflection(config, astTypes)

--- a/packages/langium-cli/src/package-types.ts
+++ b/packages/langium-cli/src/package-types.ts
@@ -30,6 +30,8 @@ export interface LangiumConfig {
     chevrotainParserConfig?: IParserConfig,
     /** The following option is meant to be used only by Langium itself */
     langiumInternal?: boolean
+    /** Use optional properties in generated ast (except for boolean and arrays properties) */
+    optionalProperties?: boolean
 }
 
 export interface LangiumLanguageConfig {

--- a/packages/langium/src/grammar/type-system/type-collector/types.ts
+++ b/packages/langium/src/grammar/type-system/type-collector/types.ts
@@ -218,7 +218,7 @@ export class InterfaceType {
         this.abstract = abstract;
     }
 
-    toAstTypesString(reflectionInfo: boolean): string {
+    toAstTypesString(reflectionInfo: boolean, optionalProperties?: boolean): string {
         const interfaceSuperTypes = this.interfaceSuperTypes.map(e => e.name);
         const superTypes = interfaceSuperTypes.length > 0 ? distinctAndSorted([...interfaceSuperTypes]) : ['AstNode'];
         const interfaceNode = expandToNode`
@@ -233,7 +233,7 @@ export class InterfaceType {
                 body.append(`readonly $type: ${distinctAndSorted([...this.typeNames]).map(e => `'${e}'`).join(' | ')};`).appendNewLine();
             }
             body.append(
-                pushProperties(this.properties, 'AstType')
+                pushProperties(this.properties, 'AstType', optionalProperties)
             );
         });
         interfaceNode.append('}').appendNewLine();
@@ -253,7 +253,7 @@ export class InterfaceType {
         return toString(
             expandToNode`
                 interface ${name}${superTypes.length > 0 ? ` extends ${superTypes}` : ''} {
-                    ${pushProperties(this.properties, 'DeclaredType', reservedWords)}
+                    ${pushProperties(this.properties, 'DeclaredType', undefined, reservedWords)}
                 }
             `.appendNewLine()
         );
@@ -408,12 +408,13 @@ function typeParenthesis(type: PropertyType, name: string): string {
 function pushProperties(
     properties: Property[],
     mode: 'AstType' | 'DeclaredType',
+    optionalProperties?: boolean,
     reserved = new Set<string>()
 ): Generated {
 
     function propertyToString(property: Property): string {
         const name = mode === 'AstType' ? property.name : escapeReservedWords(property.name, reserved);
-        const optional = property.optional && !isMandatoryPropertyType(property.type);
+        const optional = !isMandatoryPropertyType(property.type) && (property.optional || optionalProperties);
         const propType = propertyTypeToString(property.type, mode);
         return `${name}${optional ? '?' : ''}: ${propType};`;
     }


### PR DESCRIPTION
This PR adds an option in the langium-cli configuration to generate the ast with optional properties except for boolean and array types which are respectively initialized with `false` and `[]`.