### PR TITLE
Remove trailing space from AST keyword names type

### DIFF
--- a/examples/arithmetics/src/language-server/generated/ast.ts
+++ b/examples/arithmetics/src/language-server/generated/ast.ts
@@ -16,7 +16,7 @@ export const ArithmeticsTerminals = {
 
 export type ArithmeticsTerminalNames = keyof typeof ArithmeticsTerminals;
 
-export type ArithmeticsKeywordNames = 
+export type ArithmeticsKeywordNames =
     | "%"
     | "("
     | ")"

--- a/examples/domainmodel/src/language-server/generated/ast.ts
+++ b/examples/domainmodel/src/language-server/generated/ast.ts
@@ -15,7 +15,7 @@ export const DomainModelTerminals = {
 
 export type DomainModelTerminalNames = keyof typeof DomainModelTerminals;
 
-export type DomainModelKeywordNames = 
+export type DomainModelKeywordNames =
     | "."
     | ":"
     | "datatype"

--- a/examples/requirements/src/language-server/generated/ast.ts
+++ b/examples/requirements/src/language-server/generated/ast.ts
@@ -16,7 +16,7 @@ export const RequirementsAndTestsTerminals = {
 
 export type RequirementsAndTestsTerminalNames = keyof typeof RequirementsAndTestsTerminals;
 
-export type RequirementsAndTestsKeywordNames = 
+export type RequirementsAndTestsKeywordNames =
     | ","
     | ":"
     | "="

--- a/examples/statemachine/src/language-server/generated/ast.ts
+++ b/examples/statemachine/src/language-server/generated/ast.ts
@@ -15,7 +15,7 @@ export const StatemachineTerminals = {
 
 export type StatemachineTerminalNames = keyof typeof StatemachineTerminals;
 
-export type StatemachineKeywordNames = 
+export type StatemachineKeywordNames =
     | "=>"
     | "actions"
     | "commands"

--- a/packages/langium-cli/src/generator/ast-generator.ts
+++ b/packages/langium-cli/src/generator/ast-generator.ts
@@ -243,7 +243,7 @@ function generateTerminalConstants(grammars: Grammar[], config: LangiumConfig): 
 
         export type ${config.projectName}TerminalNames = keyof typeof ${config.projectName}Terminals;
 
-        export type ${config.projectName}KeywordNames = ${keywordStrings.length > 0 ? keywordStrings.map(keyword => `${EOL}    | ${keyword}`).join('') : 'never'};
+        export type ${config.projectName}KeywordNames =${keywordStrings.length > 0 ? keywordStrings.map(keyword => `${EOL}    | ${keyword}`).join('') : ' never'};
 
         export type ${config.projectName}TokenNames = ${config.projectName}TerminalNames | ${config.projectName}KeywordNames;
     `.appendNewLine();

--- a/packages/langium/src/languages/generated/ast.ts
+++ b/packages/langium/src/languages/generated/ast.ts
@@ -18,7 +18,7 @@ export const LangiumGrammarTerminals = {
 
 export type LangiumGrammarTerminalNames = keyof typeof LangiumGrammarTerminals;
 
-export type LangiumGrammarKeywordNames = 
+export type LangiumGrammarKeywordNames =
     | "!"
     | "&"
     | "("


### PR DESCRIPTION
This is mostly just a nitpick, but it caused an annoyance when inspecting the generated AST file in VS Code with the `files.trimTrailingWhitespace` option turned on (caused the CI to fail due to a git diff).