### PR TITLE
Adds a BNF generator to generate GBNF definition from the Langium grammar

### DIFF
--- a/packages/langium-cli/src/generate.ts
+++ b/packages/langium-cli/src/generate.ts
@@ -5,7 +5,7 @@
  ******************************************************************************/
 
 import type { AstNode, Grammar, LangiumDocument, Mutable } from 'langium';
-import type { LangiumConfig, LangiumLanguageConfig} from './package-types.js';
+import type { LangiumConfig, LangiumLanguageConfig } from './package-types.js';
 import { URI } from 'langium';
 import { loadConfig } from './package.js';
 import { AstUtils, GrammarAST } from 'langium';
@@ -14,6 +14,7 @@ import { NodeFileSystem } from 'langium/node';
 import { generateAst } from './generator/ast-generator.js';
 import { serializeGrammar } from './generator/grammar-serializer.js';
 import { generateModule } from './generator/module-generator.js';
+import { generateBnf } from './generator/bnf-generator.js';
 import { generateTextMate } from './generator/highlighting/textmate-generator.js';
 import { generateMonarch } from './generator/highlighting/monarch-generator.js';
 import { generatePrismHighlighting } from './generator/highlighting/prism-generator.js';
@@ -389,6 +390,11 @@ export async function runGenerator(config: LangiumConfig, options: GenerateOptio
                     await writeWithFail(`${filePath}.svg`, diagram, options);
                 }
             }
+        }
+        if (languageConfig?.bnf) {
+            const genBnf = generateBnf([grammar]);
+            const bnfPath = path.resolve(relPath, languageConfig.bnf.out ?? `${grammar.name ?? 'grammar'}.gbnf`);
+            await writeWithFail(bnfPath, genBnf, options);
         }
     }
 

--- a/packages/langium-cli/src/generate.ts
+++ b/packages/langium-cli/src/generate.ts
@@ -392,7 +392,7 @@ export async function runGenerator(config: LangiumConfig, options: GenerateOptio
             }
         }
         if (languageConfig?.bnf) {
-            const genBnf = generateBnf([grammar]);
+            const genBnf = generateBnf([grammar], { dialect: languageConfig.bnf.dialect ?? 'GBNF' });
             const bnfPath = path.resolve(relPath, languageConfig.bnf.out ?? `${grammar.name ?? 'grammar'}.gbnf`);
             await writeWithFail(bnfPath, genBnf, options);
         }

--- a/packages/langium-cli/src/generator/bnf-generator.ts
+++ b/packages/langium-cli/src/generator/bnf-generator.ts
@@ -111,7 +111,8 @@ function processComment(rule: AbstractRule, ctx: GeneratorContext) {
         if (ctx.dialect === 'GBNF') {
             return `# ${comment}\n`;
         } else {
-            return `/* ${comment} */\n`;
+            // TODO  (*  *) is not supported in some of EBNF parsers but /* */.
+            return `(* ${comment} *)\n`;
         }
     }
     return '';

--- a/packages/langium-cli/src/generator/bnf-generator.ts
+++ b/packages/langium-cli/src/generator/bnf-generator.ts
@@ -4,23 +4,39 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import type { Grammar } from 'langium';
-import type { AbstractElement, AbstractRule } from '../../../langium/lib/languages/generated/ast.js';
-import { isAction, isAlternatives, isAssignment, isCrossReference, isGroup, isKeyword, isParserRule, isRegexToken, isRuleCall } from '../../../langium/lib/languages/generated/ast.js';
+import { CstUtils, type Grammar } from 'langium';
+import * as _ from 'lodash';
+import type { AbstractElement, AbstractRule, TerminalRule } from '../../../langium/lib/languages/generated/ast.js';
+import {
+    isAction, isAlternatives, isAssignment, isCrossReference, isGroup, isKeyword, isParserRule, isRegexToken,
+    isRuleCall, isTerminalGroup, isTerminalRule, isTerminalRuleCall
+} from '../../../langium/lib/languages/generated/ast.js';
 
-export function generateBnf(grammars: Grammar[]): string {
+export function generateBnf(grammars: Grammar[], options: { dialect: BnfDialect } = { dialect: 'GBNF' }): string {
     const grammarsWithName = grammars.filter(grammar => !!grammar.name);
-    let result: string = '';
+
     const ctx: GeneratorContext = {
-        rootAssigned: false
+        rootAssigned: options.dialect === 'EBNF',
+        hasHiddenRules: grammarsWithName.some(grammar => grammar.rules.some(rule => isTerminalRule(rule) && rule.hidden)),
+        ...options
     };
+
+    const hiddenRules: TerminalRule[] = [];
+
+    let result: string = '';
     grammarsWithName.forEach(grammar => {
-        grammar.rules.filter(rule => !rule.fragment).forEach(rule => {
+        grammar.rules.forEach(rule => {
             result += processRule(rule, ctx);
             result += '\n\n';
+            if (ctx.hasHiddenRules && isTerminalRule(rule) && rule.hidden) {
+                hiddenRules.push(rule);
+            }
         });
+    });
+
+    if (hiddenRules.length > 0) {
+        result += `${processName('HIDDEN', ctx)} ::= ( ${hiddenRules.map(rule => processName(rule.name, ctx)).join(' | ')} )\n`;
     }
-    );
     return result;
 }
 
@@ -29,43 +45,99 @@ function processRule(rule: AbstractRule, ctx: GeneratorContext): string {
     if (markRoot) {
         ctx.rootAssigned = true;
     }
-    return `${markRoot ? 'root' : rule.name} ::= ${processElement(rule.definition)}`;
+
+    // GBNF expects 'root' as the root rule name, Lark e.g. expects 'start'.
+    const ruleName = processName(markRoot ? 'root' : rule.name, ctx);
+    const ruleComment = processComment(rule, ctx);
+    const hiddenPrefix = (isTerminalRule(rule) && !rule.hidden) ? hiddenRuleCall(ctx) : '';
+    return `${ruleComment}${ruleName} ::= ${hiddenPrefix}${processElement(rule.definition, ctx)}`;
 }
 
-function processElement(element: AbstractElement): string {
+/*
+* TODO list:
+* 1. ???
+*/
+function processElement(element: AbstractElement, ctx: GeneratorContext): string {
+    const processRecursively = (element: AbstractElement) => {
+        return processElement(element, ctx);
+    };
     if (isKeyword(element)) {
-        return `"${element.value}"`;
-    } else if (isGroup(element)) {
+        return `${hiddenRuleCall(ctx)}"${element.value}"`;
+    } else if (isGroup(element) || isTerminalGroup(element)) {
         if (element.cardinality) {
-            return `(${element.elements.map(processElement).filter(notEmpty).join(' ')})${processCardinality(element)}`;
+            return `( ${element.elements.map(processRecursively).filter(notEmpty).join(' ')} )${processCardinality(element)}`;
         } else {
-            return element.elements.map(processElement).filter(notEmpty).join(' ');
+            return element.elements.map(processRecursively).filter(notEmpty).join(' ');
         }
     } else if (isAssignment(element)) {
-        return processElement(element.terminal) + processCardinality(element);
-    } else if (isRuleCall(element)) {
-        return element.rule.ref?.name ?? element.rule.$refText;
+        return processRecursively(element.terminal) + processCardinality(element);
+    } else if (isRuleCall(element) || isTerminalRuleCall(element)) {
+        return processName(element.rule.ref?.name ?? element.rule.$refText, ctx) + processCardinality(element);
     } else if (isAlternatives(element)) {
-        return '(' + element.elements.map(processElement).filter(notEmpty).join(' | ') + ')';
+        return '(' + element.elements.map(processRecursively).filter(notEmpty).join(' | ') + ')' + processCardinality(element);
     } else if (isRegexToken(element)) {
         // First remove trailing and leading slashes. Replace escaped slashes `\/` with unescaped slashes `/`.
         return element.regex.replace(/(?<!\\)\//g, '').replace(/\\\//g, '/');
     } else if (isCrossReference(element)) {
-        return element.terminal ? processElement(element.terminal) : 'ID';
+        return (element.terminal ? processRecursively(element.terminal) : 'ID') + processCardinality(element);
     } else if (isAction(element)) {
         return '';
     }
-    return `not-handled type: ${element.$type}`;
+    return `not-handled-(${element.$type})`;
 }
 
 function processCardinality(element: AbstractElement): string {
     return element.cardinality ?? '';
 }
 
+function processName(name: string, ctx: GeneratorContext): string {
+    switch (ctx.dialect) {
+        case 'GBNF':
+            // convert camel case to Kebab Case for GBNF (GGML AI)
+            return _.kebabCase(name);
+        case 'EBNF':
+            return `<${name}>`;
+        default:
+            return name;
+    }
+}
+
+function processComment(rule: AbstractRule, ctx: GeneratorContext) {
+    const comment = CstUtils.findCommentNode(rule.$cstNode, ['ML_COMMENT'])?.text
+        ?.replace(/\r?\n|\r/g, ' ') // Replace line breaks
+        ?.replace(/^\/\*\s*/, '')   // Remove leading `/*`
+        ?.replace(/\s*\*\/$/, '');  // Remove trailing `*/`
+    if (comment) {
+        if (ctx.dialect === 'GBNF') {
+            return `# ${comment}\n`;
+        } else {
+            return `/* ${comment} */\n`;
+        }
+    }
+    return '';
+}
+
+/**
+ * Generates a call to the `HIDDEN` rule with a trailing space, if there are hidden rules in the grammar.
+ * @param ctx GeneratorContext
+ * @returns `HIDDEN* ` if there are hidden rules in the grammar.
+ */
+function hiddenRuleCall(ctx: GeneratorContext): string {
+    return ctx.hasHiddenRules ? (processName('HIDDEN', ctx) + '* ') : '';
+}
+
 function notEmpty(text: string): boolean {
     return text.trim().length > 0;
 }
 
+/**
+ * Default: GBNF
+ * EBNF doesn't support RegEx terminal rules.
+ */
+export type BnfDialect = 'GBNF' | 'EBNF';
+
 type GeneratorContext = {
     rootAssigned: boolean;
+    hasHiddenRules: boolean;
+    dialect: string;
 };

--- a/packages/langium-cli/src/generator/bnf-generator.ts
+++ b/packages/langium-cli/src/generator/bnf-generator.ts
@@ -1,0 +1,71 @@
+/******************************************************************************
+ * Copyright 2021 TypeFox GmbH
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License, which is available in the project root.
+ ******************************************************************************/
+
+import type { Grammar } from 'langium';
+import type { AbstractElement, AbstractRule } from '../../../langium/lib/languages/generated/ast.js';
+import { isAction, isAlternatives, isAssignment, isCrossReference, isGroup, isKeyword, isParserRule, isRegexToken, isRuleCall } from '../../../langium/lib/languages/generated/ast.js';
+
+export function generateBnf(grammars: Grammar[]): string {
+    const grammarsWithName = grammars.filter(grammar => !!grammar.name);
+    let result: string = '';
+    const ctx: GeneratorContext = {
+        rootAssigned: false
+    };
+    grammarsWithName.forEach(grammar => {
+        grammar.rules.filter(rule => !rule.fragment).forEach(rule => {
+            result += processRule(rule, ctx);
+            result += '\n\n';
+        });
+    }
+    );
+    return result;
+}
+
+function processRule(rule: AbstractRule, ctx: GeneratorContext): string {
+    const markRoot = !ctx.rootAssigned && isParserRule(rule) && rule.entry;
+    if (markRoot) {
+        ctx.rootAssigned = true;
+    }
+    return `${markRoot ? 'root' : rule.name} ::= ${processElement(rule.definition)}`;
+}
+
+function processElement(element: AbstractElement): string {
+    if (isKeyword(element)) {
+        return `"${element.value}"`;
+    } else if (isGroup(element)) {
+        if (element.cardinality) {
+            return `(${element.elements.map(processElement).filter(notEmpty).join(' ')})${processCardinality(element)}`;
+        } else {
+            return element.elements.map(processElement).filter(notEmpty).join(' ');
+        }
+    } else if (isAssignment(element)) {
+        return processElement(element.terminal) + processCardinality(element);
+    } else if (isRuleCall(element)) {
+        return element.rule.ref?.name ?? element.rule.$refText;
+    } else if (isAlternatives(element)) {
+        return '(' + element.elements.map(processElement).filter(notEmpty).join(' | ') + ')';
+    } else if (isRegexToken(element)) {
+        // First remove trailing and leading slashes. Replace escaped slashes `\/` with unescaped slashes `/`.
+        return element.regex.replace(/(?<!\\)\//g, '').replace(/\\\//g, '/');
+    } else if (isCrossReference(element)) {
+        return element.terminal ? processElement(element.terminal) : 'ID';
+    } else if (isAction(element)) {
+        return '';
+    }
+    return `not-handled type: ${element.$type}`;
+}
+
+function processCardinality(element: AbstractElement): string {
+    return element.cardinality ?? '';
+}
+
+function notEmpty(text: string): boolean {
+    return text.trim().length > 0;
+}
+
+type GeneratorContext = {
+    rootAssigned: boolean;
+};

--- a/packages/langium-cli/src/package-types.ts
+++ b/packages/langium-cli/src/package-types.ts
@@ -70,6 +70,8 @@ export interface LangiumLanguageConfig {
     /** Enable GBNF file generation */
     bnf?: {
         /** Output path for GBNF file */
-        out: string
+        out: string,
+        /** Dialect of the generated BNF file. GBNF is the default. In EBNF RegEx terminals are not supported. */
+        dialect?: 'GBNF' | 'EBNF'
     }
 }

--- a/packages/langium-cli/src/package-types.ts
+++ b/packages/langium-cli/src/package-types.ts
@@ -67,4 +67,9 @@ export interface LangiumLanguageConfig {
     }
     /** Configure the chevrotain parser for a single language */
     chevrotainParserConfig?: IParserConfig
+    /** Enable GBNF file generation */
+    bnf?: {
+        /** Output path for GBNF file */
+        out: string
+    }
 }

--- a/packages/langium-cli/test/generator/bnf-generator.test.ts
+++ b/packages/langium-cli/test/generator/bnf-generator.test.ts
@@ -1,0 +1,100 @@
+/******************************************************************************
+ * Copyright 2025 TypeFox GmbH
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License, which is available in the project root.
+ ******************************************************************************/
+
+import type { Grammar } from 'langium';
+import { EmptyFileSystem } from 'langium';
+import { expandToStringWithNL } from 'langium/generate';
+import { createLangiumGrammarServices } from 'langium/grammar';
+import { parseHelper } from 'langium/test';
+import { describe, expect, test } from 'vitest';
+import { generateBnf } from '../../src/generator/bnf-generator.js';
+
+const { grammar } = createLangiumGrammarServices(EmptyFileSystem);
+
+describe('BNF generator', () => {
+
+    test('should generate GBNF file', async () => {
+        const result = (await parseHelper<Grammar>(grammar)(TEST_GRAMMAR)).parseResult;
+        const typesFileContent = generateBnf([result.value]);
+        expect(typesFileContent).toBe(EXPECTED_BNF);
+    });
+
+});
+
+const EXPECTED_BNF = expandToStringWithNL`
+root ::= "module" ID Statement*
+
+Statement ::= (Definition | Evaluation)
+
+Definition ::= "def" ID ("(" DeclaredParameter ("," DeclaredParameter)* ")")? ":" Expression ";"
+
+DeclaredParameter ::= ID
+
+Evaluation ::= Expression ";"
+
+Expression ::= Addition
+
+Addition ::= Multiplication (("+" | "-") Multiplication)*
+
+Multiplication ::= PrimaryExpression (("*" | "/") PrimaryExpression)*
+
+PrimaryExpression ::= ("(" Expression ")" | NUMBER | ID ("(" Expression ("," Expression)* ")")?)
+
+WS ::= \\s+
+
+ID ::= [_a-zA-Z][\\w_]*
+
+NUMBER ::= [0-9]+(\\.[0-9]*)?
+
+ML_COMMENT ::= /\\*[\\s\\S]*?\\*/
+
+SL_COMMENT ::= //[^\\n\\r]*
+
+`;
+
+const TEST_GRAMMAR = expandToStringWithNL`
+    grammar Arithmetics
+
+    entry Module:
+        'module' name=ID
+        (statements+=Statement)*;
+
+    Statement:
+        Definition | Evaluation;
+
+    Definition:
+        'def' name=ID ('(' args+=DeclaredParameter (',' args+=DeclaredParameter)* ')')?
+        ':' expr=Expression ';';
+
+    DeclaredParameter:
+        name=ID;
+
+    type AbstractDefinition = Definition | DeclaredParameter;
+
+    Evaluation:
+        expression=Expression ';';
+
+    Expression:
+        Addition;
+
+    Addition infers Expression:
+        Multiplication ({infer BinaryExpression.left=current} operator=('+' | '-') right=Multiplication)*;
+
+    Multiplication infers Expression:
+        PrimaryExpression ({infer BinaryExpression.left=current} operator=('*' | '/') right=PrimaryExpression)*;
+
+    PrimaryExpression infers Expression:
+        '(' Expression ')' |
+        {infer NumberLiteral} value=NUMBER |
+        {infer FunctionCall} func=[AbstractDefinition] ('(' args+=Expression (',' args+=Expression)* ')')?;
+
+    hidden terminal WS: /\\s+/;
+    terminal ID: /[_a-zA-Z][\\w_]*/;
+    terminal NUMBER returns number: /[0-9]+(\\.[0-9]*)?/;
+
+    hidden terminal ML_COMMENT: /\\/\\*[\\s\\S]*?\\*\\//;
+    hidden terminal SL_COMMENT: /\\/\\/[^\\n\\r]*/;
+`;

--- a/packages/langium-cli/test/generator/bnf-generator.test.ts
+++ b/packages/langium-cli/test/generator/bnf-generator.test.ts
@@ -16,43 +16,123 @@ const { grammar } = createLangiumGrammarServices(EmptyFileSystem);
 
 describe('BNF generator', () => {
 
-    test('should generate GBNF file', async () => {
+    test('GBNF - Simple grammar', async () => {
         const result = (await parseHelper<Grammar>(grammar)(TEST_GRAMMAR)).parseResult;
         const typesFileContent = generateBnf([result.value]);
         expect(typesFileContent).toBe(EXPECTED_BNF);
     });
 
+    test('GBNF - Fragment, comment generation', async () => {
+        const result = (await parseHelper<Grammar>(grammar)(GRAMMAR_WITH_FRAGMENT)).parseResult;
+        const typesFileContent = generateBnf([result.value]);
+        const expected = expandToStringWithNL`
+        # * This is a root rule
+        root ::= package-declaration*
+
+        # * This is a package declaration * Using parser rule fragment
+        package-declaration ::= hidden* "package" named-element hidden* "{" hidden* "}"
+
+        named-element ::= qualified-name
+
+        qualified-name ::= id ( hidden* "." id )*
+
+        # * Terminal fragment
+        number ::= hidden* [0-9]+
+
+        # * Terminal using fragment
+        signed-number ::= hidden* [+-] number+
+
+        # Terminal rule
+        id ::= hidden* [A-z]*
+
+        ws ::= \\s+
+
+        hidden ::= ( ws )
+        `;
+        expect(typesFileContent).toBe(expected);
+    });
+
+    test('EBNF - Fragment, comment generation', async () => {
+        const result = (await parseHelper<Grammar>(grammar)(GRAMMAR_WITH_FRAGMENT)).parseResult;
+        const typesFileContent = generateBnf([result.value], { dialect: 'EBNF' });
+        const expected = expandToStringWithNL`
+        /* * This is a root rule */
+        <Domainmodel> ::= <PackageDeclaration>*
+
+        /* * This is a package declaration * Using parser rule fragment */
+        <PackageDeclaration> ::= <HIDDEN>* "package" <NamedElement> <HIDDEN>* "{" <HIDDEN>* "}"
+
+        <NamedElement> ::= <QualifiedName>
+
+        <QualifiedName> ::= <ID> ( <HIDDEN>* "." <ID> )*
+
+        /* * Terminal fragment */
+        <NUMBER> ::= <HIDDEN>* [0-9]+
+
+        /* * Terminal using fragment */
+        <SIGNED_NUMBER> ::= <HIDDEN>* [+-] <NUMBER>+
+
+        /* Terminal rule */
+        <ID> ::= <HIDDEN>* [A-z]*
+
+        <WS> ::= \\s+
+
+        <HIDDEN> ::= ( <WS> )
+        `;
+        expect(typesFileContent).toBe(expected);
+    });
+
+    test('GBNF - No hidden rules', async () => {
+        const grammarContent = `
+        grammar RootLang
+        entry Root:
+            'root' name=ID;
+        terminal ID: /[_a-zA-Z][\\w_]*/;
+        `;
+
+        const result = (await parseHelper<Grammar>(grammar)(grammarContent)).parseResult;
+        const typesFileContent = generateBnf([result.value]);
+        const expected = expandToStringWithNL`
+        root ::= "root" id
+
+        id ::= [_a-zA-Z][\\w_]*
+
+        `;
+        expect(typesFileContent).toBe(expected);
+    });
+
 });
 
 const EXPECTED_BNF = expandToStringWithNL`
-root ::= "module" ID Statement*
+root ::= hidden* "module" id statement*
 
-Statement ::= (Definition | Evaluation)
+statement ::= (definition | evaluation)
 
-Definition ::= "def" ID ("(" DeclaredParameter ("," DeclaredParameter)* ")")? ":" Expression ";"
+definition ::= hidden* "def" id ( hidden* "(" declared-parameter ( hidden* "," declared-parameter )* hidden* ")" )? hidden* ":" expression hidden* ";"
 
-DeclaredParameter ::= ID
+declared-parameter ::= id
 
-Evaluation ::= Expression ";"
+evaluation ::= expression hidden* ";"
 
-Expression ::= Addition
+expression ::= addition
 
-Addition ::= Multiplication (("+" | "-") Multiplication)*
+addition ::= multiplication ( (hidden* "+" | hidden* "-") multiplication )*
 
-Multiplication ::= PrimaryExpression (("*" | "/") PrimaryExpression)*
+multiplication ::= primary-expression ( (hidden* "*" | hidden* "/") primary-expression )*
 
-PrimaryExpression ::= ("(" Expression ")" | NUMBER | ID ("(" Expression ("," Expression)* ")")?)
+primary-expression ::= (hidden* "(" expression hidden* ")" | number | ID ( hidden* "(" expression ( hidden* "," expression )* hidden* ")" )?)
 
-WS ::= \\s+
+ws ::= \\s+
 
-ID ::= [_a-zA-Z][\\w_]*
+id ::= hidden* [_a-zA-Z][\\w_]*
 
-NUMBER ::= [0-9]+(\\.[0-9]*)?
+number ::= hidden* [0-9]+(\\.[0-9]*)?
 
-ML_COMMENT ::= /\\*[\\s\\S]*?\\*/
+ml-comment ::= /\\*[\\s\\S]*?\\*/
 
-SL_COMMENT ::= //[^\\n\\r]*
+sl-comment ::= //[^\\n\\r]*
 
+hidden ::= ( ws | ml-comment | sl-comment )
 `;
 
 const TEST_GRAMMAR = expandToStringWithNL`
@@ -97,4 +177,35 @@ const TEST_GRAMMAR = expandToStringWithNL`
 
     hidden terminal ML_COMMENT: /\\/\\*[\\s\\S]*?\\*\\//;
     hidden terminal SL_COMMENT: /\\/\\/[^\\n\\r]*/;
+`;
+
+const GRAMMAR_WITH_FRAGMENT = expandToStringWithNL`
+    grammar DomainModel
+    /** This is a root rule */
+    entry Domainmodel:
+        (elements+=PackageDeclaration)*;
+
+    /*
+    * This is a package declaration
+    * Using parser rule fragment
+    */
+    PackageDeclaration:
+        'package' NamedElement '{'
+        '}';
+
+    fragment NamedElement:
+        name=QualifiedName
+    ;
+
+    // Datatype rule
+    QualifiedName returns string:
+        ID ('.' ID)*;
+
+    /** Terminal fragment */
+    terminal fragment NUMBER: /[0-9]+/;
+    /** Terminal using fragment */
+    terminal SIGNED_NUMBER returns number: /[+-]/ NUMBER+;
+    /* Terminal rule */
+    terminal ID: /[A-z]*/;
+    hidden terminal WS: /\\s+/;
 `;

--- a/packages/langium-cli/test/generator/bnf-generator.test.ts
+++ b/packages/langium-cli/test/generator/bnf-generator.test.ts
@@ -56,23 +56,23 @@ describe('BNF generator', () => {
         const result = (await parseHelper<Grammar>(grammar)(GRAMMAR_WITH_FRAGMENT)).parseResult;
         const typesFileContent = generateBnf([result.value], { dialect: 'EBNF' });
         const expected = expandToStringWithNL`
-        /* * This is a root rule */
+        (* * This is a root rule *)
         <Domainmodel> ::= <PackageDeclaration>*
 
-        /* * This is a package declaration * Using parser rule fragment */
+        (* * This is a package declaration * Using parser rule fragment *)
         <PackageDeclaration> ::= <HIDDEN>* "package" <NamedElement> <HIDDEN>* "{" <HIDDEN>* "}"
 
         <NamedElement> ::= <QualifiedName>
 
         <QualifiedName> ::= <ID> ( <HIDDEN>* "." <ID> )*
 
-        /* * Terminal fragment */
+        (* * Terminal fragment *)
         <NUMBER> ::= <HIDDEN>* [0-9]+
 
-        /* * Terminal using fragment */
+        (* * Terminal using fragment *)
         <SIGNED_NUMBER> ::= <HIDDEN>* [+-] <NUMBER>+
 
-        /* Terminal rule */
+        (* Terminal rule *)
         <ID> ::= <HIDDEN>* [A-z]*
 
         <WS> ::= \\s+


### PR DESCRIPTION
Adds an optional BNF Generator to Langium Configuration:
```js
/** Enable GBNF file generation */
bnf?: {
    /** Output path for GBNF file */
    out: string,
    /** Dialect of the generated BNF file. GBNF is the default. In EBNF RegEx terminals are not supported. */
    dialect?: 'GBNF' | 'EBNF'
}
``` 
 
The option `GBNF` will produce a grammar file corresponding to this [description](https://github.com/ggml-org/llama.cpp/blob/master/grammars/README.md).

An experimental `EBNF` option will produce an EBNF like grammar definition. Note: in most cases one will need to rewrite the Regex terminal rules to the EBNF syntax.  