### PR TITLE
add support for languages with specific file names

### DIFF
--- a/packages/langium-cli/langium-config-schema.json
+++ b/packages/langium-cli/langium-config-schema.json
@@ -56,6 +56,15 @@
                         }
                     ]
                 },
+                "fileNames": {
+                    "description": "The file names used by the DSL",
+                    "type": "array",
+                    "items": [
+                        {
+                            "type": "string"
+                        }
+                    ]
+                },
                 "caseInsensitive": {
                     "description": "Enable case-insensitive keywords parsing",
                     "type": "boolean"

--- a/packages/langium-cli/src/generator/module-generator.ts
+++ b/packages/langium-cli/src/generator/module-generator.ts
@@ -48,6 +48,7 @@ export function generateModule(grammars: Grammar[], config: LangiumConfig, gramm
                     export const ${ grammar.name }LanguageMetaData = {
                         languageId: '${config.id}',
                         fileExtensions: [${config.fileExtensions && joinToNode(config.fileExtensions, e => appendQuotesAndDot(e), { separator: ', ' })}],
+                        ${config.fileNames ? `fileNames: [${config.fileNames.map(name => `'${name}'`).join(', ')}],` : undefined}
                         caseInsensitive: ${Boolean(config.caseInsensitive)},
                         mode: '${modeValue}'
                     } as const satisfies LanguageMetaData;

--- a/packages/langium-cli/src/package-types.ts
+++ b/packages/langium-cli/src/package-types.ts
@@ -39,6 +39,8 @@ export interface LangiumLanguageConfig {
     grammar: string
     /** File extensions with leading `.` */
     fileExtensions?: string[]
+    /** File names */
+    fileNames?: string[]
     /** Enable case-insensitive keywords parsing */
     caseInsensitive?: boolean
     /** Enable generating a TextMate syntax highlighting file */

--- a/packages/langium-cli/src/parser-validation.ts
+++ b/packages/langium-cli/src/parser-validation.ts
@@ -59,6 +59,7 @@ function languageConfigToMetaData(config: LangiumLanguageConfig): LanguageMetaDa
     return {
         languageId: config.id,
         fileExtensions: config.fileExtensions ?? [],
+        fileNames: config.fileNames,
         caseInsensitive: Boolean(config.caseInsensitive),
         mode: 'development'
     };

--- a/packages/langium-vscode/src/language-server/grammar-workspace-manager.ts
+++ b/packages/langium-vscode/src/language-server/grammar-workspace-manager.ts
@@ -6,7 +6,7 @@
 
 import type { Ignore } from 'ignore';
 import ignore from 'ignore';
-import type { ConfigurationProvider, FileSystemNode, WorkspaceFolder } from 'langium';
+import type { ConfigurationProvider, FileSelector, FileSystemNode, WorkspaceFolder } from 'langium';
 import { Cancellation, DefaultWorkspaceManager, URI, UriUtils } from 'langium';
 import type { LangiumSharedServices } from 'langium/lsp';
 import * as path from 'path';
@@ -52,14 +52,15 @@ export class LangiumGrammarWorkspaceManager extends DefaultWorkspaceManager {
         return super.initializeWorkspace(folders, cancelToken);
     }
 
-    protected override includeEntry(workspaceFolder: WorkspaceFolder, entry: FileSystemNode, fileExtensions: string[]): boolean {
+    protected override includeEntry(workspaceFolder: WorkspaceFolder, entry: FileSystemNode, selector: FileSelector): boolean {
         if (this.matcher) {
             // create path relative to workspace folder root: /user/foo/workspace/entry.txt -> entry.txt
             const relPath = path.relative(URI.parse(workspaceFolder.uri).path, entry.uri.path);
             const ignored = this.matcher.ignores(relPath);
-            return !ignored && (entry.isDirectory || (entry.isFile && fileExtensions.includes(UriUtils.extname(entry.uri))));
+            return !ignored && (entry.isDirectory || (entry.isFile && (selector.fileExtensions.includes(UriUtils.extname(entry.uri)) ||
+                selector.fileNames.includes(UriUtils.basename(entry.uri)))));
         }
-        return super.includeEntry(workspaceFolder, entry, fileExtensions);
+        return super.includeEntry(workspaceFolder, entry, selector);
     }
 
 }

--- a/packages/langium/src/languages/language-meta-data.ts
+++ b/packages/langium/src/languages/language-meta-data.ts
@@ -10,6 +10,7 @@
 export interface LanguageMetaData {
     languageId: string;
     fileExtensions: readonly string[];
+    fileNames?: readonly string[];
     caseInsensitive: boolean;
     /**
      * Mode used to optimize code for development or production environments.

--- a/packages/langium/src/service-registry.ts
+++ b/packages/langium/src/service-registry.ts
@@ -103,9 +103,9 @@ export class DefaultServiceRegistry implements ServiceRegistry {
 
         if (!services) {
             if (languageId) {
-                throw new Error(`The service registry contains no services for the file '${name}' for language '${languageId}'.`);
+                throw new Error(`The service registry contains no services for the extension '${ext}' for language '${languageId}'.`);
             } else {
-                throw new Error(`The service registry contains no services for the file '${name}'.`);
+                throw new Error(`The service registry contains no services for the extension '${ext}'.`);
             }
         }
         return services;

--- a/packages/langium/src/service-registry.ts
+++ b/packages/langium/src/service-registry.ts
@@ -44,6 +44,7 @@ export class DefaultServiceRegistry implements ServiceRegistry {
     protected singleton?: LangiumCoreServices;
     protected readonly languageIdMap = new Map<string, LangiumCoreServices>();
     protected readonly fileExtensionMap = new Map<string, LangiumCoreServices>();
+    protected readonly fileNameMap = new Map<string, LangiumCoreServices>();
 
     /**
      * @deprecated Use the new `fileExtensionMap` (or `languageIdMap`) property instead.
@@ -65,6 +66,14 @@ export class DefaultServiceRegistry implements ServiceRegistry {
                 console.warn(`The file extension ${ext} is used by multiple languages. It is now assigned to '${data.languageId}'.`);
             }
             this.fileExtensionMap.set(ext, language);
+        }
+        if (data.fileNames) {
+            for (const name of data.fileNames) {
+                if (this.fileNameMap.has(name)) {
+                    console.warn(`The file name ${name} is used by multiple languages. It is now assigned to '${data.languageId}'.`);
+                }
+                this.fileNameMap.set(name, language);
+            }
         }
         this.languageIdMap.set(data.languageId, language);
         if (this.languageIdMap.size === 1) {
@@ -89,12 +98,14 @@ export class DefaultServiceRegistry implements ServiceRegistry {
             }
         }
         const ext = UriUtils.extname(uri);
-        const services = this.fileExtensionMap.get(ext);
+        const name = UriUtils.basename(uri);
+        const services = this.fileNameMap.get(name) ?? this.fileExtensionMap.get(ext);
+
         if (!services) {
             if (languageId) {
-                throw new Error(`The service registry contains no services for the extension '${ext}' for language '${languageId}'.`);
+                throw new Error(`The service registry contains no services for the file '${name}' for language '${languageId}'.`);
             } else {
-                throw new Error(`The service registry contains no services for the extension '${ext}'.`);
+                throw new Error(`The service registry contains no services for the file '${name}'.`);
             }
         }
         return services;

--- a/packages/langium/src/workspace/workspace-manager.ts
+++ b/packages/langium/src/workspace/workspace-manager.ts
@@ -66,8 +66,13 @@ export interface WorkspaceManager {
     initializeWorkspace(folders: WorkspaceFolder[], cancelToken?: CancellationToken): Promise<void>;
 
 }
+/**
+ * The FileSelector provides file names and extensions used by this extension.
+ */
 export interface FileSelector {
+    /** Allowed file extensions (e.g., ["ts", "js"]). */
     fileExtensions: string[];
+    /** Allowed file names (e.g., ["config", "settings"]). */
     fileNames: string[];
 }
 

--- a/packages/langium/src/workspace/workspace-manager.ts
+++ b/packages/langium/src/workspace/workspace-manager.ts
@@ -66,6 +66,10 @@ export interface WorkspaceManager {
     initializeWorkspace(folders: WorkspaceFolder[], cancelToken?: CancellationToken): Promise<void>;
 
 }
+export interface FileSelector {
+    fileExtensions: string[];
+    fileNames: string[];
+}
 
 export class DefaultWorkspaceManager implements WorkspaceManager {
 
@@ -119,6 +123,7 @@ export class DefaultWorkspaceManager implements WorkspaceManager {
      */
     protected async performStartup(folders: WorkspaceFolder[]): Promise<LangiumDocument[]> {
         const fileExtensions = this.serviceRegistry.all.flatMap(e => e.LanguageMetaData.fileExtensions);
+        const fileNames = this.serviceRegistry.all.flatMap(e => e.LanguageMetaData.fileNames ?? []);
         const documents: LangiumDocument[] = [];
         const collector = (document: LangiumDocument) => {
             documents.push(document);
@@ -132,7 +137,7 @@ export class DefaultWorkspaceManager implements WorkspaceManager {
         await this.loadAdditionalDocuments(folders, collector);
         await Promise.all(
             folders.map(wf => [wf, this.getRootFolder(wf)] as [WorkspaceFolder, URI])
-                .map(async entry => this.traverseFolder(...entry, fileExtensions, collector))
+                .map(async entry => this.traverseFolder(...entry, {fileExtensions, fileNames}, collector))
         );
         this._ready.resolve();
         return documents;
@@ -160,12 +165,12 @@ export class DefaultWorkspaceManager implements WorkspaceManager {
      * Traverse the file system folder identified by the given URI and its subfolders. All
      * contained files that match the file extensions are added to the collector.
      */
-    protected async traverseFolder(workspaceFolder: WorkspaceFolder, folderPath: URI, fileExtensions: string[], collector: (document: LangiumDocument) => void): Promise<void> {
+    protected async traverseFolder(workspaceFolder: WorkspaceFolder, folderPath: URI, selector: FileSelector, collector: (document: LangiumDocument) => void): Promise<void> {
         const content = await this.fileSystemProvider.readDirectory(folderPath);
         await Promise.all(content.map(async entry => {
-            if (this.includeEntry(workspaceFolder, entry, fileExtensions)) {
+            if (this.includeEntry(workspaceFolder, entry, selector)) {
                 if (entry.isDirectory) {
-                    await this.traverseFolder(workspaceFolder, entry.uri, fileExtensions, collector);
+                    await this.traverseFolder(workspaceFolder, entry.uri, selector, collector);
                 } else if (entry.isFile) {
                     const document = await this.langiumDocuments.getOrCreateDocument(entry.uri);
                     collector(document);
@@ -177,7 +182,7 @@ export class DefaultWorkspaceManager implements WorkspaceManager {
     /**
      * Determine whether the given folder entry shall be included while indexing the workspace.
      */
-    protected includeEntry(_workspaceFolder: WorkspaceFolder, entry: FileSystemNode, fileExtensions: string[]): boolean {
+    protected includeEntry(_workspaceFolder: WorkspaceFolder, entry: FileSystemNode, selector: FileSelector): boolean {
         const name = UriUtils.basename(entry.uri);
         if (name.startsWith('.')) {
             return false;
@@ -185,8 +190,8 @@ export class DefaultWorkspaceManager implements WorkspaceManager {
         if (entry.isDirectory) {
             return name !== 'node_modules' && name !== 'out';
         } else if (entry.isFile) {
-            const extname = UriUtils.extname(entry.uri);
-            return fileExtensions.includes(extname);
+            return selector.fileExtensions.includes(UriUtils.extname(entry.uri)) ||
+                selector.fileNames.includes(UriUtils.basename(entry.uri));
         }
         return false;
     }

--- a/packages/langium/test/service-registry.test.ts
+++ b/packages/langium/test/service-registry.test.ts
@@ -41,6 +41,16 @@ describe('DefaultServiceRegistry', () => {
         expect(registry.getServices(URI.parse('file:/test.y'))).toBe(language2);
         expect(registry.all).toHaveLength(2);
     });
+    test('a file name has a highest priority than an extension', () => {
+        const language1: LangiumCoreServices = { LanguageMetaData: { fileExtensions: [], fileNames: ['test.x'], languageId: 'foo' } } as any;
+        const language2: LangiumCoreServices = { LanguageMetaData: { fileExtensions: ['.x'], languageId: 'bar' } } as any;
+        const registry = new DefaultServiceRegistry(createSharedCoreServices());
+        registry.register(language1);
+        registry.register(language2);
+        expect(registry.getServices(URI.parse('file:/test.x'))).toBe(language1);
+        expect(registry.getServices(URI.parse('file:/other.x'))).toBe(language2);
+        expect(registry.all).toHaveLength(2);
+    });
 
     function createSharedCoreServices(id?: string): LangiumSharedCoreServices {
         const textDocumentsModule: Module<LangiumSharedCoreServices, PartialLangiumSharedCoreServices> = {

--- a/packages/langium/test/service-registry.test.ts
+++ b/packages/langium/test/service-registry.test.ts
@@ -41,7 +41,7 @@ describe('DefaultServiceRegistry', () => {
         expect(registry.getServices(URI.parse('file:/test.y'))).toBe(language2);
         expect(registry.all).toHaveLength(2);
     });
-    test('a file name has a highest priority than an extension', () => {
+    test('a file name has a higher priority than an extension', () => {
         const language1: LangiumCoreServices = { LanguageMetaData: { fileExtensions: [], fileNames: ['test.x'], languageId: 'foo' } } as any;
         const language2: LangiumCoreServices = { LanguageMetaData: { fileExtensions: ['.x'], languageId: 'bar' } } as any;
         const registry = new DefaultServiceRegistry(createSharedCoreServices());


### PR DESCRIPTION
Solves #1871

Add an optional fileNames entry in the langium configuration.

In VSCode contributions it is also possible to provide a filenamePatterns: https://code.visualstudio.com/api/references/contribution-points#contributes.languages but to add this to Langium it would requires to add a glob library as dependency.

It changes the API of traverseFolder and includeEntry in workspace-manager.ts so maybe for 4.0 ?