### PR TITLE
BNF generator - Support for rule parameters

### DIFF
--- a/packages/langium-cli/langium-config-schema.json
+++ b/packages/langium-cli/langium-config-schema.json
@@ -126,6 +126,35 @@
                 },
                 "chevrotainParserConfig": {
                     "$ref": "#/$defs/chevrotainParserConfig"
+                },
+                "bnf": {
+                    "description": "An object to describe bnf generator properties.",
+                    "type": "object",
+                    "properties": {
+                        "out": {
+                            "description": "The output path for the BNF file.",
+                            "type": "string"
+                        },
+                        "comment": {
+                            "description": "By default, comments are generated according to the dialect. GBNF uses `#`, EBNF uses `(* *)`. Use this option to force a specific comment style. Use `parentheses` for `(* comment *)`, `slash` for `/* comment *\/`, `hash` for `# comment` and `skip` to disable comment generation.",
+                            "type": {
+                                "enum": [
+                                    "skip", "parentheses", "slash", "hash"
+                                ]
+                            }
+                        },
+                        "dialect": {
+                            "description": "Dialect of the generated BNF file. GBNF is the default. In EBNF RegEx terminals are not supported.",
+                            "type": {
+                                "enum": [
+                                    "GBNF", "EBNF"
+                                ]
+                            }
+                        }
+                    },
+                    "required": [
+                        "out"
+                    ]
                 }
             },
             "required": [


### PR DESCRIPTION
Adds support for Parser rule parameter and guards to the BNF generator.

Langium grammar:
 ```js
grammar Test
entry Model:
    element1=InferredType<false>
    element2=InferredType<true>
;
InferredType<imperative>:
    (<imperative> 'infer' | <!imperative> 'infers') name=ID
;
terminal ID: /\^?[_a-zA-Z][\w_]*/;
```

Transformed output:
```ebnf
root ::= inferred-type inferred-type-imperative

inferred-type ::= ("infers") id
inferred-type-imperative ::= ("infer") id

id ::= ^?[_a-zA-Z][w_]*
```