### PR TITLE
Improve case insensitive Regex generation

### DIFF
--- a/examples/arithmetics/syntaxes/arithmetics.tmLanguage.json
+++ b/examples/arithmetics/syntaxes/arithmetics.tmLanguage.json
@@ -10,7 +10,7 @@
     },
     {
       "name": "keyword.control.arithmetics",
-      "match": "\\b([dD][eE][fF]|[mM][oO][dD][uU][lL][eE])\\b"
+      "match": "(?i)\\b(def|module)\\b"
     }
   ],
   "repository": {

--- a/packages/langium-cli/src/generator/highlighting/textmate-generator.ts
+++ b/packages/langium-cli/src/generator/highlighting/textmate-generator.ts
@@ -128,14 +128,14 @@ function getRepository(grammar: Grammar, config: LangiumLanguageConfig): Reposit
 function getControlKeywords(grammar: Grammar, pack: LangiumLanguageConfig): Pattern {
     const regex = /[A-Za-z]/;
     const controlKeywords = collectKeywords(grammar).filter(kw => regex.test(kw));
-    const groups = groupKeywords(controlKeywords, pack.caseInsensitive);
+    const groups = groupKeywords(controlKeywords);
     return {
         'name': `keyword.control.${pack.id}`,
-        'match': groups.join('|')
+        'match': `${pack.caseInsensitive ? '(?i)' : ''}${groups.join('|')}`
     };
 }
 
-function groupKeywords(keywords: string[], caseInsensitive: boolean | undefined): string[] {
+function groupKeywords(keywords: string[]): string[] {
     const groups: {
         letter: string[],
         leftSpecial: string[],
@@ -144,7 +144,7 @@ function groupKeywords(keywords: string[], caseInsensitive: boolean | undefined)
     } = { letter: [], leftSpecial: [], rightSpecial: [], special: [] };
 
     keywords.forEach(keyword => {
-        const keywordPattern = caseInsensitive ? RegExpUtils.getCaseInsensitivePattern(keyword) : RegExpUtils.escapeRegExp(keyword);
+        const keywordPattern = RegExpUtils.escapeRegExp(keyword);
         if (/\w/.test(keyword[0])) {
             if (/\w/.test(keyword[keyword.length - 1])) {
                 groups.letter.push(keywordPattern);

--- a/packages/langium/src/utils/regexp-utils.ts
+++ b/packages/langium/src/utils/regexp-utils.ts
@@ -155,12 +155,6 @@ export function escapeRegExp(value: string): string {
     return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
-export function getCaseInsensitivePattern(keyword: string): string {
-    return Array.prototype.map.call(keyword, letter =>
-        /\w/.test(letter) ? `[${letter.toLowerCase()}${letter.toUpperCase()}]` : escapeRegExp(letter)
-    ).join('');
-}
-
 /**
  * Determines whether the given input has a partial match with the specified regex.
  * @param regex The regex to partially match against

--- a/packages/langium/test/parser/token-builder.test.ts
+++ b/packages/langium/test/parser/token-builder.test.ts
@@ -140,23 +140,23 @@ describe('tokenBuilder#caseInsensitivePattern', () => {
     });
 
     test('should create from keyword with special symbols', () => {
-        expect(implementPattern).toEqual(/@[iI][mM][pP][lL][eE][mM][eE][nN][tT]/);
+        expect(implementPattern).toEqual(/@implement/i);
     });
 
     test('should create from keyword with special escape symbols', () => {
-        expect(strangePattern).toEqual(/\\[sS][tT][rR][aA][nN][gG][eE]\\/);
+        expect(strangePattern).toEqual(/\\strange\\/i);
     });
 
     test('should create from mixed-case word', () => {
-        expect(abcPattern).toEqual(/[aA][bB][cC]/);
+        expect(abcPattern).toEqual(/AbC/i);
     });
 
     test('should create from lower-case word', () => {
-        expect(abPattern).toEqual(/[aA][bB]/);
+        expect(abPattern).toEqual(/ab/i);
     });
 
     test('should create from upper-case word', () => {
-        expect(aPattern).toEqual(/[aA]/);
+        expect(aPattern).toEqual(/A/i);
     });
 
     test('should ignore terminals', () => {


### PR DESCRIPTION
Our current way of representing case insensitive tokens in the token builder and textmate grammars is rather unusual. Instead of using `[xX]` for every possible character `x`, we can make use of the `i` or `(?i)` regex options instead. This massively improves readability of the generated textmate grammars.