### PR TITLE
Await language client start in generated extension

### DIFF
--- a/examples/arithmetics/src/extension.ts
+++ b/examples/arithmetics/src/extension.ts
@@ -12,8 +12,8 @@ import { LanguageClient, TransportKind } from 'vscode-languageclient/node.js';
 let client: LanguageClient;
 
 // This function is called when the extension is activated.
-export function activate(context: vscode.ExtensionContext): void {
-    client = startLanguageClient(context);
+export async function activate(context: vscode.ExtensionContext): Promise<void> {
+    client = await startLanguageClient(context);
 }
 
 // This function is called when the extension is deactivated.
@@ -24,7 +24,7 @@ export function deactivate(): Thenable<void> | undefined {
     return undefined;
 }
 
-function startLanguageClient(context: vscode.ExtensionContext): LanguageClient {
+async function startLanguageClient(context: vscode.ExtensionContext): Promise<LanguageClient> {
     const serverModule = context.asAbsolutePath(path.join('out', 'language-server', 'main.cjs'));
     // The debug options for the server
     // --inspect=6009: runs the server in Node's Inspector mode so VS Code can attach to the server for debugging
@@ -51,6 +51,6 @@ function startLanguageClient(context: vscode.ExtensionContext): LanguageClient {
     );
 
     // Start the client. This will also launch the server
-    client.start();
+    await client.start();
     return client;
 }

--- a/examples/domainmodel/src/extension.ts
+++ b/examples/domainmodel/src/extension.ts
@@ -12,8 +12,8 @@ import { LanguageClient, TransportKind } from 'vscode-languageclient/node.js';
 let client: LanguageClient;
 
 // This function is called when the extension is activated.
-export function activate(context: vscode.ExtensionContext): void {
-    client = startLanguageClient(context);
+export async function activate(context: vscode.ExtensionContext): Promise<void> {
+    client = await startLanguageClient(context);
 }
 
 // This function is called when the extension is deactivated.
@@ -24,7 +24,7 @@ export function deactivate(): Thenable<void> | undefined {
     return undefined;
 }
 
-function startLanguageClient(context: vscode.ExtensionContext): LanguageClient {
+async function startLanguageClient(context: vscode.ExtensionContext): Promise<LanguageClient> {
     const serverModule = context.asAbsolutePath(path.join('out', 'language-server', 'main.cjs'));
     // The debug options for the server
     // --inspect=6009: runs the server in Node's Inspector mode so VS Code can attach to the server for debugging
@@ -51,6 +51,6 @@ function startLanguageClient(context: vscode.ExtensionContext): LanguageClient {
     );
 
     // Start the client. This will also launch the server
-    client.start();
+    await client.start();
     return client;
 }

--- a/examples/requirements/src/extension.ts
+++ b/examples/requirements/src/extension.ts
@@ -12,8 +12,8 @@ import * as path from 'node:path';
 let client: LanguageClient;
 
 // This function is called when the extension is activated.
-export function activate(context: vscode.ExtensionContext): void {
-    client = startLanguageClient(context);
+export async function activate(context: vscode.ExtensionContext): Promise<void> {
+    client = await startLanguageClient(context);
 }
 
 // This function is called when the extension is deactivated.
@@ -24,7 +24,7 @@ export function deactivate(): Thenable<void> | undefined {
     return undefined;
 }
 
-function startLanguageClient(context: vscode.ExtensionContext): LanguageClient {
+async function startLanguageClient(context: vscode.ExtensionContext): Promise<LanguageClient> {
     const serverModule = context.asAbsolutePath(path.join('out', 'language-server', 'main.cjs'));
     // The debug options for the server
     // --inspect=6009: runs the server in Node's Inspector mode so VS Code can attach to the server for debugging.
@@ -54,6 +54,6 @@ function startLanguageClient(context: vscode.ExtensionContext): LanguageClient {
     );
 
     // Start the client. This will also launch the server
-    client.start();
+    await client.start();
     return client;
 }

--- a/examples/statemachine/src/extension.ts
+++ b/examples/statemachine/src/extension.ts
@@ -12,8 +12,8 @@ import { LanguageClient, TransportKind } from 'vscode-languageclient/node.js';
 let client: LanguageClient;
 
 // This function is called when the extension is activated.
-export function activate(context: vscode.ExtensionContext): void {
-    client = startLanguageClient(context);
+export async function activate(context: vscode.ExtensionContext): Promise<void> {
+    client = await startLanguageClient(context);
 }
 
 // This function is called when the extension is deactivated.
@@ -24,7 +24,7 @@ export function deactivate(): Thenable<void> | undefined {
     return undefined;
 }
 
-function startLanguageClient(context: vscode.ExtensionContext): LanguageClient {
+async function startLanguageClient(context: vscode.ExtensionContext): Promise<LanguageClient> {
     const serverModule = context.asAbsolutePath(path.join('out', 'language-server', 'main.cjs'));
     // The debug options for the server
     // --inspect=6009: runs the server in Node's Inspector mode so VS Code can attach to the server for debugging
@@ -51,6 +51,6 @@ function startLanguageClient(context: vscode.ExtensionContext): LanguageClient {
     );
 
     // Start the client. This will also launch the server
-    client.start();
+    await client.start();
     return client;
 }

--- a/packages/generator-langium/templates/vscode/src/extension/main.ts
+++ b/packages/generator-langium/templates/vscode/src/extension/main.ts
@@ -1,4 +1,4 @@
-import type { LanguageClientOptions, ServerOptions} from 'vscode-languageclient/node.js';
+import type { LanguageClientOptions, ServerOptions } from 'vscode-languageclient/node.js';
 import type * as vscode from 'vscode';
 import * as path from 'node:path';
 import { LanguageClient, TransportKind } from 'vscode-languageclient/node.js';
@@ -6,8 +6,8 @@ import { LanguageClient, TransportKind } from 'vscode-languageclient/node.js';
 let client: LanguageClient;
 
 // This function is called when the extension is activated.
-export function activate(context: vscode.ExtensionContext): void {
-    client = startLanguageClient(context);
+export async function activate(context: vscode.ExtensionContext): Promise<void> {
+    client = await startLanguageClient(context);
 }
 
 // This function is called when the extension is deactivated.
@@ -18,7 +18,7 @@ export function deactivate(): Thenable<void> | undefined {
     return undefined;
 }
 
-function startLanguageClient(context: vscode.ExtensionContext): LanguageClient {
+async function startLanguageClient(context: vscode.ExtensionContext): Promise<LanguageClient> {
     const serverModule = context.asAbsolutePath(path.join('out', 'language', 'main.cjs'));
     // The debug options for the server
     // --inspect=6009: runs the server in Node's Inspector mode so VS Code can attach to the server for debugging.
@@ -46,6 +46,6 @@ function startLanguageClient(context: vscode.ExtensionContext): LanguageClient {
     );
 
     // Start the client. This will also launch the server
-    client.start();
+    await client.start();
     return client;
 }


### PR DESCRIPTION
See discussion in https://github.com/eclipse-langium/langium/discussions/1801#discussioncomment-13121766. In some cases, the language server didn't pick up on dirty files in the editor, since we didn't await the startup sequence of the language client. This change adjusts this for our examples & yeoman generator.