### PR TITLE
Enable verbatimModuleSyntax in tsconfig

### DIFF
--- a/packages/langium/src/index.ts
+++ b/packages/langium/src/index.ts
@@ -23,4 +23,5 @@ export * from './workspace/index.js';
 // Export the Langium Grammar AST definitions in the `GrammarAST` namespace
 import * as GrammarAST from './languages/generated/ast.js';
 import type { Grammar } from './languages/generated/ast.js';
-export { Grammar, GrammarAST };
+export type { Grammar };
+export { GrammarAST };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -46,7 +46,9 @@
     // Skip type checking of declaration files.
     "skipLibCheck": true,
     // This setting controls how TypeScript determines whether a file is a script or a module.
-    "moduleDetection": "force"
+    "moduleDetection": "force",
+    // any imports or exports without a type modifier are left around. Anything that uses the type modifier is dropped entirely.
+    "verbatimModuleSyntax": true
   },
   "include": [
      "**/src/**/*",


### PR DESCRIPTION
I forgot that in the tsc/tsconfig update #1930 

eslint rule `@typescript-eslint/consistent-type-imports` already helped a lot. There is only one change now.