### PR TITLE
Fixed infix parsing for incomplete expression

### DIFF
--- a/examples/arithmetics/src/language-server/arithmetics-module.ts
+++ b/examples/arithmetics/src/language-server/arithmetics-module.ts
@@ -9,6 +9,7 @@ import { createDefaultModule, createDefaultSharedModule, type DefaultSharedModul
 import { ArithmeticsScopeProvider } from './arithmetics-scope-provider.js';
 import { ArithmeticsValidator, registerValidationChecks } from './arithmetics-validator.js';
 import { ArithmeticsGeneratedModule, ArithmeticsGeneratedSharedModule } from './generated/module.js';
+import { ArithmeticsCodeActionProvider } from './lsp/arithmetics-code-actions.js';
 
 /**
  * Declaration of custom services - add your own service classes here.
@@ -36,6 +37,9 @@ export const ArithmeticsModule: Module<ArithmeticsServices, PartialLangiumServic
     },
     validation: {
         ArithmeticsValidator: () => new ArithmeticsValidator()
+    },
+    lsp: {
+        CodeActionProvider: () => new ArithmeticsCodeActionProvider()
     }
 };
 

--- a/examples/arithmetics/src/language-server/lsp/arithmetics-code-actions.ts
+++ b/examples/arithmetics/src/language-server/lsp/arithmetics-code-actions.ts
@@ -1,0 +1,55 @@
+/******************************************************************************
+ * Copyright 2025 TypeFox GmbH
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License, which is available in the project root.
+ ******************************************************************************/
+
+import type { Diagnostic } from 'vscode-languageserver';
+import { CodeActionKind } from 'vscode-languageserver';
+import type { CodeActionParams } from 'vscode-languageserver-protocol';
+import type { CodeAction, Command } from 'vscode-languageserver-types';
+import type { MaybePromise, LangiumDocument, DiagnosticData } from 'langium';
+import type { CodeActionProvider } from 'langium/lsp';
+import { IssueCodes } from '../arithmetics-validator.js';
+
+export class ArithmeticsCodeActionProvider implements CodeActionProvider {
+
+    getCodeActions(document: LangiumDocument, params: CodeActionParams): MaybePromise<Array<Command | CodeAction>> {
+        const result: CodeAction[] = [];
+        const acceptor = (ca: CodeAction | undefined) => ca && result.push(ca);
+        for (const diagnostic of params.context.diagnostics) {
+            this.createCodeActions(diagnostic, document, acceptor);
+        }
+        return result;
+    }
+
+    private createCodeActions(diagnostic: Diagnostic, document: LangiumDocument, accept: (ca: CodeAction | undefined) => void): void {
+        switch ((diagnostic.data as DiagnosticData)?.code) {
+            case IssueCodes.ExpressionNormalizable:
+                accept(this.normalizeExpression(diagnostic, document));
+                break;
+        }
+    }
+
+    private normalizeExpression(diagnostic: Diagnostic, document: LangiumDocument): CodeAction | undefined {
+        const data = diagnostic.data as DiagnosticData & { constant: number };
+        if (data && typeof data.constant === 'number') {
+            return {
+                title: `Replace with constant ${data.constant}`,
+                kind: CodeActionKind.QuickFix,
+                diagnostics: [diagnostic],
+                isPreferred: true,
+                edit: {
+                    changes: {
+                        [document.textDocument.uri]: [{
+                            range: diagnostic.range,
+                            newText: data.constant.toString()
+                        }]
+                    }
+                }
+            };
+        }
+        return undefined;
+    }
+}
+

--- a/examples/arithmetics/test/arithmetics-validator.test.ts
+++ b/examples/arithmetics/test/arithmetics-validator.test.ts
@@ -1,0 +1,212 @@
+/******************************************************************************
+ * Copyright 2025 TypeFox GmbH
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License, which is available in the project root.
+ ******************************************************************************/
+
+import { describe, expect, test } from 'vitest';
+import { createArithmeticsServices } from '../src/language-server/arithmetics-module.js';
+import { EmptyFileSystem } from 'langium';
+import { expectError, expectIssue, expectNoIssues, validationHelper } from 'langium/test';
+import type { Module, Definition, BinaryExpression, FunctionCall, DeclaredParameter } from '../src/language-server/generated/ast.js';
+import { IssueCodes } from '../src/language-server/arithmetics-validator.js';
+
+const services = createArithmeticsServices(EmptyFileSystem);
+const validate = validationHelper<Module>(services.arithmetics);
+
+describe('Arithmetics validation', () => {
+
+    test('Division by zero should be detected', async () => {
+        const validationResult = await validate(`
+            module test
+            5 / 0;
+        `);
+
+        expectError(validationResult, 'Division by zero is detected.', {
+            property: 'right'
+        });
+    });
+
+    test('Modulo by zero should be detected', async () => {
+        const validationResult = await validate(`
+            module test
+            5 % 0;
+        `);
+
+        expectError(validationResult, 'Division by zero is detected.', {
+            property: 'right'
+        });
+    });
+
+    test('Division by non-zero should not cause error', async () => {
+        const validationResult = await validate(`
+            module test
+            5 / 2;
+        `);
+
+        expectNoIssues(validationResult);
+    });
+
+    test('Expression normalization should be suggested', async () => {
+        const validationResult = await validate(`
+            module test
+            def test: 2 + 3;
+        `);
+
+        expectIssue(validationResult, {
+            message: 'Expression could be normalized to constant 5',
+            data: {
+                code: IssueCodes.ExpressionNormalizable,
+                constant: 5
+            }
+        });
+    });
+
+    test('Duplicate definition names should be detected', async () => {
+        const validationResult = await validate(`
+            module test
+            def x: 1;
+            def x: 2;
+        `);
+
+        const module = validationResult.document.parseResult.value;
+        const firstDef = module.statements[0] as Definition;
+        const secondDef = module.statements[1] as Definition;
+
+        expect(validationResult.diagnostics).toHaveLength(2);
+        expectError(validationResult, 'Duplicate definition name: x', {
+            node: firstDef,
+            property: 'name'
+        });
+        expectError(validationResult, 'Duplicate definition name: x', {
+            node: secondDef,
+            property: 'name'
+        });
+    });
+
+    test('Unique definition names should not cause error', async () => {
+        const validationResult = await validate(`
+            module test
+            def x: 1;
+            def y: 2;
+        `);
+
+        expectNoIssues(validationResult);
+    });
+
+    test('Function recursion should be detected', async () => {
+        const validationResult = await validate(`
+            module test
+            def factorial(n): factorial(n - 1);
+        `);
+
+        const module = validationResult.document.parseResult.value;
+        const def = module.statements[0] as Definition;
+        const binaryExpr = def.expr as BinaryExpression;
+        const funcCall = binaryExpr.left as FunctionCall;
+
+        expectError(validationResult, /Recursion is not allowed/, {
+            node: funcCall,
+            property: 'func'
+        });
+    });
+
+    test('Function mutual recursion should be detected', async () => {
+        const validationResult = await validate(`
+            module test
+            def even(n): odd(n - 1);
+            def odd(n): even(n - 1);
+        `);
+
+        expect(validationResult.diagnostics.length).toBeGreaterThan(0);
+        expectError(validationResult, /Recursion is not allowed/, {
+            property: 'func'
+        });
+    });
+
+    test('Non-recursive function calls should not cause error', async () => {
+        const validationResult = await validate(`
+            module test
+            def add(a, b): a + b;
+            def calculate: add(2, 3);
+        `);
+
+        expectNoIssues(validationResult);
+    });
+
+    test('Duplicate parameter names should be detected', async () => {
+        const validationResult = await validate(`
+            module test
+            def test(x, x): x + 1;
+        `);
+
+        const module = validationResult.document.parseResult.value;
+        const def = module.statements[0] as Definition;
+        const firstParam = def.args[0] as DeclaredParameter;
+        const secondParam = def.args[1] as DeclaredParameter;
+
+        expect(validationResult.diagnostics).toHaveLength(2);
+        expectError(validationResult, 'Duplicate definition name: x', {
+            node: firstParam,
+            property: 'name'
+        });
+        expectError(validationResult, 'Duplicate definition name: x', {
+            node: secondParam,
+            property: 'name'
+        });
+    });
+
+    test('Unique parameter names should not cause error', async () => {
+        const validationResult = await validate(`
+            module test
+            def test(x, y): x + y;
+        `);
+
+        expectNoIssues(validationResult);
+    });
+
+    test('Function call parameter count mismatch should be detected', async () => {
+        const validationResult = await validate(`
+            module test
+            def add(a, b): a + b;
+            add(1, 2, 3);
+        `);
+
+        expectError(validationResult, 'Function add expects 2 parameters, but 3 were given.', {
+            property: 'args'
+        });
+    });
+
+    test('Function call with too few parameters should be detected', async () => {
+        const validationResult = await validate(`
+            module test
+            def add(a, b): a + b;
+            add(1);
+        `);
+
+        expectError(validationResult, 'Function add expects 2 parameters, but 1 were given.', {
+            property: 'args'
+        });
+    });
+
+    test('Function call with correct parameter count should not cause error', async () => {
+        const validationResult = await validate(`
+            module test
+            def add(a, b): a + b;
+            add(1, 2);
+        `);
+
+        expectNoIssues(validationResult);
+    });
+
+    test('Function call with no parameters should work when function expects none', async () => {
+        const validationResult = await validate(`
+            module test
+            def pi: 3.14159;
+            pi;
+        `);
+
+        expectNoIssues(validationResult);
+    });
+});
+

--- a/examples/arithmetics/test/lsp/arithmetics-code-actions.test.ts
+++ b/examples/arithmetics/test/lsp/arithmetics-code-actions.test.ts
@@ -1,0 +1,34 @@
+/******************************************************************************
+ * Copyright 2025 TypeFox GmbH
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License, which is available in the project root.
+ ******************************************************************************/
+
+import { describe, expect, test } from 'vitest';
+import { EmptyFileSystem } from 'langium';
+import { testCodeAction } from 'langium/test';
+import { createArithmeticsServices } from '../../src/language-server/arithmetics-module.js';
+import { IssueCodes } from '../../src/language-server/arithmetics-validator.js';
+
+const services = createArithmeticsServices(EmptyFileSystem);
+const testCodeActions = testCodeAction(services.arithmetics);
+
+describe('Arithmetics code actions', () => {
+    test('Replace normalizable expression with constant', async () => {
+        const textBefore = `
+            module test
+            def foo: 2 + 3;
+        `;
+
+        const textAfter = `
+            module test
+            def foo: 5;
+        `;
+
+        const result = await testCodeActions(textBefore, IssueCodes.ExpressionNormalizable, textAfter);
+        const action = result.action;
+        expect(action).toBeTruthy();
+        expect(action!.title).toBe('Replace with constant 5');
+    });
+});
+

--- a/packages/langium/src/parser/langium-parser.ts
+++ b/packages/langium/src/parser/langium-parser.ts
@@ -462,6 +462,10 @@ export class LangiumParser extends AbstractLangiumParser {
             // Simply return the expression as is.
             return obj.parts[0];
         }
+        if (obj.parts.length === 0) {
+            // This can happen if the expression is incomplete
+            return undefined;
+        }
         // Find the operator with the lowest precedence (highest value in precedence map)
         let lowestPrecedenceIdx = 0;
         let lowestPrecedenceValue = -1;

--- a/packages/langium/test/parser/langium-parser.test.ts
+++ b/packages/langium/test/parser/langium-parser.test.ts
@@ -162,15 +162,21 @@ describe('Infix operator parsing', async () => {
         await expectExpr('1 = 2 = 3', '(1 = (2 = 3))');
     });
 
-    async function expectExpr(text: string, expected: string): Promise<void> {
+    test('Should parse incomplete infix operator', async () => {
+        await expectExpr('1 + 2 -', '((1 + 2) - undefined)', 1);
+    });
+
+    async function expectExpr(text: string, expected: string, errors: number = 0): Promise<void> {
         const document = await parse(text);
-        expect(document.parseResult.parserErrors.length).toBe(0);
+        expect(document.parseResult.parserErrors.length).toBe(errors);
         const expr = document.parseResult.value as ExprModel;
         expect(stringifyExpr(expr.expr)).toEqual(expected);
     }
 
     function stringifyExpr(expr: Expr): string {
-        if (expr.$type === 'BinaryExpr') {
+        if (expr === undefined) {
+            return 'undefined';
+        } else if (expr.$type === 'BinaryExpr') {
             const bin = expr as BinaryExpr;
             return `(${stringifyExpr(bin.left)} ${bin.operator} ${stringifyExpr(bin.right)})`;
         } else if (expr.$type === 'PrimaryExpr') {


### PR DESCRIPTION
Expressions like `1 + 2 -` led to infinite recursion (stack overflow) in the `constructInfix` method because the expression has too few complete parts.

Also added a code action and more tests to the Arithmetics example (#1255).