### PR TITLE
Added grammar validation config, added strict mode for types

### DIFF
--- a/examples/statemachine/src/language-server/generated/ast.ts
+++ b/examples/statemachine/src/language-server/generated/ast.ts
@@ -70,7 +70,7 @@ export function isState(item: unknown): item is State {
     return reflection.isInstance(item, State);
 }
 
-/** A textual represntation of a state machine */
+/** A textual representation of a state machine */
 export interface Statemachine extends langium.AstNode {
     readonly $type: 'Statemachine';
     commands: Array<Command>;

--- a/examples/statemachine/src/language-server/generated/grammar.ts
+++ b/examples/statemachine/src/language-server/generated/grammar.ts
@@ -118,7 +118,7 @@ export const StatemachineGrammar = (): Grammar => loadedStatemachineGrammar ?? (
       },
       "fragment": false,
       "parameters": [],
-      "$comment": "/** A textual represntation of a state machine */"
+      "$comment": "/** A textual representation of a state machine */"
     },
     {
       "$type": "ParserRule",

--- a/examples/statemachine/src/language-server/statemachine.langium
+++ b/examples/statemachine/src/language-server/statemachine.langium
@@ -1,6 +1,6 @@
 grammar Statemachine
 
-/** A textual represntation of a state machine */
+/** A textual representation of a state machine */
 entry Statemachine:
     'statemachine'
     /** The name of the machine */

--- a/packages/generator-langium/templates/.vscode/settings.json
+++ b/packages/generator-langium/templates/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "langium.config": "packages/language/langium-config.json"
+}

--- a/packages/langium-cli/langium-config-schema.json
+++ b/packages/langium-cli/langium-config-schema.json
@@ -4,6 +4,7 @@
         "chevrotainParserConfig": {
             "description": "An object to describe the Chevrotain parser configuration",
             "type": "object",
+            "additionalProperties": false,
             "properties": {
                 "recoveryEnabled": {
                     "description": "Is the error recovery / fault tolerance of the Chevrotain Parser enabled",
@@ -72,6 +73,7 @@
                 "textMate": {
                     "description": "An object to describe the textMate grammar properties",
                     "type": "object",
+                    "additionalProperties": false,
                     "properties": {
                         "out": {
                             "description": "The output file path to the generated textMate grammar",
@@ -85,6 +87,7 @@
                 "monarch": {
                     "description": "An object to describe the monarch grammar properties",
                     "type": "object",
+                    "additionalProperties": false,
                     "properties": {
                         "out": {
                             "description": "The output file path to the generated monarch grammar",
@@ -98,6 +101,7 @@
                 "prism": {
                     "description": "An object to describe the prism grammar properties",
                     "type": "object",
+                    "additionalProperties": false,
                     "properties": {
                         "out": {
                             "description": "The output file path to the generated prism grammar",
@@ -111,6 +115,7 @@
                 "railroad": {
                     "description": "An object to describe railroad syntax diagram properties",
                     "type": "object",
+                    "additionalProperties": false,
                     "properties": {
                         "out": {
                             "description": "The output path to the generated railroad diagrams",
@@ -139,6 +144,7 @@
                 "bnf": {
                     "description": "An object to describe bnf generator properties.",
                     "type": "object",
+                    "additionalProperties": false,
                     "properties": {
                         "out": {
                             "description": "The output path for the BNF file.",
@@ -202,6 +208,18 @@
             "description": "Mode for generating optimized code for the current environment",
             "type": "string",
             "enum": ["development", "production"]
+        },
+        "validation": {
+            "description": "Options for grammar validation",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "types": {
+                    "description": "Handling of type definitions and inference in the grammar; 'normal' allows both inferred and declared types, 'strict' only allows declared types.",
+                    "type": "string",
+                    "enum": ["normal", "strict"]
+                }
+            }
         },
         "chevrotainParserConfig": {
             "$ref": "#/$defs/chevrotainParserConfig"

--- a/packages/langium-cli/src/generate.ts
+++ b/packages/langium-cli/src/generate.ts
@@ -255,6 +255,11 @@ export async function runGenerator(config: LangiumConfig, options: GenerateOptio
     if (options.mode) {
         config.mode = options.mode;
     }
+
+    if (config.validation) {
+        grammarServices.validation.LangiumGrammarValidator.options = config.validation;
+    }
+
     const all = await buildAll(config);
     const buildResult: (success: boolean) => GeneratorResult = (success: boolean) => ({
         success,

--- a/packages/langium-cli/src/langium.ts
+++ b/packages/langium-cli/src/langium.ts
@@ -15,9 +15,9 @@ program
     .version(cliVersion)
     .command('generate')
     .description('Generate code for a Langium grammar')
-    .option('-f, --file <file>', 'the configuration file or package.json setting up the generator')
-    .option('-w, --watch', 'enables watch mode', false)
-    .addOption(new Option('-m, --mode <mode>', 'used mode for optimized builds for your current environment').choices(['development', 'production']))
+    .option('-f, --file <file>', 'The configuration file or package.json setting up the generator')
+    .option('-w, --watch', 'Enable watch mode to regenerate when a grammar file is changed', false)
+    .addOption(new Option('-m, --mode <mode>', 'Mode for optimized builds for your current environment').choices(['development', 'production']))
     .action((options: GenerateOptions) => {
         generate(options)
             .then(success => {
@@ -34,9 +34,9 @@ program
     });
 
 program.command('extract-types')
-    .argument('<file>', 'the langium grammar file to generate types for')
-    .option('-o, --output <file>', 'output file name. Default is types.langium next to the grammar file.')
-    .option('-f, --force', 'Force overwrite existing file.')
+    .argument('<file>', 'The langium grammar file to generate types for')
+    .option('-o, --output <file>', "Output file name; default is 'types.langium' next to the grammar file")
+    .option('-f, --force', 'Force overwriting any existing file')
     .action((file, options: ExtractTypesOptions) => {
         options.grammar = file;
         generateTypes(options).catch(err => {

--- a/packages/langium-cli/src/package-types.ts
+++ b/packages/langium-cli/src/package-types.ts
@@ -3,7 +3,9 @@
  * This program and the accompanying materials are made available under the
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
+
 import type { IParserConfig } from 'langium';
+import type { LangiumGrammarValidationOptions } from 'langium/grammar';
 
 export interface Package {
     name: string
@@ -26,6 +28,8 @@ export interface LangiumConfig {
     importExtension?: string
     /** Mode used to generate optimized files for development or production environments */
     mode?: 'development' | 'production';
+    /** Options for grammar validation */
+    validation?: LangiumGrammarValidationOptions
     /** Configure the chevrotain parser for all languages */
     chevrotainParserConfig?: IParserConfig,
     /** The following option is meant to be used only by Langium itself */

--- a/packages/langium-vscode/package.json
+++ b/packages/langium-vscode/package.json
@@ -73,6 +73,11 @@
           "type": "string",
           "default": "node_modules, out",
           "description": "Specifies the exclusion patterns during initial workspace indexing. You will need to reload your extension afterwards."
+        },
+        "langium.config": {
+          "type": "string",
+          "default": "langium-config.json",
+          "description": "Path to the Langium configuration file, relative to the workspace root. This is used to control validation options."
         }
       }
     }

--- a/packages/langium-vscode/src/language-server/config-handler.ts
+++ b/packages/langium-vscode/src/language-server/config-handler.ts
@@ -1,0 +1,104 @@
+/******************************************************************************
+ * Copyright 2025 TypeFox GmbH
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License, which is available in the project root.
+ ******************************************************************************/
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { URI } from 'vscode-uri';
+import type { LangiumGrammarServices } from 'langium/grammar';
+import type { LangiumSharedServices } from 'langium/lsp';
+import type { Connection, WorkspaceFolder } from 'vscode-languageserver';
+
+export function registerLangiumConfigHandler(connection: Connection, shared: LangiumSharedServices, grammar: LangiumGrammarServices) {
+    async function tryConfig(filePath: string) {
+        try {
+            const json = await fs.readFile(filePath, { encoding: 'utf-8' });
+            let config = JSON.parse(json);
+            if (path.basename(filePath) === 'package.json') {
+                config = config.langium;
+            }
+            if (typeof config === 'object' && config !== null) {
+                // Langium config found, apply validation options
+                grammar.validation.LangiumGrammarValidator.options = config.validation ?? {};
+                return config;
+            }
+            return undefined;
+        } catch (_error) {
+            return undefined;
+        }
+    }
+
+    let workspaceFolders: WorkspaceFolder[] | undefined;
+    shared.lsp.LanguageServer.onInitialize((params) => {
+        workspaceFolders = params.workspaceFolders ?? undefined;
+    });
+
+    async function updateConfig(configPath: string): Promise<string | undefined> {
+        if (typeof configPath !== 'string') {
+            return;
+        }
+        if (path.isAbsolute(configPath)) {
+            const normalized = path.normalize(configPath);
+            const result = await tryConfig(normalized);
+            if (result) {
+                return normalized;
+            }
+        }
+        // Try to find a configuration file in workspace folders
+        for (const folder of workspaceFolders ?? []) {
+            const filePath = path.join(URI.parse(folder.uri).fsPath, configPath);
+            const result = await tryConfig(filePath);
+            if (result) {
+                return filePath;
+            }
+        }
+        return undefined;
+    }
+
+    let configPath: string | undefined;
+    async function configChanged(newConfigPath: string) {
+        const resolved = await updateConfig(newConfigPath);
+        if (!resolved) {
+            // No configuration file found, use default validation options
+            grammar.validation.LangiumGrammarValidator.options = {};
+        }
+        configPath = resolved;
+
+        // Revalidate all documents
+        const documents = shared.workspace.LangiumDocuments;
+        const documentBuilder = shared.workspace.DocumentBuilder;
+        await documentBuilder.build(documents.all.toArray(), { validation: true });
+    }
+
+    // Load validation options from configuration
+    shared.lsp.LanguageServer.onInitialized(async () => {
+        const setting = (await shared.workspace.ConfigurationProvider.getConfiguration('langium', 'config')) || 'langium-config.json';
+        configPath = await updateConfig(setting);
+    });
+
+    // Update validation options when configuration changes
+    shared.workspace.ConfigurationProvider.onConfigurationSectionUpdate(async update => {
+        if (update.section === 'langium' && typeof update.configuration === 'object' && update.configuration !== null) {
+            const newConfigPath = update.configuration.config || 'langium-config.json';
+            if (newConfigPath !== configPath) {
+                await configChanged(newConfigPath);
+            }
+        }
+    });
+
+    // Update validation options when the config file is changed
+    shared.lsp.DocumentUpdateHandler.onWatchedFilesChange(params => {
+        if (!configPath) {
+            return;
+        }
+        for (const change of params.changes) {
+            const uri = URI.parse(change.uri);
+            if (uri.fsPath === configPath) {
+                configChanged(uri.fsPath).catch(err => console.error(err));
+                return;
+            }
+        }
+    });
+}

--- a/packages/langium-vscode/src/language-server/main.ts
+++ b/packages/langium-vscode/src/language-server/main.ts
@@ -4,13 +4,14 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import type { Module } from 'langium';
+import { type Module } from 'langium';
 import { createLangiumGrammarServices } from 'langium/grammar';
 import { startLanguageServer, type LangiumSharedServices, type PartialLangiumSharedServices } from 'langium/lsp';
 import { NodeFileSystem } from 'langium/node';
 import { ProposedFeatures, createConnection } from 'vscode-languageserver/node.js';
 import { LangiumGrammarWorkspaceManager } from './grammar-workspace-manager.js';
 import { registerRailroadConnectionHandler } from './railroad-handler.js';
+import { registerLangiumConfigHandler } from './config-handler.js';
 
 const connection = createConnection(ProposedFeatures.all);
 
@@ -21,5 +22,6 @@ export const LangiumGrammarSharedModule: Module<LangiumSharedServices, PartialLa
 };
 
 const { shared, grammar } = createLangiumGrammarServices({ connection, ...NodeFileSystem }, LangiumGrammarSharedModule);
+registerLangiumConfigHandler(connection, shared, grammar);
 registerRailroadConnectionHandler(connection, grammar);
 startLanguageServer(shared);

--- a/packages/langium/src/grammar/langium-grammar-module.ts
+++ b/packages/langium/src/grammar/langium-grammar-module.ts
@@ -5,6 +5,7 @@
  ******************************************************************************/
 
 import type { Module } from '../dependency-injection.js';
+import type { DeepPartial } from '../services.js';
 import type { LangiumServices, LangiumSharedServices, PartialLangiumServices, PartialLangiumSharedServices } from '../lsp/lsp-services.js';
 import { LangiumGrammarTypeHierarchyProvider } from './lsp/grammar-type-hierarchy.js';
 import type { LangiumGrammarDocument } from './workspace/documents.js';
@@ -71,7 +72,7 @@ export const LangiumGrammarModule: Module<LangiumGrammarServices, PartialLangium
  */
 export function createLangiumGrammarServices(context: DefaultSharedModuleContext,
     sharedModule?: Module<LangiumSharedServices, PartialLangiumSharedServices>,
-    module?: Module<LangiumServices, PartialLangiumServices>): {
+    module?: Module<LangiumGrammarServices, DeepPartial<LangiumServices & LangiumGrammarAddedServices>>): {
         shared: LangiumSharedServices,
         grammar: LangiumGrammarServices
     } {

--- a/packages/langium/src/lsp/language-server.ts
+++ b/packages/langium/src/lsp/language-server.ts
@@ -508,9 +508,7 @@ export function addSemanticTokenHandler(connection: Connection, services: Langiu
 }
 export function addConfigurationChangeHandler(connection: Connection, services: LangiumSharedServices): void {
     connection.onDidChangeConfiguration(change => {
-        if (change.settings) {
-            services.workspace.ConfigurationProvider.updateConfiguration(change);
-        }
+        services.workspace.ConfigurationProvider.updateConfiguration(change);
     });
 }
 

--- a/packages/langium/src/workspace/configuration.ts
+++ b/packages/langium/src/workspace/configuration.ts
@@ -87,9 +87,9 @@ export class DefaultConfigurationProvider implements ConfigurationProvider {
 
     protected readonly serviceRegistry: ServiceRegistry;
     protected readonly _ready = new Deferred<void>();
+    protected readonly onConfigurationSectionUpdateEmitter = new Emitter<ConfigurationSectionUpdate>();
     protected settings: Record<string, Record<string, any>> = {};
     protected workspaceConfig = false;
-    protected onConfigurationSectionUpdateEmitter = new Emitter<ConfigurationSectionUpdate>();
 
     constructor(services: LangiumSharedCoreServices) {
         this.serviceRegistry = services.ServiceRegistry;
@@ -141,11 +141,10 @@ export class DefaultConfigurationProvider implements ConfigurationProvider {
      * `settings` property of the change object could be expressed as `Record<string, Record<string, any>>`
      */
     updateConfiguration(change: DidChangeConfigurationParams): void {
-        if (!change.settings) {
+        if (typeof change.settings !== 'object' || change.settings === null) {
             return;
         }
-        Object.keys(change.settings).forEach(section => {
-            const configuration = change.settings[section];
+        Object.entries(change.settings).forEach(([section, configuration]) => {
             this.updateSectionConfiguration(section, configuration);
             this.onConfigurationSectionUpdateEmitter.fire({ section, configuration });
         });


### PR DESCRIPTION
Closes #385.

This introduces a vscode setting for the Langium config file path and sets up configuration change watchers so all grammar files are revalidated when either the config file path or the config file content changes.

The actual strict mode is then a rather easy change, forbidding inferred types in your grammar definitions.