### PR TITLE
Supplement of the generator API

### DIFF
--- a/packages/langium/src/generate/generator-node.ts
+++ b/packages/langium/src/generate/generator-node.ts
@@ -1117,9 +1117,9 @@ export function traceToNodeIf<T extends AstNode>(condition: boolean, source: T |
  */
 export class IndentNode extends CompositeGeneratorNode {
 
-    indentation?: string;
-    indentImmediately = true;
-    indentEmptyLines = false;
+    readonly indentation?: string;
+    readonly indentImmediately;
+    readonly indentEmptyLines;
 
     constructor(indentation?: string | number, indentImmediately = true, indentEmptyLines = false) {
         super();
@@ -1133,19 +1133,22 @@ export class IndentNode extends CompositeGeneratorNode {
     }
 }
 
+export namespace NewLineNode {
+    /**
+     * Integer range type allowing to specify 1 to 6 consecutive line breaks, i.e. up to 5 empty lines with a single `NewLineNode`.
+     */
+    export type NoOfLineBreaks = 1 | 2 | 3 | 4 | 5 | 6;
+}
+
 /**
  * Implementation of @{link GeneratorNode} denoting linebreaks in the desired generated text.
  */
 export class NewLineNode {
-
-    lineDelimiter: string;
-
-    ifNotEmpty = false;
-
-    constructor(lineDelimiter?: string, ifNotEmpty = false) {
-        this.lineDelimiter = lineDelimiter ?? EOL;
-        this.ifNotEmpty = ifNotEmpty;
-    }
+    constructor(
+        public readonly lineDelimiter: string = EOL,
+        public readonly ifNotEmpty: boolean = false,
+        public readonly count: NewLineNode.NoOfLineBreaks = 1
+    ) {}
 }
 
 export const NL = new NewLineNode();

--- a/packages/langium/src/generate/generator-node.ts
+++ b/packages/langium/src/generate/generator-node.ts
@@ -1118,10 +1118,10 @@ export function traceToNodeIf<T extends AstNode>(condition: boolean, source: T |
 export class IndentNode extends CompositeGeneratorNode {
 
     readonly indentation?: string;
-    readonly indentImmediately;
-    readonly indentEmptyLines;
+    readonly indentImmediately: boolean;
+    readonly indentEmptyLines: boolean;
 
-    constructor(indentation?: string | number, indentImmediately = true, indentEmptyLines = false) {
+    constructor(indentation?: string | number, indentImmediately: boolean = true, indentEmptyLines: boolean = false) {
         super();
         if (typeof (indentation) === 'string') {
             this.indentation = indentation;

--- a/packages/langium/src/generate/generator-node.ts
+++ b/packages/langium/src/generate/generator-node.ts
@@ -198,6 +198,25 @@ export class CompositeGeneratorNode {
     }
 
     /**
+     * Prepends `strings` and instances of {@link GeneratorNode} to the content of `this` generator node.
+     *
+     * @param content a var arg mixture of `strings` or {@link GeneratorNode GeneratorNodes}.
+     *
+     * @returns `this` {@link CompositeGeneratorNode} for convenience.
+     *
+     * @example
+     *   generateSomeContent()?.prepend(
+     *      'Some preamble text:', NL
+     *   ).append(
+     *      'Some postamble text:', NL
+     *   );
+     */
+    prepend(...content: Generated[]): this {
+        this.contents.unshift(...content.filter(c => c !== undefined));
+        return this;
+    }
+
+    /**
      * Appends `strings` and instances of {@link GeneratorNode} to `this` generator node, if `condition` is equal to `true`.
      *
      * If `condition` is satisfied this method delegates to {@link append}, otherwise it returns just `this`.
@@ -218,6 +237,30 @@ export class CompositeGeneratorNode {
      */
     appendIf(condition: boolean, ...content: Array<Generated | ((node: CompositeGeneratorNode) => void)>): this {
         return condition ? this.append(...content) : this;
+    }
+
+    /**
+     * Prepends `strings` and instances of {@link GeneratorNode} to the content of `this` generator node, if `condition` is equal to `true`.
+     *
+     * If `condition` is satisfied this method delegates to {@link prepend}, otherwise it returns just `this`.
+     *
+     * @param condition a boolean value indicating whether to prepend the elements of `args` to the content of `this`.
+     *
+     * @param content a var arg mixture of `strings` or {@link GeneratorNode GeneratorNodes}.
+     *
+     * @returns `this` {@link CompositeGeneratorNode} for convenience.
+     *
+     * @example
+     *   generateSomeContent()?.prependIf(
+     *      generatePreamble === true,
+     *      'Some preamble', NL
+     *   ).appendIf(
+     *      generatePostamble === true,
+     *      'Some postamble', NL
+     *   );
+     */
+    prependIf(condition: boolean, ...content: Generated[]): this {
+        return condition ? this.prepend(...content) : this;
     }
 
     /**

--- a/packages/langium/src/generate/node-joiner.ts
+++ b/packages/langium/src/generate/node-joiner.ts
@@ -8,12 +8,36 @@ import type { AstNode, Properties } from '../syntax-tree.js';
 import { CompositeGeneratorNode, type Generated, isGeneratorNode, NewLineNode, traceToNode } from './generator-node.js';
 import type { SourceRegion } from './generator-tracing.js';
 
-export interface JoinOptions<T> {
-    filter?: (element: T, index: number, isLast: boolean) => boolean;
-    prefix?: Generated | ((element: T, index: number, isLast: boolean) => Generated | undefined);
-    suffix?: Generated | ((element: T, index: number, isLast: boolean) => Generated | undefined);
+export interface JoinOptions<T, U extends T = T> {
+    /**
+     * A plain or type guard filter function.
+     *
+     * Benefit compared to pre-filtering the joined iterable: Original indices of the elements are preserved and forwarded to the `toGenerated` function.
+     */
+    filter?: ((element: T, index: number, isLast: boolean) => boolean) | ((element: T, index: number, isLast: boolean) => element is U);
+
+    /** A fixed prefix or prefix computation function to be prepended before each element of the iterable. */
+    prefix?: Generated | ((element: U, index: number, isLast: boolean) => Generated | undefined);
+
+    /** A fixed suffix or suffix computation function to be appended after each element of the iterable. */
+    suffix?: Generated | ((element: U, index: number, isLast: boolean) => Generated | undefined);
+
+    /** A fixed element separator to be inserted between 2 consecutive non-undefined item representations incl. their suffixes and prefixes. */
     separator?: Generated;
+
+    /**
+     * Activates appending of up 6 line breaks after a non-undefined element + suffix + separator if given.
+     *
+     * If `true` a single line break is appended.
+     *
+     * If a number `> 6` is required you can achieve that via the `separator` or `suffix` options,
+     *  e.g. `separator: new CompositeGeneratorNode(calcLineBreaks(...))`.
+     */
     appendNewLineIfNotEmpty?: true | NewLineNode.NoOfLineBreaks;
+
+    /**
+     * Suppresses appending trailing line breaks after the last item in the iterable if activated via `appendNewLineIfNotEmpty`.
+     */
     skipNewLineAfterLastItem?: true;
 }
 
@@ -32,7 +56,7 @@ const defaultToGenerated = (e: unknown): Generated => e === undefined || typeof 
  *
  * Examples:
  * ```
- *   exandToNode`
+ *   expandToNode`
  *       ${ joinToNode(['a', 'b'], { appendNewLineIfNotEmpty: true }) }
  *
  *       ${ joinToNode(new Set(['a', undefined, getElementNode()]), { separator: ',', appendNewLineIfNotEmpty: true }) }
@@ -43,8 +67,8 @@ const defaultToGenerated = (e: unknown): Generated => e === undefined || typeof 
  *
  * @param options optional config object for defining a `separator`, contributing specialized
  *  `prefix` and/or `suffix` providers, and activating conditional line-break insertion. In addition,
- *  a dedicated `filter` function can be provided that is required get provided with the original
- *  element indices in the aforementioned functions, if the list is to be filtered. If
+ *  a dedicated `filter` function can be provided that enables the provision of the original
+ *  element indices to the aforementioned functions, if the list is to be filtered. If
  *  {@link Array.filter} would be applied to the original list, the indices will be those of the
  *  filtered list during subsequent processing that in particular will cause confusion when using
  *  the tracing variant of this function named ({@link joinTracedToNode}).
@@ -65,7 +89,7 @@ export function joinToNode<Generated>(
  *
  * Examples:
  * ```
- *   exandToNode`
+ *   expandToNode`
  *       ${ joinToNode(['a', 'b'], String, { appendNewLineIfNotEmpty: true }) }
  *
  *       ${ joinToNode(new Set(['a', undefined, 'b']), e => e && String(e), { separator: ',', appendNewLineIfNotEmpty: true }) }
@@ -80,8 +104,8 @@ export function joinToNode<Generated>(
  *
  * @param options optional config object for defining a `separator`, contributing specialized
  *  `prefix` and/or `suffix` providers, and activating conditional line-break insertion. In addition,
- *  a dedicated `filter` function can be provided that is required get provided with the original
- *  element indices in the aformentioned functions, if the list is to be filtered. If
+ *  a dedicated `filter` function can be provided that enables the provision of the
+ *  original element indices to the aforementioned functions, if the list is to be filtered. If
  *  {@link Array.filter} would be applied to the original list, the indices will be those of the
  *  filtered list during subsequent processing that in particular will cause confusion when using
  *  the tracing variant of this function named ({@link joinTracedToNode}).
@@ -91,6 +115,46 @@ export function joinToNode<T>(
     iterable: Iterable<T> | T[],
     toGenerated?: ((element: T, index: number, isLast: boolean) => Generated),
     options?: JoinOptions<T>
+): CompositeGeneratorNode | undefined;
+
+/**
+ * Joins the elements of the given `iterable` by applying `toGenerated` to each element
+ * and appending the results to a {@link CompositeGeneratorNode} being returned finally.
+ *
+ * Here the mandatory type guard `filter` function is used to filter the elements of
+ * `iterable` and to apply the `toGenerated` function as well as the optional
+ * `prefix` and `suffix` functions to the accepted items with the more specific type
+ * `U` and their original indices.
+ *
+ * Note: empty strings being returned by `toGenerated` are treated as ordinary string
+ * representations, while the result of `undefined` makes this function to ignore the
+ * corresponding item and no separator is appended, if configured.
+ *
+ * Example:
+ * ```
+ *   expandToNode`
+ *       ${ joinToNode([x, y], e => e.propertyOfX, { filter: (e): e is X => e.$type === 'X' }) }
+ *   `
+ * ```
+ *
+ * @param iterable an {@link Array} or {@link Iterable} providing the elements to be joined
+ *
+ * @param toGenerated a callback converting each individual element to a string, a
+ *  {@link CompositeGeneratorNode}, or to `undefined` if to be omitted, defaults to the `identity`
+ *  for strings, generator nodes, and `undefined`, and to {@link String} otherwise.
+ *
+ * @param options config object including the here required type guard filter function, as well as
+ *  optional `separator` and `prefix` and/or `suffix` providers, and activating conditional
+ *  line-break insertion.
+ *  In contrast to {@link Array.filter} the dedicated `filter` function enables the provision of the
+ *  original element indices to `toGenerated` and the aforementioned functions, if the list is to be
+ *  filtered.
+ * @returns the resulting {@link CompositeGeneratorNode} representing `iterable`'s content
+ */
+export function joinToNode<T, U extends T>(
+    iterable: Iterable<T> | T[],
+    toGenerated: ((element: U, index: number, isLast: boolean) => Generated),
+    options: JoinOptions<T, U> & { filter: (element: T, index: number, isLast: boolean) => element is U; } // the type guard filter function is mandatory here!
 ): CompositeGeneratorNode | undefined;
 
 export function joinToNode<T>(
@@ -122,12 +186,9 @@ export function joinToNode<T>(
                 // besides, append the newLine(s) only if more lines are following, or if appending a newline
                 //  is not suppressed for the final item
                 !node.isEmpty() && !!appendNewLineIfNotEmpty && (!isLast || !skipNewLineAfterLastItem),
-                n => {
-                    if (appendNewLineIfNotEmpty === true || appendNewLineIfNotEmpty === 1)
-                        n.appendNewLineIfNotEmpty();
-                    else
-                        n.append(new NewLineNode(undefined, true, appendNewLineIfNotEmpty));
-                }
+                n => (appendNewLineIfNotEmpty === true || appendNewLineIfNotEmpty === 1)
+                    ? n.appendNewLineIfNotEmpty()
+                    : n.append(new NewLineNode(undefined, true, appendNewLineIfNotEmpty))
             );
     });
 }

--- a/packages/langium/src/generate/node-processor.ts
+++ b/packages/langium/src/generate/node-processor.ts
@@ -290,8 +290,11 @@ function processNewLineNode(node: NewLineNode, context: Context) {
         context.resetCurrentLine();
     } else {
         handlePendingIndent(context, true);
-        context.append(node.lineDelimiter);
-        context.addNewLine();
+        let count = node.count;
+        while (count-- > 0) {
+            context.append(node.lineDelimiter);
+            context.addNewLine();
+        }
     }
 }
 

--- a/packages/langium/test/generate/node.test.ts
+++ b/packages/langium/test/generate/node.test.ts
@@ -45,10 +45,28 @@ describe('new lines', () => {
         expect(process(comp)).toBe(`First${EOL}${EOL}Second`);
     });
 
+    test('should create 3 line breaks', () => {
+        const comp = new CompositeGeneratorNode();
+        comp.append('First', new NewLineNode(undefined, false, 3), 'Second');
+        expect(process(comp)).toBe(`First${EOL}${EOL}${EOL}Second`);
+    });
+
+    test('should create 5 line breaks after previous non-empty line', () => {
+        const comp = new CompositeGeneratorNode();
+        comp.append('First', new NewLineNode(undefined, true, 5), 'Second');
+        expect(process(comp)).toBe(`First${EOL}${EOL}${EOL}${EOL}${EOL}Second`);
+    });
+
     test('should not create multiple new lines on previous empty line', () => {
         const comp = new CompositeGeneratorNode();
         comp.append('First', NL, NLEmpty, 'Second');
         expect(process(comp)).toBe(`First${EOL}Second`);
+    });
+
+    test('should not create 5 line breaks after previous empty line', () => {
+        const comp = new CompositeGeneratorNode();
+        comp.append('', new NewLineNode(undefined, true, 5), 'Second');
+        expect(process(comp)).toBe('Second');
     });
 
 });
@@ -135,10 +153,9 @@ describe('indentation', () => {
     test('should indent 2 spaces by default after new line if specified', () => {
         const comp = new CompositeGeneratorNode();
         comp.append('No indent', NL);
-        const indent = new IndentNode();
+        const indent = new IndentNode('  ');
         indent.append('Indent');
         comp.append(indent);
-        indent.indentation = '  ';
         expect(process(comp)).toBe(`No indent${EOL}  Indent`);
     });
 

--- a/packages/langium/test/generate/node.test.ts
+++ b/packages/langium/test/generate/node.test.ts
@@ -21,7 +21,7 @@ describe('new lines', () => {
         expect(process(comp)).toBe(`First${EOL}Second`);
     });
 
-    test('should process with speicified line delimiter', () => {
+    test('should process with specified line delimiter', () => {
         const comp = new CompositeGeneratorNode();
         comp.append('First', new NewLineNode('/'), 'Second');
         expect(process(comp)).toBe('First/Second');
@@ -202,6 +202,30 @@ describe('composite', () => {
         const comp = new CompositeGeneratorNode();
         comp.append('Some ', node => node.append('more'), ' text');
         expect(process(comp)).toBe('Some more text');
+    });
+
+    test('should prepend strings', () => {
+        const comp = new CompositeGeneratorNode('Some content.');
+        comp.prepend('A', ' ', 'preamble', NL);
+        comp.append(NL, 'The', ' ', 'postamble');
+        expect(process(comp)).toBe(`A preamble${EOL}Some content.${EOL}The postamble`);
+    });
+
+    test('should prepend optional generator nodes', () => {
+        const prefix = [ new CompositeGeneratorNode('Preamble'), NL, undefined ];
+        const comp = new CompositeGeneratorNode('Some content.');
+        comp.prepend(...prefix);
+
+        expect(process(comp)).toBe(`Preamble${EOL}Some content.`);
+    });
+
+    test('should conditionally prepend optional generator nodes', () => {
+        const prefix = [ new CompositeGeneratorNode('Preamble'), NL, undefined ];
+        const comp = new CompositeGeneratorNode('Some content.').prependIf(false, ...prefix);
+        expect(process(comp)).toBe('Some content.');
+
+        comp.prependIf(true, ...prefix);
+        expect(process(comp)).toBe(`Preamble${EOL}Some content.`);
     });
 
     test('should indent without function argument', () => {

--- a/packages/langium/test/generate/template-node.test.ts
+++ b/packages/langium/test/generate/template-node.test.ts
@@ -1133,6 +1133,41 @@ describe('Joining lists', () => {
         `);
     });
 
+    test('ForEach loop with 3 line breaks if not empty', () => {
+        const node = n`
+            Data:
+              ${joinToNode(stream(['a', ' ', 'b']), String, { appendNewLineIfNotEmpty: 3})}
+        `;
+        const text = toString(node);
+        expect(text).toBe(s`
+            Data:
+              a
+            
+            
+              b
+            
+            
+            
+        `);
+    });
+    test('ForEach loop with 6 line breaks if not empty and skip line break after last line', () => {
+        const node = n`
+            Data:
+              ${joinToNode(stream(['a', '\t', 'b']), String, { appendNewLineIfNotEmpty: 6, skipNewLineAfterLastItem: true})}
+        `;
+        const text = toString(node);
+        expect(text).toBe(s`
+            Data:
+              a
+            
+            
+            
+            
+            
+              b
+        `);
+    });
+
 });
 
 describe('Appending templates to existing nodes', () => {

--- a/packages/langium/test/generate/template-node.test.ts
+++ b/packages/langium/test/generate/template-node.test.ts
@@ -4,8 +4,8 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import { stream } from 'langium';
-import { CompositeGeneratorNode, EOL, NL, joinToNode, expandToNode as n, expandToString as s, toString } from 'langium/generate';
+import { EMPTY_STREAM, stream } from 'langium';
+import { CompositeGeneratorNode, EOL, NL, type NewLineNode, joinToNode, expandToNode as n, expandToString as s, toString } from 'langium/generate';
 import { describe, expect, test } from 'vitest';
 
 // deactivate the eslint check 'no-unexpected-multiline' with the message
@@ -873,7 +873,7 @@ describe('Multiple nested substitution templates', () => {
 });
 
 describe('Joining lists', () => {
-    test('ForEach loop with empty iterable', () => {
+    test('Joining an empty iterable 1', () => {
         const node = n`
             Data:
               ${joinToNode([], String, { appendNewLineIfNotEmpty: true})}
@@ -885,10 +885,10 @@ describe('Joining lists', () => {
             Footer:
         `);
     });
-    test('ForEach loop with empty iterable 2 (\'toGenerated\' === \'undefined\')', () => {
+    test('Joining an empty iterable 2 (\'toGenerated\' === \'undefined\')', () => {
         const node = n`
             Data:
-              ${joinToNode([], undefined, { appendNewLineIfNotEmpty: true})}
+              ${joinToNode(EMPTY_STREAM, undefined, { appendNewLineIfNotEmpty: true})}
             Footer:
         `;
         const text = toString(node);
@@ -897,10 +897,10 @@ describe('Joining lists', () => {
             Footer:
         `);
     });
-    test('ForEach loop with empty iterable 3 (no \'toGenerated\')', () => {
+    test('Joining an empty iterable 3 (no \'toGenerated\')', () => {
         const node = n`
             Data:
-              ${joinToNode([], { appendNewLineIfNotEmpty: true})}
+              ${joinToNode(new Set(), { appendNewLineIfNotEmpty: true})}
             Footer:
         `;
         const text = toString(node);
@@ -909,7 +909,7 @@ describe('Joining lists', () => {
             Footer:
         `);
     });
-    test('ForEach loop with Array input (no \'toGenerated\', no \'options\')', () => {
+    test('Joining an Array input (no \'toGenerated\', no \'options\')', () => {
         const node = n`
             Data:
               ${joinToNode(['a', 'b'])}
@@ -920,7 +920,7 @@ describe('Joining lists', () => {
               ab
         `);
     });
-    test('ForEach loop with separator and Array input', () => {
+    test('Joining with separator and Array input 1', () => {
         const node = n`
             Data:
               ${joinToNode(['a', 'b'], String, { separator: ', ' })}
@@ -931,7 +931,7 @@ describe('Joining lists', () => {
               a, b
         `);
     });
-    test('ForEach loop with separator and Array input 2 (\'toGenerated\' === \'undefined\')', () => {
+    test('Joining with separator and Array input 2 (\'toGenerated\' === \'undefined\')', () => {
         const node = n`
             Data:
               ${joinToNode(['a', 'b'], undefined, { separator: ', ' })}
@@ -942,7 +942,7 @@ describe('Joining lists', () => {
               a, b
         `);
     });
-    test('ForEach loop with separator and Array input 3 (no \'toGenerated\')', () => {
+    test('Joining with separator and Array input 3 (no \'toGenerated\')', () => {
         const node = n`
             Data:
               ${joinToNode(['a', 'b'], { separator: ', ' })}
@@ -953,7 +953,7 @@ describe('Joining lists', () => {
               a, b
         `);
     });
-    test('ForEach loop with separator and Array of generator nodes input', () => {
+    test('Joining with separator and Array of generator nodes input 1', () => {
         const node = n`
             Data:
               ${joinToNode([n`a`, ' b', NL], n => n, { separator: ',' })}
@@ -965,7 +965,7 @@ describe('Joining lists', () => {
 
         `);
     });
-    test('ForEach loop with separator and Array of generator nodes input 2 (\'toGenerated\' === \'undefined\')', () => {
+    test('Joining with separator and Array of generator nodes input 2 (\'toGenerated\' === \'undefined\')', () => {
         const node = n`
             Data:
               ${joinToNode([n`a`, ' b', NL], undefined, { separator: ',' })}
@@ -977,7 +977,7 @@ describe('Joining lists', () => {
 
         `);
     });
-    test('ForEach loop with separator and Array of generator nodes input 3 (no \'toGenerated\')', () => {
+    test('Joining with separator and Array of generator nodes input 3 (no \'toGenerated\')', () => {
         const node = n`
             Data:
               ${joinToNode([n`a`, ' b', NL], { separator: ',' })}
@@ -989,7 +989,7 @@ describe('Joining lists', () => {
 
         `);
     });
-    test('ForEach loop with element prefix and Array input', () => {
+    test('Joining with element prefix and Array input 1', () => {
         const node = n`
             Data:
               ${joinToNode(['a', 'b'], String, { prefix: ',' })}
@@ -1000,7 +1000,7 @@ describe('Joining lists', () => {
               ,a,b
         `);
     });
-    test('ForEach loop with element prefix and Array input 2 (function)', () => {
+    test('Joining with element prefix and Array input 2 (function)', () => {
         const node = n`
             Data:
               ${joinToNode(['a', 'b'], String, { prefix: (e, i) => i === 0 ? '': ', ' })}
@@ -1011,7 +1011,7 @@ describe('Joining lists', () => {
               a, b
         `);
     });
-    test('ForEach loop with element suffix and Set input', () => {
+    test('Joining with element suffix and Set input 1', () => {
         const node = n`
             Data:
               ${joinToNode(new Set(['a', 'b']), String, { suffix: ',' })}
@@ -1022,7 +1022,7 @@ describe('Joining lists', () => {
               a,b,
         `);
     });
-    test('ForEach loop with element suffix and Set input 2 (function)', () => {
+    test('Joining with element suffix and Set input 2 (function)', () => {
         const node = n`
             Data:
               ${joinToNode(new Set(['a', 'b']), String, { suffix: (e, i, isLast) => isLast ? '': ', ' })}
@@ -1033,7 +1033,7 @@ describe('Joining lists', () => {
               a, b
         `);
     });
-    test('ForEach loop with Stream input (no \'toGenerated\', no \'options\')', () => {
+    test('Joining with Stream input (no \'toGenerated\', no \'options\')', () => {
         const node = n`
             Data:
               ${joinToNode(stream('a', 'b'))}
@@ -1044,7 +1044,35 @@ describe('Joining lists', () => {
               ab
         `);
     });
-    test('ForEach loop with line breaks and Stream input', () => {
+    test('Joining with filter function', () => {
+        const node = n`
+            Data:
+              ${joinToNode(stream(['a', 'b']), String, { filter: e => e !== 'a' })}
+        `;
+        const text = toString(node);
+        expect(text).toBe(s`
+            Data:
+              b
+        `);
+    });
+
+    test('Joining with type guard filter function, prefix, and separator', () => {
+        const isAorC =      (e: string): e is 'a' | 'c' => e === 'a' || e === 'c';
+        const toGenerated = (e: 'a' | 'c')              => String(e);
+        const prefix =      (e: 'a' | 'c')              => e === 'a' ? '*' : undefined;
+
+        const node = n`
+            Data:
+              ${joinToNode(stream(['a', 'b', 'c']), toGenerated, { filter: isAorC, prefix, separator: ','})}
+        `;
+        const text = toString(node);
+        expect(text).toBe(s`
+            Data:
+              *a,c
+        `);
+    });
+
+    test('Joining with line breaks and Stream input', () => {
         const node = n`
             Data:
               ${joinToNode(stream(['a', 'b']), String, { appendNewLineIfNotEmpty: true})}
@@ -1057,7 +1085,7 @@ describe('Joining lists', () => {
             
         `);
     });
-    test('ForEach loop with line breaks and skip line break after last line and Stream input', () => {
+    test('Joining with line breaks and skip line break after last line and Stream input', () => {
         const node = n`
             Data:
               ${joinToNode(stream(['a', 'b']), String, { appendNewLineIfNotEmpty: true, skipNewLineAfterLastItem: true})}
@@ -1069,7 +1097,7 @@ describe('Joining lists', () => {
               b
         `);
     });
-    test('ForEach loop with separator, line breaks, and Stream input', () => {
+    test('Joining with separator, line breaks, and Stream input', () => {
         const node = n`
             Data:
               ${joinToNode(stream(['a', undefined, 'b']), String, { separator: ',', appendNewLineIfNotEmpty: true})}
@@ -1083,7 +1111,7 @@ describe('Joining lists', () => {
             
         `);
     });
-    test('ForEach loop with separator, line breaks and skip line break after last line, and Stream input', () => {
+    test('Joining with separator, line breaks and skip line break after last line, and Stream input', () => {
         const node = n`
             Data:
               ${joinToNode(stream(['a', undefined, 'b']), String, { separator: ',', appendNewLineIfNotEmpty: true, skipNewLineAfterLastItem: true})}
@@ -1096,7 +1124,7 @@ describe('Joining lists', () => {
               b
         `);
     });
-    test('ForEach loop with omitted `undefined`, separator, line breaks and Stream input', () => {
+    test('Joining with omitted `undefined`, separator, line breaks and Stream input', () => {
         const node = n`
             Data:
               ${joinToNode(stream(['a', undefined, 'b']), e => e && String(e), { separator: ',', appendNewLineIfNotEmpty: true})}
@@ -1109,7 +1137,7 @@ describe('Joining lists', () => {
             
         `);
     });
-    test('ForEach loop with omitted `undefined`, separator, line breaks and skip line break after last line, and Stream input', () => {
+    test('Joining with omitted `undefined`, separator, line breaks and skip line break after last line, and Stream input', () => {
         const node = n`
             Data:
               ${joinToNode(stream(['a', undefined, 'b']), e => e && String(e), { separator: ',', appendNewLineIfNotEmpty: true, skipNewLineAfterLastItem: true})}
@@ -1121,8 +1149,7 @@ describe('Joining lists', () => {
               b
         `);
     });
-
-    test('Nested ForEach loop with empty iterable followed by an indented line', () => {
+    test('Nested joining of empty iterable followed by an indented line', () => {
         const node = n`
             ${joinToNode([], { appendNewLineIfNotEmpty: true})}
             a
@@ -1132,8 +1159,7 @@ describe('Joining lists', () => {
             a
         `);
     });
-
-    test('ForEach loop with 3 line breaks if not empty', () => {
+    test('Joining with 3 line breaks if not empty', () => {
         const node = n`
             Data:
               ${joinToNode(stream(['a', ' ', 'b']), String, { appendNewLineIfNotEmpty: 3})}
@@ -1150,7 +1176,7 @@ describe('Joining lists', () => {
             
         `);
     });
-    test('ForEach loop with 6 line breaks if not empty and skip line break after last line', () => {
+    test('Joining with 6 line breaks if not empty and skip line breaks after last line if not empty', () => {
         const node = n`
             Data:
               ${joinToNode(stream(['a', '\t', 'b']), String, { appendNewLineIfNotEmpty: 6, skipNewLineAfterLastItem: true})}
@@ -1167,7 +1193,18 @@ describe('Joining lists', () => {
               b
         `);
     });
-
+    test('Joining with a computed number of line breaks', () => {
+        const lbs: NewLineNode.NoOfLineBreaks = [].length === 0 ? 2 : 3;
+        const node = n`
+              ${joinToNode(stream(['a', '\t', 'b']), String, { appendNewLineIfNotEmpty: lbs, skipNewLineAfterLastItem: true})}
+        `;
+        const text = toString(node);
+        expect(text).toBe(s`
+              a
+            
+              b
+        `);
+    });
 });
 
 describe('Appending templates to existing nodes', () => {


### PR DESCRIPTION
This PR contributes 2 supplements to the generator API of 'langium/generate'.

1. `CompositeGeneratorNode.prepend(...)` & `CompositeGeneratorNode.prependIf(...)`:
    This enables prepending pre-composed generator node with a prefix, esp. depending on previously executed logic creates composite generator node conditionally. This new API facilitates expressions like
    ```js
   expandToNode`
     foo {
       ${generateBarIfPresent(foo.bar)?.prepend('bar: ')}${generateFlagIfPresent(foo.flag)?.prepend(' ')}
     }
    `
    ```
    that prepend some preceding text or whitespace to conditionally created content depending on its presence.

2. Multiple linebreak separator insertion by `joinToNode(list, toStringFunc, { appendNewLineIfNotEmpty: 3 })`:
   The current version `joinToNode(...., { appendNewLineIfNotEmpty: true })` permits single linebreaks only.

   Attempting to achieve the generation of elements of a list with the generated representations being separated by one or more empty lines — i.e. inserting more than one linebreak — quickly ends in a hassle, if those separating lines shall not be added to the end of the list or produced if the list is empty. For example:
   ```js
   expandToNode`
       ${joinToNode(model.declarations, generateDeclaration, { appendNewLineIfNotEmpty: 2, skipNewLineAfterLastItem: model.statements.isEmpty()})}
       ${joinToNode(model.statements,   generateStatement,   { appendNewLineIfNotEmpty: 2, skipNewLineAfterLastItem: true })}
   `
   ```
   This way all the `declarations` and `statements` are separated by 2 line breaks -> 1 empty line with:
      * no extra leading line breaks are added if `model.declarations` is empty
      * no extra trailing line breaks are added if `model.statements` is empty
      * no linebreaks are added at all if both lists are empty
    
   This contribution adds support for 1 to 5 empty separator lines requiring up to 6 linebreaks.
   Thus, `appendNewLineIfNotEmpty` now accepts values of the union `true | 1 | 2 | 3 | 4 | 5 | 6`.
   
   In order to implement this, I extended `NewLineNode` and the generator node processor correspondingly.