### PR TITLE
Define Grammar AST types explicitly, drop topological sorting of interfaces, refine EBNF-based terminals to avoid synthetic capturing groups

### DIFF
--- a/examples/arithmetics/src/language-server/generated/grammar.ts
+++ b/examples/arithmetics/src/language-server/generated/grammar.ts
@@ -436,7 +436,8 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ?? (lo
       "name": "WS",
       "definition": {
         "$type": "RegexToken",
-        "regex": "/\\\\s+/"
+        "regex": "/\\\\s+/",
+        "parenthesized": false
       },
       "fragment": false
     },
@@ -445,7 +446,8 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ?? (lo
       "name": "ID",
       "definition": {
         "$type": "RegexToken",
-        "regex": "/[_a-zA-Z][\\\\w_]*/"
+        "regex": "/[_a-zA-Z][\\\\w_]*/",
+        "parenthesized": false
       },
       "fragment": false,
       "hidden": false
@@ -459,7 +461,8 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ?? (lo
       },
       "definition": {
         "$type": "RegexToken",
-        "regex": "/[0-9]+(\\\\.[0-9]*)?/"
+        "regex": "/[0-9]+(\\\\.[0-9]*)?/",
+        "parenthesized": false
       },
       "fragment": false,
       "hidden": false
@@ -470,7 +473,8 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ?? (lo
       "name": "ML_COMMENT",
       "definition": {
         "$type": "RegexToken",
-        "regex": "/\\\\/\\\\*[\\\\s\\\\S]*?\\\\*\\\\//"
+        "regex": "/\\\\/\\\\*[\\\\s\\\\S]*?\\\\*\\\\//",
+        "parenthesized": false
       },
       "fragment": false
     },
@@ -480,7 +484,8 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ?? (lo
       "name": "SL_COMMENT",
       "definition": {
         "$type": "RegexToken",
-        "regex": "/\\\\/\\\\/[^\\\\n\\\\r]*/"
+        "regex": "/\\\\/\\\\/[^\\\\n\\\\r]*/",
+        "parenthesized": false
       },
       "fragment": false
     }

--- a/examples/domainmodel/src/language-server/generated/grammar.ts
+++ b/examples/domainmodel/src/language-server/generated/grammar.ts
@@ -341,7 +341,8 @@ export const DomainModelGrammar = (): Grammar => loadedDomainModelGrammar ?? (lo
       "name": "WS",
       "definition": {
         "$type": "RegexToken",
-        "regex": "/\\\\s+/"
+        "regex": "/\\\\s+/",
+        "parenthesized": false
       },
       "fragment": false
     },
@@ -350,7 +351,8 @@ export const DomainModelGrammar = (): Grammar => loadedDomainModelGrammar ?? (lo
       "name": "ID",
       "definition": {
         "$type": "RegexToken",
-        "regex": "/[_a-zA-Z][\\\\w_]*/"
+        "regex": "/[_a-zA-Z][\\\\w_]*/",
+        "parenthesized": false
       },
       "fragment": false,
       "hidden": false
@@ -361,7 +363,8 @@ export const DomainModelGrammar = (): Grammar => loadedDomainModelGrammar ?? (lo
       "name": "ML_COMMENT",
       "definition": {
         "$type": "RegexToken",
-        "regex": "/\\\\/\\\\*[\\\\s\\\\S]*?\\\\*\\\\//"
+        "regex": "/\\\\/\\\\*[\\\\s\\\\S]*?\\\\*\\\\//",
+        "parenthesized": false
       },
       "fragment": false
     },
@@ -371,7 +374,8 @@ export const DomainModelGrammar = (): Grammar => loadedDomainModelGrammar ?? (lo
       "name": "SL_COMMENT",
       "definition": {
         "$type": "RegexToken",
-        "regex": "/\\\\/\\\\/[^\\\\n\\\\r]*/"
+        "regex": "/\\\\/\\\\/[^\\\\n\\\\r]*/",
+        "parenthesized": false
       },
       "fragment": false
     }

--- a/examples/requirements/src/language-server/generated/grammar.ts
+++ b/examples/requirements/src/language-server/generated/grammar.ts
@@ -236,7 +236,8 @@ export const RequirementsGrammar = (): Grammar => loadedRequirementsGrammar ?? (
       "name": "WS",
       "definition": {
         "$type": "RegexToken",
-        "regex": "/\\\\s+/"
+        "regex": "/\\\\s+/",
+        "parenthesized": false
       },
       "fragment": false
     },
@@ -245,7 +246,8 @@ export const RequirementsGrammar = (): Grammar => loadedRequirementsGrammar ?? (
       "name": "ID",
       "definition": {
         "$type": "RegexToken",
-        "regex": "/[_a-zA-Z][\\\\w_]*/"
+        "regex": "/[_a-zA-Z][\\\\w_]*/",
+        "parenthesized": false
       },
       "fragment": false,
       "hidden": false
@@ -259,7 +261,8 @@ export const RequirementsGrammar = (): Grammar => loadedRequirementsGrammar ?? (
       },
       "definition": {
         "$type": "RegexToken",
-        "regex": "/[0-9]+/"
+        "regex": "/[0-9]+/",
+        "parenthesized": false
       },
       "fragment": false,
       "hidden": false
@@ -269,7 +272,8 @@ export const RequirementsGrammar = (): Grammar => loadedRequirementsGrammar ?? (
       "name": "STRING",
       "definition": {
         "$type": "RegexToken",
-        "regex": "/\\"(\\\\\\\\.|[^\\"\\\\\\\\])*\\"|'(\\\\\\\\.|[^'\\\\\\\\])*'/"
+        "regex": "/\\"(\\\\\\\\.|[^\\"\\\\\\\\])*\\"|'(\\\\\\\\.|[^'\\\\\\\\])*'/",
+        "parenthesized": false
       },
       "fragment": false,
       "hidden": false
@@ -280,7 +284,8 @@ export const RequirementsGrammar = (): Grammar => loadedRequirementsGrammar ?? (
       "name": "ML_COMMENT",
       "definition": {
         "$type": "RegexToken",
-        "regex": "/\\\\/\\\\*[\\\\s\\\\S]*?\\\\*\\\\//"
+        "regex": "/\\\\/\\\\*[\\\\s\\\\S]*?\\\\*\\\\//",
+        "parenthesized": false
       },
       "fragment": false
     },
@@ -290,7 +295,8 @@ export const RequirementsGrammar = (): Grammar => loadedRequirementsGrammar ?? (
       "name": "SL_COMMENT",
       "definition": {
         "$type": "RegexToken",
-        "regex": "/\\\\/\\\\/[^\\\\n\\\\r]*/"
+        "regex": "/\\\\/\\\\/[^\\\\n\\\\r]*/",
+        "parenthesized": false
       },
       "fragment": false
     }
@@ -725,7 +731,8 @@ export const TestsGrammar = (): Grammar => loadedTestsGrammar ?? (loadedTestsGra
       "name": "WS",
       "definition": {
         "$type": "RegexToken",
-        "regex": "/\\\\s+/"
+        "regex": "/\\\\s+/",
+        "parenthesized": false
       },
       "fragment": false
     },
@@ -734,7 +741,8 @@ export const TestsGrammar = (): Grammar => loadedTestsGrammar ?? (loadedTestsGra
       "name": "ID",
       "definition": {
         "$type": "RegexToken",
-        "regex": "/[_a-zA-Z][\\\\w_]*/"
+        "regex": "/[_a-zA-Z][\\\\w_]*/",
+        "parenthesized": false
       },
       "fragment": false,
       "hidden": false
@@ -748,7 +756,8 @@ export const TestsGrammar = (): Grammar => loadedTestsGrammar ?? (loadedTestsGra
       },
       "definition": {
         "$type": "RegexToken",
-        "regex": "/[0-9]+/"
+        "regex": "/[0-9]+/",
+        "parenthesized": false
       },
       "fragment": false,
       "hidden": false
@@ -758,7 +767,8 @@ export const TestsGrammar = (): Grammar => loadedTestsGrammar ?? (loadedTestsGra
       "name": "STRING",
       "definition": {
         "$type": "RegexToken",
-        "regex": "/\\"(\\\\\\\\.|[^\\"\\\\\\\\])*\\"|'(\\\\\\\\.|[^'\\\\\\\\])*'/"
+        "regex": "/\\"(\\\\\\\\.|[^\\"\\\\\\\\])*\\"|'(\\\\\\\\.|[^'\\\\\\\\])*'/",
+        "parenthesized": false
       },
       "fragment": false,
       "hidden": false
@@ -769,7 +779,8 @@ export const TestsGrammar = (): Grammar => loadedTestsGrammar ?? (loadedTestsGra
       "name": "ML_COMMENT",
       "definition": {
         "$type": "RegexToken",
-        "regex": "/\\\\/\\\\*[\\\\s\\\\S]*?\\\\*\\\\//"
+        "regex": "/\\\\/\\\\*[\\\\s\\\\S]*?\\\\*\\\\//",
+        "parenthesized": false
       },
       "fragment": false
     },
@@ -779,7 +790,8 @@ export const TestsGrammar = (): Grammar => loadedTestsGrammar ?? (loadedTestsGra
       "name": "SL_COMMENT",
       "definition": {
         "$type": "RegexToken",
-        "regex": "/\\\\/\\\\/[^\\\\n\\\\r]*/"
+        "regex": "/\\\\/\\\\/[^\\\\n\\\\r]*/",
+        "parenthesized": false
       },
       "fragment": false
     }

--- a/examples/statemachine/src/language-server/generated/grammar.ts
+++ b/examples/statemachine/src/language-server/generated/grammar.ts
@@ -291,7 +291,8 @@ export const StatemachineGrammar = (): Grammar => loadedStatemachineGrammar ?? (
       "name": "WS",
       "definition": {
         "$type": "RegexToken",
-        "regex": "/\\\\s+/"
+        "regex": "/\\\\s+/",
+        "parenthesized": false
       },
       "fragment": false
     },
@@ -300,7 +301,8 @@ export const StatemachineGrammar = (): Grammar => loadedStatemachineGrammar ?? (
       "name": "ID",
       "definition": {
         "$type": "RegexToken",
-        "regex": "/[_a-zA-Z][\\\\w_]*/"
+        "regex": "/[_a-zA-Z][\\\\w_]*/",
+        "parenthesized": false
       },
       "fragment": false,
       "hidden": false
@@ -311,7 +313,8 @@ export const StatemachineGrammar = (): Grammar => loadedStatemachineGrammar ?? (
       "name": "ML_COMMENT",
       "definition": {
         "$type": "RegexToken",
-        "regex": "/\\\\/\\\\*[\\\\s\\\\S]*?\\\\*\\\\//"
+        "regex": "/\\\\/\\\\*[\\\\s\\\\S]*?\\\\*\\\\//",
+        "parenthesized": false
       },
       "fragment": false
     },
@@ -321,7 +324,8 @@ export const StatemachineGrammar = (): Grammar => loadedStatemachineGrammar ?? (
       "name": "SL_COMMENT",
       "definition": {
         "$type": "RegexToken",
-        "regex": "/\\\\/\\\\/[^\\\\n\\\\r]*/"
+        "regex": "/\\\\/\\\\/[^\\\\n\\\\r]*/",
+        "parenthesized": false
       },
       "fragment": false
     }

--- a/packages/langium-cli/test/generator/ast-generator.test.ts
+++ b/packages/langium-cli/test/generator/ast-generator.test.ts
@@ -6,8 +6,8 @@
 
 import { EmptyFileSystem, type Grammar } from 'langium';
 import { expandToString, normalizeEOL } from 'langium/generate';
-import { parseHelper } from 'langium/test';
 import { createLangiumGrammarServices } from 'langium/grammar';
+import { parseHelper } from 'langium/test';
 import { describe, expect, test } from 'vitest';
 import { generateAst } from '../../src/generator/ast-generator.js';
 import type { LangiumConfig } from '../../src/package-types.js';
@@ -18,7 +18,7 @@ const parse = parseHelper<Grammar>(services.grammar);
 
 describe('Ast generator', () => {
 
-    testGeneratedAst('should generate checker functions for datatype rules comprised of a single string', `
+    test('should generate checker functions for datatype rules comprised of a single string', () => testGeneratedAst(`
         grammar TestGrammar
 
         A returns string:
@@ -32,9 +32,9 @@ describe('Ast generator', () => {
         export function isA(item: unknown): item is A {
             return item === 'a';
         }
-    `);
+    `));
 
-    testGeneratedAst('should generate checker functions for datatype rules comprised of a multiple strings', `
+    test('should generate checker functions for datatype rules comprised of a multiple strings', () => testGeneratedAst(`
         grammar TestGrammar
 
         A returns string:
@@ -48,9 +48,9 @@ describe('Ast generator', () => {
         export function isA(item: unknown): item is A {
             return item === 'a' || item === 'b' || item === 'c';
         }
-    `);
+    `));
 
-    testGeneratedAst('should generate checker functions for datatype rules with subtypes', `
+    test('should generate checker functions for datatype rules with subtypes', () => testGeneratedAst(`
         grammar TestGrammar
 
         A returns string:
@@ -73,9 +73,9 @@ describe('Ast generator', () => {
         export function isAB(item: unknown): item is AB {
             return isA(item) || item === 'b';
         }
-    `);
+    `));
 
-    testGeneratedAst('should generate checker functions for datatype rules referencing a terminal', `
+    test('should generate checker functions for datatype rules referencing a terminal', () => testGeneratedAst(`
         grammar TestGrammar
 
         A returns string:
@@ -89,9 +89,9 @@ describe('Ast generator', () => {
         export function isA(item: unknown): item is A {
             return (typeof item === 'string' && (/[_a-zA-Z][\\w_]*/.test(item)));
         }
-    `);
+    `));
 
-    testGeneratedAst('should generate checker functions for datatype rules referencing multiple terminals', `
+    test('should generate checker functions for datatype rules referencing multiple terminals', () => testGeneratedAst(`
         grammar TestGrammar
 
         A returns string:
@@ -106,9 +106,9 @@ describe('Ast generator', () => {
         export function isA(item: unknown): item is A {
             return (typeof item === 'string' && (/[_a-zA-Z][\\w_]*/.test(item) || /"(\\\\.|[^"\\\\])*"|'(\\\\.|[^'\\\\])*'/.test(item)));
         }
-    `);
+    `));
 
-    testGeneratedAst('should generate checker functions for datatype rules with nested union', `
+    test('should generate checker functions for datatype rules with nested union', () => testGeneratedAst(`
         grammar TestGrammar
 
         A returns string:
@@ -149,9 +149,9 @@ describe('Ast generator', () => {
         export function isC(item: unknown): item is C {
             return item === 'c';
         }
-    `);
+    `));
 
-    testGeneratedAst('should generate checker functions for datatype rules with repeated terminals', `
+    test('should generate checker functions for datatype rules with repeated terminals', () => testGeneratedAst(`
         grammar TestGrammar
 
         A returns string:
@@ -165,9 +165,9 @@ describe('Ast generator', () => {
         export function isA(item: unknown): item is A {
             return typeof item === 'string';
         }
-    `);
+    `));
 
-    testGeneratedInterface('should escape string delimiters in property type', `
+    test('should escape string delimiters in property type', () => testGeneratedInterface(`
         grammar TestGrammar
 
         entry Test: value="'test'";
@@ -187,9 +187,9 @@ describe('Ast generator', () => {
         export function isTest(item: unknown): item is Test {
             return reflection.isInstance(item, Test.$type);
         }
-    `);
+    `));
 
-    testGeneratedAst('should generate checker functions for datatype rules of type number', `
+    test('should generate checker functions for datatype rules of type number', () => testGeneratedAst(`
         grammar TestGrammar
 
         A returns number: '1';
@@ -202,9 +202,9 @@ describe('Ast generator', () => {
         export function isA(item: unknown): item is A {
             return typeof item === 'number';
         }
-    `);
+    `));
 
-    testGeneratedAst('check generated property with datatype rule of type number: single-value', `
+    test('check generated property with datatype rule of type number: single-value', () => testGeneratedAst(`
         grammar TestGrammar
 
         Node: num=A;
@@ -232,9 +232,9 @@ describe('Ast generator', () => {
         export function isNode(item: unknown): item is Node {
             return reflection.isInstance(item, Node.$type);
         }
-    `);
+    `));
 
-    testGeneratedAst('check generated property with datatype rule of type number: multi-value', `
+    test('check generated property with datatype rule of type number: multi-value', () => testGeneratedAst(`
         grammar TestGrammar
 
         Node: num+=A*;
@@ -262,9 +262,9 @@ describe('Ast generator', () => {
         export function isNode(item: unknown): item is Node {
             return reflection.isInstance(item, Node.$type);
         }
-    `);
+    `));
 
-    testGeneratedAst('should generate checker functions for datatype rules of type boolean', `
+    test('should generate checker functions for datatype rules of type boolean', () => testGeneratedAst(`
         grammar TestGrammar
 
         A returns boolean: 'on';
@@ -277,9 +277,9 @@ describe('Ast generator', () => {
         export function isA(item: unknown): item is A {
             return typeof item === 'boolean';
         }
-    `);
+    `));
 
-    testGeneratedAst('should generate checker functions for datatype rules of type bigint', `
+    test('should generate checker functions for datatype rules of type bigint', () => testGeneratedAst(`
         grammar TestGrammar
 
         A returns bigint: '1';
@@ -292,9 +292,9 @@ describe('Ast generator', () => {
         export function isA(item: unknown): item is A {
             return typeof item === 'bigint';
         }
-    `);
+    `));
 
-    testGeneratedAst('should generate checker functions for datatype rules of type Date', `
+    test('should generate checker functions for datatype rules of type Date', () => testGeneratedAst(`
         grammar TestGrammar
 
         A returns Date: '2023-01-01';
@@ -307,7 +307,7 @@ describe('Ast generator', () => {
         export function isA(item: unknown): item is A {
             return item instanceof Date;
         }
-    `);
+    `));
 
     test('should generate terminal names and regular expressions', () => testTerminalConstants(`
         grammar TestGrammar
@@ -325,36 +325,115 @@ describe('Ast generator', () => {
         };
     `));
 
-    test('should generate terminal constants with range operator', () => testTerminalConstants(`
+    test('should generate EBNF terminals with range operator', () => testTerminalConstants(`
         grammar TestGrammar
 
-        entry Amount:
-            value=NUMBER;
-
-        hidden terminal WS: /\\s+/;
+        entry Value: value=NUMBER;
 
         terminal NUMBER: '0'..'9'+;
     `, expandToString`
         export const TestTerminals = {
-            WS: /\\s+/,
             NUMBER: /[0-9]+/,
         };
     `));
 
-    test('should generate terminal constants with fragments', () => testTerminalConstants(`
+    test('should generate EBNF terminals with groups', () => testTerminalConstants(`
         grammar TestGrammar
 
-        entry Amount:
-            value=NUMBER;
+        entry Value: value=Literal;
 
-        hidden terminal WS: /\\s+/;
+        terminal Literal: /PRE#/? '0'..'9' /#SUF?/;
+    `, expandToString`
+        export const TestTerminals = {
+            Literal: /PRE#?[0-9]#SUF?/,
+        };
+    `));
 
-        terminal NUMBER: DIGIT+;
+    test('should generate EBNF terminals with parenthesized groups', () => testTerminalConstants(`
+        grammar TestGrammar
+
+        entry Value: value=Literal;
+
+        terminal Literal: (/PRE#/)? ('0'..'9' /#SUF?/);
+    `, expandToString`
+        export const TestTerminals = {
+            Literal: /(PRE#)?([0-9]#SUF?)/,
+        };
+    `));
+
+    test('should generate EBNF terminals with alternatives', () => testTerminalConstants(`
+        grammar TestGrammar
+
+        entry Value: value=Literal;
+
+        terminal Literal: '0'..'9' | /PRE#/ '0'..'9' /#SUF/;
+    `, expandToString`
+        export const TestTerminals = {
+            Literal: /[0-9]|PRE#[0-9]#SUF/,
+        };
+    `));
+
+    test('should generate EBNF terminals with parenthesized alternatives', () => testTerminalConstants(`
+        grammar TestGrammar
+
+        entry Value: value=Literal;
+
+        terminal Literal: ((/PRE#/ | /P#/) '0'..'9') ((/#SUF/ | /S#/))?;    // Note: double parentheses are 'merged' during parsing, not reflected in the AST
+    `, expandToString`
+        export const TestTerminals = {
+            Literal: /((PRE#|P#)[0-9])(#SUF|S#)?/,
+        };
+    `));
+
+    test('should generate EBNF terminals with fragment references', () => testTerminalConstants(`
+        grammar TestGrammar
+
+        entry Value: value=NUMBER;
+
+        terminal NUMBER: DIGIT;
         terminal fragment DIGIT: '0'..'9';
     `, expandToString`
         export const TestTerminals = {
-            WS: /\\s+/,
-            NUMBER: /([0-9])+/,
+            NUMBER: /(?:[0-9])/,
+        };
+    `));
+
+    test('should generate EBNF terminals with parenthesized fragment references', () => testTerminalConstants(`
+        grammar TestGrammar
+
+        entry Value: value=NUMBER;
+
+        terminal NUMBER: (DIGIT);
+        terminal fragment DIGIT: '0'..'9';
+    `, expandToString`
+        export const TestTerminals = {
+            NUMBER: /([0-9])/,
+        };
+    `));
+
+    test('should generate EBNF terminals with referenced fragments with parenthesized content 1', () => testTerminalConstants(`
+        grammar TestGrammar
+
+        entry Value: value=NUMBER;
+
+        terminal NUMBER: DIGIT+;
+        terminal fragment DIGIT: ('0'..'9');
+    `, expandToString`
+        export const TestTerminals = {
+            NUMBER: /(?:([0-9]))+/,
+        };
+    `));
+
+    test('should generate EBNF terminals with referenced fragments with parenthesized content 2', () => testTerminalConstants(`
+        grammar TestGrammar
+
+        entry Value: value=NUMBER;
+
+        terminal NUMBER: DIGIT+;
+        terminal fragment DIGIT: ('0'..'9') '_'?;
+    `, expandToString`
+        export const TestTerminals = {
+            NUMBER: /(?:([0-9])_?)+/,
         };
     `));
 
@@ -371,7 +450,7 @@ describe('Ast generator', () => {
         };
     `));
 
-    testTypeMetaData('should generate property metadata for super types', `
+    test('should generate property metadata for super types', () => testTypeMetaData(`
         grammar TestGrammar
 
         interface IAmArray {
@@ -409,9 +488,9 @@ describe('Ast generator', () => {
                 }
             } as const satisfies langium.AstMetaData
         }`
-    );
+    ));
 
-    testTypeMetaData('should generate property metadata for empty types', `
+    test('should generate property metadata for empty types', () => testTypeMetaData(`
         grammar TestGrammar
 
         interface IAmArray { }
@@ -445,9 +524,9 @@ describe('Ast generator', () => {
                 }
             } as const satisfies langium.AstMetaData
         }`
-    );
+    ));
 
-    testTypeMetaData('should generate escaped default value', `
+    test('should generate escaped default value', () => testTypeMetaData(`
         grammar TestGrammar
 
         interface Test {
@@ -474,9 +553,9 @@ describe('Ast generator', () => {
                 }
             } as const satisfies langium.AstMetaData
         }`
-    );
+    ));
 
-    testReferenceType('check all referenceIds are properly generated', `
+    test('check all referenceIds are properly generated', () => testReferenceType(`
         grammar TestGrammar
 
         interface A {
@@ -573,7 +652,7 @@ describe('Ast generator', () => {
                 }
             } as const satisfies langium.AstMetaData
         }`
-    );
+    ));
 });
 
 async function testTerminalConstants(grammar: string, expected: string) {
@@ -592,36 +671,35 @@ async function testTerminalConstants(grammar: string, expected: string) {
     expect(relevantPart).toEqual(expectedPart);
 }
 
-function testGeneratedInterface(name: string, grammar: string, expected: string): void {
-    testGenerated(name, grammar, expected, 'export interface', 'export type testAstType');
+async function testGeneratedInterface(grammar: string, expected: string): Promise<void> {
+    return testGenerated(grammar, expected, 'export interface', 'export type testAstType');
 }
 
-function testGeneratedAst(name: string, grammar: string, expected: string): void {
-    testGenerated(name, grammar, expected, 'export type', 'export type testAstType', 3);
+async function testGeneratedAst(grammar: string, expected: string): Promise<void> {
+    return testGenerated(grammar, expected, 'export type', 'export type testAstType', 3);
 }
 
-function testTypeMetaData(name: string, grammar: string, expected: string): void {
-    testGenerated(name, grammar, expected, 'export class testAstReflection', 'export const reflection');
+async function testTypeMetaData(grammar: string, expected: string): Promise<void> {
+    return testGenerated(grammar, expected, 'export class testAstReflection', 'export const reflection');
 }
 
-function testReferenceType(name: string, grammar: string, expected: string): void {
-    testGenerated(name, grammar, expected, 'export class testAstReflection', 'export const reflection');
+async function testReferenceType(grammar: string, expected: string): Promise<void> {
+    return testGenerated(grammar, expected, 'export class testAstReflection', 'export const reflection');
 }
-function testGenerated(name: string, grammar: string, expected: string, start: string, end: string, startCount = 0): void {
-    test(name, async () => {
-        const result = (await parse(grammar)).parseResult;
-        const config: LangiumConfig = {
-            [RelativePath]: './',
-            projectName: 'test',
-            languages: []
-        };
-        const expectedPart = normalizeEOL(expected).trim();
-        const typesFileContent = generateAst(services.grammar, [result.value], config);
-        let startIndex = typesFileContent.indexOf(start);
-        for (let i = 0; i < startCount; i++) {
-            startIndex = typesFileContent.indexOf(start, startIndex + start.length);
-        }
-        const relevantPart = typesFileContent.substring(startIndex, typesFileContent.indexOf(end)).trim();
-        expect(relevantPart).toEqual(expectedPart);
-    });
+
+async function testGenerated(grammar: string, expected: string, start: string, end: string, startCount = 0): Promise<void> {
+    const result = (await parse(grammar)).parseResult;
+    const config: LangiumConfig = {
+        [RelativePath]: './',
+        projectName: 'test',
+        languages: []
+    };
+    const expectedPart = normalizeEOL(expected).trim();
+    const typesFileContent = generateAst(services.grammar, [result.value], config);
+    let startIndex = typesFileContent.indexOf(start);
+    for (let i = 0; i < startCount; i++) {
+        startIndex = typesFileContent.indexOf(start, startIndex + start.length);
+    }
+    const relevantPart = typesFileContent.substring(startIndex, typesFileContent.indexOf(end)).trim();
+    expect(relevantPart).toEqual(expectedPart);
 }

--- a/packages/langium/src/grammar/generated/grammar.ts
+++ b/packages/langium/src/grammar/generated/grammar.ts
@@ -3349,8 +3349,13 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "arguments": []
           },
           {
-            "$type": "Keyword",
-            "value": ")"
+            "$type": "Assignment",
+            "feature": "parenthesized",
+            "operator": "?=",
+            "terminal": {
+              "$type": "Keyword",
+              "value": ")"
+            }
           }
         ]
       },
@@ -3702,7 +3707,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       "name": "ID",
       "definition": {
         "$type": "RegexToken",
-        "regex": "/\\\\^?[_a-zA-Z][\\\\w_]*/"
+        "regex": "/\\\\^?[_a-zA-Z][\\\\w_]*/",
+        "parenthesized": false
       },
       "fragment": false,
       "hidden": false
@@ -3712,7 +3718,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       "name": "STRING",
       "definition": {
         "$type": "RegexToken",
-        "regex": "/\\"(\\\\\\\\.|[^\\"\\\\\\\\])*\\"|'(\\\\\\\\.|[^'\\\\\\\\])*'/"
+        "regex": "/\\"(\\\\\\\\.|[^\\"\\\\\\\\])*\\"|'(\\\\\\\\.|[^'\\\\\\\\])*'/",
+        "parenthesized": false
       },
       "fragment": false,
       "hidden": false
@@ -3726,7 +3733,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       },
       "definition": {
         "$type": "RegexToken",
-        "regex": "/NaN|-?((\\\\d*\\\\.\\\\d+|\\\\d+)([Ee][+-]?\\\\d+)?|Infinity)/"
+        "regex": "/NaN|-?((\\\\d*\\\\.\\\\d+|\\\\d+)([Ee][+-]?\\\\d+)?|Infinity)/",
+        "parenthesized": false
       },
       "fragment": false,
       "hidden": false
@@ -3740,7 +3748,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       },
       "definition": {
         "$type": "RegexToken",
-        "regex": "/\\\\/(?![*+?])(?:[^\\\\r\\\\n\\\\[/\\\\\\\\]|\\\\\\\\.|\\\\[(?:[^\\\\r\\\\n\\\\]\\\\\\\\]|\\\\\\\\.)*\\\\])+\\\\/[a-z]*/"
+        "regex": "/\\\\/(?![*+?])(?:[^\\\\r\\\\n\\\\[/\\\\\\\\]|\\\\\\\\.|\\\\[(?:[^\\\\r\\\\n\\\\]\\\\\\\\]|\\\\\\\\.)*\\\\])+\\\\/[a-z]*/",
+        "parenthesized": false
       },
       "fragment": false,
       "hidden": false
@@ -3751,7 +3760,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       "name": "WS",
       "definition": {
         "$type": "RegexToken",
-        "regex": "/\\\\s+/"
+        "regex": "/\\\\s+/",
+        "parenthesized": false
       },
       "fragment": false
     },
@@ -3761,7 +3771,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       "name": "ML_COMMENT",
       "definition": {
         "$type": "RegexToken",
-        "regex": "/\\\\/\\\\*[\\\\s\\\\S]*?\\\\*\\\\//"
+        "regex": "/\\\\/\\\\*[\\\\s\\\\S]*?\\\\*\\\\//",
+        "parenthesized": false
       },
       "fragment": false
     },
@@ -3771,7 +3782,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       "name": "SL_COMMENT",
       "definition": {
         "$type": "RegexToken",
-        "regex": "/\\\\/\\\\/[^\\\\n\\\\r]*/"
+        "regex": "/\\\\/\\\\/[^\\\\n\\\\r]*/",
+        "parenthesized": false
       },
       "fragment": false
     }
@@ -5019,6 +5031,15 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "stringType": "?="
               }
             ]
+          }
+        },
+        {
+          "$type": "TypeAttribute",
+          "name": "parenthesized",
+          "isOptional": true,
+          "type": {
+            "$type": "SimpleType",
+            "primitiveType": "boolean"
           }
         }
       ]

--- a/packages/langium/src/grammar/generated/grammar.ts
+++ b/packages/langium/src/grammar/generated/grammar.ts
@@ -11,11 +11,15 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
   "$type": "Grammar",
   "isDeclared": true,
   "name": "LangiumGrammar",
+  "imports": [],
   "rules": [
     {
       "$type": "ParserRule",
       "entry": true,
       "name": "Grammar",
+      "returnType": {
+        "$ref": "#/interfaces@12"
+      },
       "definition": {
         "$type": "Group",
         "elements": [
@@ -109,6 +113,9 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
     {
       "$type": "ParserRule",
       "name": "Interface",
+      "returnType": {
+        "$ref": "#/interfaces@19"
+      },
       "definition": {
         "$type": "Group",
         "elements": [
@@ -142,7 +149,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "CrossReference",
                   "type": {
-                    "$ref": "#/types@0"
+                    "$ref": "#/types@1"
                   },
                   "terminal": {
                     "$type": "RuleCall",
@@ -169,7 +176,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                     "terminal": {
                       "$type": "CrossReference",
                       "type": {
-                        "$ref": "#/types@0"
+                        "$ref": "#/types@1"
                       },
                       "terminal": {
                         "$type": "RuleCall",
@@ -223,6 +230,9 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
     {
       "$type": "ParserRule",
       "name": "TypeAttribute",
+      "returnType": {
+        "$ref": "#/interfaces@40"
+      },
       "definition": {
         "$type": "Group",
         "elements": [
@@ -300,6 +310,9 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
     {
       "$type": "ParserRule",
       "name": "ValueLiteral",
+      "returnType": {
+        "$ref": "#/types@7"
+      },
       "definition": {
         "$type": "Alternatives",
         "elements": [
@@ -340,6 +353,9 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
     {
       "$type": "ParserRule",
       "name": "StringLiteral",
+      "returnType": {
+        "$ref": "#/interfaces@33"
+      },
       "definition": {
         "$type": "Assignment",
         "feature": "value",
@@ -359,6 +375,9 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
     {
       "$type": "ParserRule",
       "name": "NumberLiteral",
+      "returnType": {
+        "$ref": "#/interfaces@24"
+      },
       "definition": {
         "$type": "Assignment",
         "feature": "value",
@@ -378,6 +397,9 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
     {
       "$type": "ParserRule",
       "name": "BooleanLiteral",
+      "returnType": {
+        "$ref": "#/interfaces@6"
+      },
       "definition": {
         "$type": "Alternatives",
         "elements": [
@@ -403,6 +425,9 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
     {
       "$type": "ParserRule",
       "name": "ArrayLiteral",
+      "returnType": {
+        "$ref": "#/interfaces@3"
+      },
       "definition": {
         "$type": "Group",
         "elements": [
@@ -463,6 +488,9 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
     {
       "$type": "ParserRule",
       "name": "TypeDefinition",
+      "returnType": {
+        "$ref": "#/types@6"
+      },
       "definition": {
         "$type": "RuleCall",
         "rule": {
@@ -477,9 +505,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
     {
       "$type": "ParserRule",
       "name": "UnionType",
-      "inferredType": {
-        "$type": "InferredType",
-        "name": "TypeDefinition"
+      "returnType": {
+        "$ref": "#/types@6"
       },
       "definition": {
         "$type": "Group",
@@ -496,9 +523,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "elements": [
               {
                 "$type": "Action",
-                "inferredType": {
-                  "$type": "InferredType",
-                  "name": "UnionType"
+                "type": {
+                  "$ref": "#/interfaces@41"
                 },
                 "feature": "types",
                 "operator": "+="
@@ -537,9 +563,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
     {
       "$type": "ParserRule",
       "name": "ArrayType",
-      "inferredType": {
-        "$type": "InferredType",
-        "name": "TypeDefinition"
+      "returnType": {
+        "$ref": "#/types@6"
       },
       "definition": {
         "$type": "Group",
@@ -556,9 +581,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "elements": [
               {
                 "$type": "Action",
-                "inferredType": {
-                  "$type": "InferredType",
-                  "name": "ArrayType"
+                "type": {
+                  "$ref": "#/interfaces@4"
                 },
                 "feature": "elementType",
                 "operator": "="
@@ -583,9 +607,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
     {
       "$type": "ParserRule",
       "name": "ReferenceType",
-      "inferredType": {
-        "$type": "InferredType",
-        "name": "TypeDefinition"
+      "returnType": {
+        "$ref": "#/types@6"
       },
       "definition": {
         "$type": "Alternatives",
@@ -602,9 +625,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "elements": [
               {
                 "$type": "Action",
-                "inferredType": {
-                  "$type": "InferredType",
-                  "name": "ReferenceType"
+                "type": {
+                  "$ref": "#/interfaces@28"
                 }
               },
               {
@@ -644,9 +666,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
     {
       "$type": "ParserRule",
       "name": "SimpleType",
-      "inferredType": {
-        "$type": "InferredType",
-        "name": "TypeDefinition"
+      "returnType": {
+        "$ref": "#/types@6"
       },
       "definition": {
         "$type": "Alternatives",
@@ -676,9 +697,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "elements": [
               {
                 "$type": "Action",
-                "inferredType": {
-                  "$type": "InferredType",
-                  "name": "SimpleType"
+                "type": {
+                  "$ref": "#/interfaces@32"
                 }
               },
               {
@@ -691,7 +711,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                     "terminal": {
                       "$type": "CrossReference",
                       "type": {
-                        "$ref": "#/types@0"
+                        "$ref": "#/types@1"
                       },
                       "terminal": {
                         "$type": "RuleCall",
@@ -774,6 +794,9 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
     {
       "$type": "ParserRule",
       "name": "Type",
+      "returnType": {
+        "$ref": "#/interfaces@39"
+      },
       "definition": {
         "$type": "Group",
         "elements": [
@@ -823,6 +846,9 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
     {
       "$type": "ParserRule",
       "name": "AbstractRule",
+      "returnType": {
+        "$ref": "#/types@0"
+      },
       "definition": {
         "$type": "Alternatives",
         "elements": [
@@ -856,6 +882,9 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
     {
       "$type": "ParserRule",
       "name": "GrammarImport",
+      "returnType": {
+        "$ref": "#/interfaces@13"
+      },
       "definition": {
         "$type": "Group",
         "elements": [
@@ -889,6 +918,9 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
     {
       "$type": "ParserRule",
       "name": "ParserRule",
+      "returnType": {
+        "$ref": "#/interfaces@27"
+      },
       "definition": {
         "$type": "Group",
         "elements": [
@@ -943,7 +975,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                         "terminal": {
                           "$type": "CrossReference",
                           "type": {
-                            "$ref": "#/types@0"
+                            "$ref": "#/types@1"
                           },
                           "terminal": {
                             "$type": "RuleCall",
@@ -1025,6 +1057,9 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
     {
       "$type": "ParserRule",
       "name": "InfixRule",
+      "returnType": {
+        "$ref": "#/interfaces@16"
+      },
       "definition": {
         "$type": "Group",
         "elements": [
@@ -1084,6 +1119,9 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
     {
       "$type": "ParserRule",
       "name": "InfixRuleOperators",
+      "returnType": {
+        "$ref": "#/interfaces@18"
+      },
       "definition": {
         "$type": "Group",
         "elements": [
@@ -1130,6 +1168,9 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
     {
       "$type": "ParserRule",
       "name": "InfixRuleOperatorList",
+      "returnType": {
+        "$ref": "#/interfaces@17"
+      },
       "definition": {
         "$type": "Group",
         "elements": [
@@ -1225,6 +1266,9 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           "name": "imperative"
         }
       ],
+      "returnType": {
+        "$ref": "#/interfaces@15"
+      },
       "definition": {
         "$type": "Group",
         "elements": [
@@ -1364,6 +1408,9 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
     {
       "$type": "ParserRule",
       "name": "Parameter",
+      "returnType": {
+        "$ref": "#/interfaces@25"
+      },
       "definition": {
         "$type": "Assignment",
         "feature": "name",
@@ -1383,9 +1430,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
     {
       "$type": "ParserRule",
       "name": "Alternatives",
-      "inferredType": {
-        "$type": "InferredType",
-        "name": "AbstractElement"
+      "returnType": {
+        "$ref": "#/interfaces@0"
       },
       "definition": {
         "$type": "Group",
@@ -1402,9 +1448,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "elements": [
               {
                 "$type": "Action",
-                "inferredType": {
-                  "$type": "InferredType",
-                  "name": "Alternatives"
+                "type": {
+                  "$ref": "#/interfaces@2"
                 },
                 "feature": "elements",
                 "operator": "+="
@@ -1443,9 +1488,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
     {
       "$type": "ParserRule",
       "name": "ConditionalBranch",
-      "inferredType": {
-        "$type": "InferredType",
-        "name": "AbstractElement"
+      "returnType": {
+        "$ref": "#/interfaces@0"
       },
       "definition": {
         "$type": "Alternatives",
@@ -1462,9 +1506,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "elements": [
               {
                 "$type": "Action",
-                "inferredType": {
-                  "$type": "InferredType",
-                  "name": "Group"
+                "type": {
+                  "$ref": "#/interfaces@14"
                 }
               },
               {
@@ -1511,9 +1554,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
     {
       "$type": "ParserRule",
       "name": "UnorderedGroup",
-      "inferredType": {
-        "$type": "InferredType",
-        "name": "AbstractElement"
+      "returnType": {
+        "$ref": "#/interfaces@0"
       },
       "definition": {
         "$type": "Group",
@@ -1530,9 +1572,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "elements": [
               {
                 "$type": "Action",
-                "inferredType": {
-                  "$type": "InferredType",
-                  "name": "UnorderedGroup"
+                "type": {
+                  "$ref": "#/interfaces@42"
                 },
                 "feature": "elements",
                 "operator": "+="
@@ -1571,9 +1612,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
     {
       "$type": "ParserRule",
       "name": "Group",
-      "inferredType": {
-        "$type": "InferredType",
-        "name": "AbstractElement"
+      "returnType": {
+        "$ref": "#/interfaces@0"
       },
       "definition": {
         "$type": "Group",
@@ -1590,9 +1630,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "elements": [
               {
                 "$type": "Action",
-                "inferredType": {
-                  "$type": "InferredType",
-                  "name": "Group"
+                "type": {
+                  "$ref": "#/interfaces@14"
                 },
                 "feature": "elements",
                 "operator": "+="
@@ -1622,9 +1661,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
     {
       "$type": "ParserRule",
       "name": "AbstractToken",
-      "inferredType": {
-        "$type": "InferredType",
-        "name": "AbstractElement"
+      "returnType": {
+        "$ref": "#/interfaces@0"
       },
       "definition": {
         "$type": "Alternatives",
@@ -1652,9 +1690,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
     {
       "$type": "ParserRule",
       "name": "AbstractTokenWithCardinality",
-      "inferredType": {
-        "$type": "InferredType",
-        "name": "AbstractElement"
+      "returnType": {
+        "$ref": "#/interfaces@0"
       },
       "definition": {
         "$type": "Group",
@@ -1710,18 +1747,16 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
     {
       "$type": "ParserRule",
       "name": "Action",
-      "inferredType": {
-        "$type": "InferredType",
-        "name": "AbstractElement"
+      "returnType": {
+        "$ref": "#/interfaces@0"
       },
       "definition": {
         "$type": "Group",
         "elements": [
           {
             "$type": "Action",
-            "inferredType": {
-              "$type": "InferredType",
-              "name": "Action"
+            "type": {
+              "$ref": "#/interfaces@1"
             }
           },
           {
@@ -1738,7 +1773,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "CrossReference",
                   "type": {
-                    "$ref": "#/types@0"
+                    "$ref": "#/types@1"
                   },
                   "terminal": {
                     "$type": "RuleCall",
@@ -1831,9 +1866,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
     {
       "$type": "ParserRule",
       "name": "AbstractTerminal",
-      "inferredType": {
-        "$type": "InferredType",
-        "name": "AbstractElement"
+      "returnType": {
+        "$ref": "#/interfaces@0"
       },
       "definition": {
         "$type": "Alternatives",
@@ -1896,14 +1930,16 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
     {
       "$type": "ParserRule",
       "name": "EndOfFile",
+      "returnType": {
+        "$ref": "#/interfaces@11"
+      },
       "definition": {
         "$type": "Group",
         "elements": [
           {
             "$type": "Action",
-            "inferredType": {
-              "$type": "InferredType",
-              "name": "EndOfFile"
+            "type": {
+              "$ref": "#/interfaces@11"
             }
           },
           {
@@ -1919,6 +1955,9 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
     {
       "$type": "ParserRule",
       "name": "Keyword",
+      "returnType": {
+        "$ref": "#/interfaces@20"
+      },
       "definition": {
         "$type": "Assignment",
         "feature": "value",
@@ -1938,6 +1977,9 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
     {
       "$type": "ParserRule",
       "name": "RuleCall",
+      "returnType": {
+        "$ref": "#/interfaces@31"
+      },
       "definition": {
         "$type": "Group",
         "elements": [
@@ -1948,7 +1990,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "CrossReference",
               "type": {
-                "$ref": "#/rules@15"
+                "$ref": "#/types@0"
               },
               "terminal": {
                 "$type": "RuleCall",
@@ -2018,6 +2060,9 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
     {
       "$type": "ParserRule",
       "name": "NamedArgument",
+      "returnType": {
+        "$ref": "#/interfaces@21"
+      },
       "definition": {
         "$type": "Group",
         "elements": [
@@ -2031,7 +2076,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "CrossReference",
                   "type": {
-                    "$ref": "#/rules@24"
+                    "$ref": "#/interfaces@25"
                   },
                   "terminal": {
                     "$type": "RuleCall",
@@ -2077,9 +2122,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
     {
       "$type": "ParserRule",
       "name": "Disjunction",
-      "inferredType": {
-        "$type": "InferredType",
-        "name": "Condition"
+      "returnType": {
+        "$ref": "#/types@3"
       },
       "definition": {
         "$type": "Group",
@@ -2096,9 +2140,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "elements": [
               {
                 "$type": "Action",
-                "inferredType": {
-                  "$type": "InferredType",
-                  "name": "Disjunction"
+                "type": {
+                  "$ref": "#/interfaces@10"
                 },
                 "feature": "left",
                 "operator": "="
@@ -2131,9 +2174,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
     {
       "$type": "ParserRule",
       "name": "Conjunction",
-      "inferredType": {
-        "$type": "InferredType",
-        "name": "Condition"
+      "returnType": {
+        "$ref": "#/types@3"
       },
       "definition": {
         "$type": "Group",
@@ -2150,9 +2192,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "elements": [
               {
                 "$type": "Action",
-                "inferredType": {
-                  "$type": "InferredType",
-                  "name": "Conjunction"
+                "type": {
+                  "$ref": "#/interfaces@8"
                 },
                 "feature": "left",
                 "operator": "="
@@ -2185,9 +2226,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
     {
       "$type": "ParserRule",
       "name": "Negation",
-      "inferredType": {
-        "$type": "InferredType",
-        "name": "Condition"
+      "returnType": {
+        "$ref": "#/types@3"
       },
       "definition": {
         "$type": "Alternatives",
@@ -2204,9 +2244,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "elements": [
               {
                 "$type": "Action",
-                "inferredType": {
-                  "$type": "InferredType",
-                  "name": "Negation"
+                "type": {
+                  "$ref": "#/interfaces@23"
                 }
               },
               {
@@ -2236,9 +2275,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
     {
       "$type": "ParserRule",
       "name": "Atom",
-      "inferredType": {
-        "$type": "InferredType",
-        "name": "Condition"
+      "returnType": {
+        "$ref": "#/types@3"
       },
       "definition": {
         "$type": "Alternatives",
@@ -2273,9 +2311,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
     {
       "$type": "ParserRule",
       "name": "ParenthesizedCondition",
-      "inferredType": {
-        "$type": "InferredType",
-        "name": "Condition"
+      "returnType": {
+        "$ref": "#/types@3"
       },
       "definition": {
         "$type": "Group",
@@ -2304,6 +2341,9 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
     {
       "$type": "ParserRule",
       "name": "ParameterReference",
+      "returnType": {
+        "$ref": "#/interfaces@26"
+      },
       "definition": {
         "$type": "Assignment",
         "feature": "parameter",
@@ -2311,7 +2351,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
         "terminal": {
           "$type": "CrossReference",
           "type": {
-            "$ref": "#/rules@24"
+            "$ref": "#/interfaces@25"
           },
           "terminal": {
             "$type": "RuleCall",
@@ -2331,9 +2371,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
     {
       "$type": "ParserRule",
       "name": "PredicatedKeyword",
-      "inferredType": {
-        "$type": "InferredType",
-        "name": "Keyword"
+      "returnType": {
+        "$ref": "#/interfaces@20"
       },
       "definition": {
         "$type": "Group",
@@ -2377,9 +2416,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
     {
       "$type": "ParserRule",
       "name": "PredicatedRuleCall",
-      "inferredType": {
-        "$type": "InferredType",
-        "name": "RuleCall"
+      "returnType": {
+        "$ref": "#/interfaces@31"
       },
       "definition": {
         "$type": "Group",
@@ -2409,7 +2447,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "CrossReference",
               "type": {
-                "$ref": "#/rules@15"
+                "$ref": "#/types@0"
               },
               "terminal": {
                 "$type": "RuleCall",
@@ -2479,18 +2517,16 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
     {
       "$type": "ParserRule",
       "name": "Assignment",
-      "inferredType": {
-        "$type": "InferredType",
-        "name": "AbstractElement"
+      "returnType": {
+        "$ref": "#/interfaces@0"
       },
       "definition": {
         "$type": "Group",
         "elements": [
           {
             "$type": "Action",
-            "inferredType": {
-              "$type": "InferredType",
-              "name": "Assignment"
+            "type": {
+              "$ref": "#/interfaces@5"
             }
           },
           {
@@ -2567,9 +2603,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
     {
       "$type": "ParserRule",
       "name": "AssignableTerminal",
-      "inferredType": {
-        "$type": "InferredType",
-        "name": "AbstractElement"
+      "returnType": {
+        "$ref": "#/interfaces@0"
       },
       "definition": {
         "$type": "Alternatives",
@@ -2611,9 +2646,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
     {
       "$type": "ParserRule",
       "name": "ParenthesizedAssignableElement",
-      "inferredType": {
-        "$type": "InferredType",
-        "name": "AbstractElement"
+      "returnType": {
+        "$ref": "#/interfaces@0"
       },
       "definition": {
         "$type": "Group",
@@ -2642,9 +2676,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
     {
       "$type": "ParserRule",
       "name": "AssignableAlternatives",
-      "inferredType": {
-        "$type": "InferredType",
-        "name": "AbstractElement"
+      "returnType": {
+        "$ref": "#/interfaces@0"
       },
       "definition": {
         "$type": "Group",
@@ -2661,9 +2694,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "elements": [
               {
                 "$type": "Action",
-                "inferredType": {
-                  "$type": "InferredType",
-                  "name": "Alternatives"
+                "type": {
+                  "$ref": "#/interfaces@2"
                 },
                 "feature": "elements",
                 "operator": "+="
@@ -2702,18 +2734,16 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
     {
       "$type": "ParserRule",
       "name": "CrossReference",
-      "inferredType": {
-        "$type": "InferredType",
-        "name": "AbstractElement"
+      "returnType": {
+        "$ref": "#/interfaces@0"
       },
       "definition": {
         "$type": "Group",
         "elements": [
           {
             "$type": "Action",
-            "inferredType": {
-              "$type": "InferredType",
-              "name": "CrossReference"
+            "type": {
+              "$ref": "#/interfaces@9"
             }
           },
           {
@@ -2737,7 +2767,14 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "CrossReference",
               "type": {
-                "$ref": "#/types@0"
+                "$ref": "#/types@1"
+              },
+              "terminal": {
+                "$type": "RuleCall",
+                "rule": {
+                  "$ref": "#/rules@67"
+                },
+                "arguments": []
               },
               "deprecatedSyntax": false,
               "isMulti": false
@@ -2792,9 +2829,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
     {
       "$type": "ParserRule",
       "name": "CrossReferenceableTerminal",
-      "inferredType": {
-        "$type": "InferredType",
-        "name": "AbstractElement"
+      "returnType": {
+        "$ref": "#/interfaces@0"
       },
       "definition": {
         "$type": "Alternatives",
@@ -2822,9 +2858,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
     {
       "$type": "ParserRule",
       "name": "ParenthesizedElement",
-      "inferredType": {
-        "$type": "InferredType",
-        "name": "AbstractElement"
+      "returnType": {
+        "$ref": "#/interfaces@0"
       },
       "definition": {
         "$type": "Group",
@@ -2853,9 +2888,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
     {
       "$type": "ParserRule",
       "name": "PredicatedGroup",
-      "inferredType": {
-        "$type": "InferredType",
-        "name": "Group"
+      "returnType": {
+        "$ref": "#/interfaces@14"
       },
       "definition": {
         "$type": "Group",
@@ -2907,6 +2941,9 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
     {
       "$type": "ParserRule",
       "name": "ReturnType",
+      "returnType": {
+        "$ref": "#/interfaces@30"
+      },
       "definition": {
         "$type": "Assignment",
         "feature": "name",
@@ -2938,6 +2975,9 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
     {
       "$type": "ParserRule",
       "name": "TerminalRule",
+      "returnType": {
+        "$ref": "#/interfaces@37"
+      },
       "definition": {
         "$type": "Group",
         "elements": [
@@ -3054,9 +3094,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
     {
       "$type": "ParserRule",
       "name": "TerminalAlternatives",
-      "inferredType": {
-        "$type": "InferredType",
-        "name": "AbstractElement"
+      "returnType": {
+        "$ref": "#/interfaces@35"
       },
       "definition": {
         "$type": "Group",
@@ -3073,9 +3112,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "elements": [
               {
                 "$type": "Action",
-                "inferredType": {
-                  "$type": "InferredType",
-                  "name": "TerminalAlternatives"
+                "type": {
+                  "$ref": "#/interfaces@34"
                 },
                 "feature": "elements",
                 "operator": "+="
@@ -3108,9 +3146,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
     {
       "$type": "ParserRule",
       "name": "TerminalGroup",
-      "inferredType": {
-        "$type": "InferredType",
-        "name": "AbstractElement"
+      "returnType": {
+        "$ref": "#/interfaces@35"
       },
       "definition": {
         "$type": "Group",
@@ -3127,9 +3164,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "elements": [
               {
                 "$type": "Action",
-                "inferredType": {
-                  "$type": "InferredType",
-                  "name": "TerminalGroup"
+                "type": {
+                  "$ref": "#/interfaces@36"
                 },
                 "feature": "elements",
                 "operator": "+="
@@ -3159,9 +3195,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
     {
       "$type": "ParserRule",
       "name": "TerminalToken",
-      "inferredType": {
-        "$type": "InferredType",
-        "name": "AbstractElement"
+      "returnType": {
+        "$ref": "#/interfaces@35"
       },
       "definition": {
         "$type": "Group",
@@ -3205,9 +3240,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
     {
       "$type": "ParserRule",
       "name": "TerminalTokenElement",
-      "inferredType": {
-        "$type": "InferredType",
-        "name": "AbstractElement"
+      "returnType": {
+        "$ref": "#/interfaces@35"
       },
       "definition": {
         "$type": "Alternatives",
@@ -3270,9 +3304,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
     {
       "$type": "ParserRule",
       "name": "ParenthesizedTerminalElement",
-      "inferredType": {
-        "$type": "InferredType",
-        "name": "AbstractElement"
+      "returnType": {
+        "$ref": "#/interfaces@35"
       },
       "definition": {
         "$type": "Group",
@@ -3328,18 +3361,16 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
     {
       "$type": "ParserRule",
       "name": "TerminalRuleCall",
-      "inferredType": {
-        "$type": "InferredType",
-        "name": "AbstractElement"
+      "returnType": {
+        "$ref": "#/interfaces@35"
       },
       "definition": {
         "$type": "Group",
         "elements": [
           {
             "$type": "Action",
-            "inferredType": {
-              "$type": "InferredType",
-              "name": "TerminalRuleCall"
+            "type": {
+              "$ref": "#/interfaces@38"
             }
           },
           {
@@ -3349,7 +3380,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "CrossReference",
               "type": {
-                "$ref": "#/rules@54"
+                "$ref": "#/interfaces@37"
               },
               "terminal": {
                 "$type": "RuleCall",
@@ -3371,18 +3402,16 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
     {
       "$type": "ParserRule",
       "name": "NegatedToken",
-      "inferredType": {
-        "$type": "InferredType",
-        "name": "AbstractElement"
+      "returnType": {
+        "$ref": "#/interfaces@35"
       },
       "definition": {
         "$type": "Group",
         "elements": [
           {
             "$type": "Action",
-            "inferredType": {
-              "$type": "InferredType",
-              "name": "NegatedToken"
+            "type": {
+              "$ref": "#/interfaces@22"
             }
           },
           {
@@ -3410,18 +3439,16 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
     {
       "$type": "ParserRule",
       "name": "UntilToken",
-      "inferredType": {
-        "$type": "InferredType",
-        "name": "AbstractElement"
+      "returnType": {
+        "$ref": "#/interfaces@35"
       },
       "definition": {
         "$type": "Group",
         "elements": [
           {
             "$type": "Action",
-            "inferredType": {
-              "$type": "InferredType",
-              "name": "UntilToken"
+            "type": {
+              "$ref": "#/interfaces@43"
             }
           },
           {
@@ -3449,18 +3476,16 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
     {
       "$type": "ParserRule",
       "name": "RegexToken",
-      "inferredType": {
-        "$type": "InferredType",
-        "name": "AbstractElement"
+      "returnType": {
+        "$ref": "#/interfaces@35"
       },
       "definition": {
         "$type": "Group",
         "elements": [
           {
             "$type": "Action",
-            "inferredType": {
-              "$type": "InferredType",
-              "name": "RegexToken"
+            "type": {
+              "$ref": "#/interfaces@29"
             }
           },
           {
@@ -3484,18 +3509,16 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
     {
       "$type": "ParserRule",
       "name": "Wildcard",
-      "inferredType": {
-        "$type": "InferredType",
-        "name": "AbstractElement"
+      "returnType": {
+        "$ref": "#/interfaces@35"
       },
       "definition": {
         "$type": "Group",
         "elements": [
           {
             "$type": "Action",
-            "inferredType": {
-              "$type": "InferredType",
-              "name": "Wildcard"
+            "type": {
+              "$ref": "#/interfaces@44"
             }
           },
           {
@@ -3511,18 +3534,16 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
     {
       "$type": "ParserRule",
       "name": "CharacterRange",
-      "inferredType": {
-        "$type": "InferredType",
-        "name": "AbstractElement"
+      "returnType": {
+        "$ref": "#/interfaces@35"
       },
       "definition": {
         "$type": "Group",
         "elements": [
           {
             "$type": "Action",
-            "inferredType": {
-              "$type": "InferredType",
-              "name": "CharacterRange"
+            "type": {
+              "$ref": "#/interfaces@7"
             }
           },
           {
@@ -3755,7 +3776,1543 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       "fragment": false
     }
   ],
+  "interfaces": [
+    {
+      "$type": "Interface",
+      "name": "AbstractElement",
+      "attributes": [
+        {
+          "$type": "TypeAttribute",
+          "name": "cardinality",
+          "isOptional": true,
+          "type": {
+            "$type": "UnionType",
+            "types": [
+              {
+                "$type": "SimpleType",
+                "stringType": "*"
+              },
+              {
+                "$type": "SimpleType",
+                "stringType": "+"
+              },
+              {
+                "$type": "SimpleType",
+                "stringType": "?"
+              }
+            ]
+          }
+        }
+      ],
+      "superTypes": []
+    },
+    {
+      "$type": "Interface",
+      "name": "Action",
+      "superTypes": [
+        {
+          "$ref": "#/interfaces@0"
+        }
+      ],
+      "attributes": [
+        {
+          "$type": "TypeAttribute",
+          "name": "feature",
+          "isOptional": true,
+          "type": {
+            "$type": "SimpleType",
+            "typeRef": {
+              "$ref": "#/types@4"
+            }
+          }
+        },
+        {
+          "$type": "TypeAttribute",
+          "name": "inferredType",
+          "isOptional": true,
+          "type": {
+            "$type": "SimpleType",
+            "typeRef": {
+              "$ref": "#/interfaces@15"
+            }
+          }
+        },
+        {
+          "$type": "TypeAttribute",
+          "name": "operator",
+          "isOptional": true,
+          "type": {
+            "$type": "UnionType",
+            "types": [
+              {
+                "$type": "SimpleType",
+                "stringType": "+="
+              },
+              {
+                "$type": "SimpleType",
+                "stringType": "="
+              }
+            ]
+          }
+        },
+        {
+          "$type": "TypeAttribute",
+          "name": "type",
+          "isOptional": true,
+          "type": {
+            "$type": "ReferenceType",
+            "referenceType": {
+              "$type": "SimpleType",
+              "typeRef": {
+                "$ref": "#/types@1"
+              }
+            },
+            "isMulti": false
+          }
+        }
+      ]
+    },
+    {
+      "$type": "Interface",
+      "name": "Alternatives",
+      "superTypes": [
+        {
+          "$ref": "#/interfaces@0"
+        }
+      ],
+      "attributes": [
+        {
+          "$type": "TypeAttribute",
+          "name": "elements",
+          "type": {
+            "$type": "ArrayType",
+            "elementType": {
+              "$type": "SimpleType",
+              "typeRef": {
+                "$ref": "#/interfaces@0"
+              }
+            }
+          },
+          "isOptional": false
+        }
+      ]
+    },
+    {
+      "$type": "Interface",
+      "name": "ArrayLiteral",
+      "attributes": [
+        {
+          "$type": "TypeAttribute",
+          "name": "elements",
+          "type": {
+            "$type": "ArrayType",
+            "elementType": {
+              "$type": "SimpleType",
+              "typeRef": {
+                "$ref": "#/types@7"
+              }
+            }
+          },
+          "isOptional": false
+        }
+      ],
+      "superTypes": []
+    },
+    {
+      "$type": "Interface",
+      "name": "ArrayType",
+      "attributes": [
+        {
+          "$type": "TypeAttribute",
+          "name": "elementType",
+          "type": {
+            "$type": "SimpleType",
+            "typeRef": {
+              "$ref": "#/types@6"
+            }
+          },
+          "isOptional": false
+        }
+      ],
+      "superTypes": []
+    },
+    {
+      "$type": "Interface",
+      "name": "Assignment",
+      "superTypes": [
+        {
+          "$ref": "#/interfaces@0"
+        }
+      ],
+      "attributes": [
+        {
+          "$type": "TypeAttribute",
+          "name": "feature",
+          "type": {
+            "$type": "SimpleType",
+            "typeRef": {
+              "$ref": "#/types@4"
+            }
+          },
+          "isOptional": false
+        },
+        {
+          "$type": "TypeAttribute",
+          "name": "operator",
+          "type": {
+            "$type": "UnionType",
+            "types": [
+              {
+                "$type": "SimpleType",
+                "stringType": "+="
+              },
+              {
+                "$type": "SimpleType",
+                "stringType": "="
+              },
+              {
+                "$type": "SimpleType",
+                "stringType": "?="
+              }
+            ]
+          },
+          "isOptional": false
+        },
+        {
+          "$type": "TypeAttribute",
+          "name": "predicate",
+          "isOptional": true,
+          "type": {
+            "$type": "UnionType",
+            "types": [
+              {
+                "$type": "SimpleType",
+                "stringType": "->"
+              },
+              {
+                "$type": "SimpleType",
+                "stringType": "=>"
+              }
+            ]
+          }
+        },
+        {
+          "$type": "TypeAttribute",
+          "name": "terminal",
+          "type": {
+            "$type": "SimpleType",
+            "typeRef": {
+              "$ref": "#/interfaces@0"
+            }
+          },
+          "isOptional": false
+        }
+      ]
+    },
+    {
+      "$type": "Interface",
+      "name": "BooleanLiteral",
+      "attributes": [
+        {
+          "$type": "TypeAttribute",
+          "name": "true",
+          "type": {
+            "$type": "SimpleType",
+            "primitiveType": "boolean"
+          },
+          "isOptional": false
+        }
+      ],
+      "superTypes": []
+    },
+    {
+      "$type": "Interface",
+      "name": "CharacterRange",
+      "superTypes": [
+        {
+          "$ref": "#/interfaces@35"
+        }
+      ],
+      "attributes": [
+        {
+          "$type": "TypeAttribute",
+          "name": "left",
+          "type": {
+            "$type": "SimpleType",
+            "typeRef": {
+              "$ref": "#/interfaces@20"
+            }
+          },
+          "isOptional": false
+        },
+        {
+          "$type": "TypeAttribute",
+          "name": "right",
+          "isOptional": true,
+          "type": {
+            "$type": "SimpleType",
+            "typeRef": {
+              "$ref": "#/interfaces@20"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "$type": "Interface",
+      "name": "Conjunction",
+      "attributes": [
+        {
+          "$type": "TypeAttribute",
+          "name": "left",
+          "type": {
+            "$type": "SimpleType",
+            "typeRef": {
+              "$ref": "#/types@3"
+            }
+          },
+          "isOptional": false
+        },
+        {
+          "$type": "TypeAttribute",
+          "name": "right",
+          "type": {
+            "$type": "SimpleType",
+            "typeRef": {
+              "$ref": "#/types@3"
+            }
+          },
+          "isOptional": false
+        }
+      ],
+      "superTypes": []
+    },
+    {
+      "$type": "Interface",
+      "name": "CrossReference",
+      "superTypes": [
+        {
+          "$ref": "#/interfaces@0"
+        }
+      ],
+      "attributes": [
+        {
+          "$type": "TypeAttribute",
+          "name": "deprecatedSyntax",
+          "type": {
+            "$type": "SimpleType",
+            "primitiveType": "boolean"
+          },
+          "isOptional": false
+        },
+        {
+          "$type": "TypeAttribute",
+          "name": "isMulti",
+          "type": {
+            "$type": "SimpleType",
+            "primitiveType": "boolean"
+          },
+          "isOptional": false
+        },
+        {
+          "$type": "TypeAttribute",
+          "name": "terminal",
+          "isOptional": true,
+          "type": {
+            "$type": "SimpleType",
+            "typeRef": {
+              "$ref": "#/interfaces@0"
+            }
+          }
+        },
+        {
+          "$type": "TypeAttribute",
+          "name": "type",
+          "type": {
+            "$type": "ReferenceType",
+            "referenceType": {
+              "$type": "SimpleType",
+              "typeRef": {
+                "$ref": "#/types@1"
+              }
+            },
+            "isMulti": false
+          },
+          "isOptional": false
+        }
+      ]
+    },
+    {
+      "$type": "Interface",
+      "name": "Disjunction",
+      "attributes": [
+        {
+          "$type": "TypeAttribute",
+          "name": "left",
+          "type": {
+            "$type": "SimpleType",
+            "typeRef": {
+              "$ref": "#/types@3"
+            }
+          },
+          "isOptional": false
+        },
+        {
+          "$type": "TypeAttribute",
+          "name": "right",
+          "type": {
+            "$type": "SimpleType",
+            "typeRef": {
+              "$ref": "#/types@3"
+            }
+          },
+          "isOptional": false
+        }
+      ],
+      "superTypes": []
+    },
+    {
+      "$type": "Interface",
+      "name": "EndOfFile",
+      "superTypes": [
+        {
+          "$ref": "#/interfaces@0"
+        }
+      ],
+      "attributes": []
+    },
+    {
+      "$type": "Interface",
+      "name": "Grammar",
+      "attributes": [
+        {
+          "$type": "TypeAttribute",
+          "name": "imports",
+          "type": {
+            "$type": "ArrayType",
+            "elementType": {
+              "$type": "SimpleType",
+              "typeRef": {
+                "$ref": "#/interfaces@13"
+              }
+            }
+          },
+          "isOptional": false
+        },
+        {
+          "$type": "TypeAttribute",
+          "name": "interfaces",
+          "type": {
+            "$type": "ArrayType",
+            "elementType": {
+              "$type": "SimpleType",
+              "typeRef": {
+                "$ref": "#/interfaces@19"
+              }
+            }
+          },
+          "isOptional": false
+        },
+        {
+          "$type": "TypeAttribute",
+          "name": "isDeclared",
+          "type": {
+            "$type": "SimpleType",
+            "primitiveType": "boolean"
+          },
+          "isOptional": false
+        },
+        {
+          "$type": "TypeAttribute",
+          "name": "name",
+          "isOptional": true,
+          "type": {
+            "$type": "SimpleType",
+            "primitiveType": "string"
+          }
+        },
+        {
+          "$type": "TypeAttribute",
+          "name": "rules",
+          "type": {
+            "$type": "ArrayType",
+            "elementType": {
+              "$type": "SimpleType",
+              "typeRef": {
+                "$ref": "#/types@0"
+              }
+            }
+          },
+          "isOptional": false
+        },
+        {
+          "$type": "TypeAttribute",
+          "name": "types",
+          "type": {
+            "$type": "ArrayType",
+            "elementType": {
+              "$type": "SimpleType",
+              "typeRef": {
+                "$ref": "#/interfaces@39"
+              }
+            }
+          },
+          "isOptional": false
+        }
+      ],
+      "superTypes": []
+    },
+    {
+      "$type": "Interface",
+      "name": "GrammarImport",
+      "attributes": [
+        {
+          "$type": "TypeAttribute",
+          "name": "path",
+          "type": {
+            "$type": "SimpleType",
+            "primitiveType": "string"
+          },
+          "isOptional": false
+        }
+      ],
+      "superTypes": []
+    },
+    {
+      "$type": "Interface",
+      "name": "Group",
+      "superTypes": [
+        {
+          "$ref": "#/interfaces@0"
+        }
+      ],
+      "attributes": [
+        {
+          "$type": "TypeAttribute",
+          "name": "elements",
+          "type": {
+            "$type": "ArrayType",
+            "elementType": {
+              "$type": "SimpleType",
+              "typeRef": {
+                "$ref": "#/interfaces@0"
+              }
+            }
+          },
+          "isOptional": false
+        },
+        {
+          "$type": "TypeAttribute",
+          "name": "guardCondition",
+          "isOptional": true,
+          "type": {
+            "$type": "SimpleType",
+            "typeRef": {
+              "$ref": "#/types@3"
+            }
+          }
+        },
+        {
+          "$type": "TypeAttribute",
+          "name": "predicate",
+          "isOptional": true,
+          "type": {
+            "$type": "UnionType",
+            "types": [
+              {
+                "$type": "SimpleType",
+                "stringType": "->"
+              },
+              {
+                "$type": "SimpleType",
+                "stringType": "=>"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "$type": "Interface",
+      "name": "InferredType",
+      "attributes": [
+        {
+          "$type": "TypeAttribute",
+          "name": "name",
+          "type": {
+            "$type": "SimpleType",
+            "primitiveType": "string"
+          },
+          "isOptional": false
+        }
+      ],
+      "superTypes": []
+    },
+    {
+      "$type": "Interface",
+      "name": "InfixRule",
+      "attributes": [
+        {
+          "$type": "TypeAttribute",
+          "name": "call",
+          "type": {
+            "$type": "SimpleType",
+            "typeRef": {
+              "$ref": "#/interfaces@31"
+            }
+          },
+          "isOptional": false
+        },
+        {
+          "$type": "TypeAttribute",
+          "name": "name",
+          "type": {
+            "$type": "SimpleType",
+            "primitiveType": "string"
+          },
+          "isOptional": false
+        },
+        {
+          "$type": "TypeAttribute",
+          "name": "operators",
+          "type": {
+            "$type": "SimpleType",
+            "typeRef": {
+              "$ref": "#/interfaces@18"
+            }
+          },
+          "isOptional": false
+        },
+        {
+          "$type": "TypeAttribute",
+          "name": "parameters",
+          "type": {
+            "$type": "ArrayType",
+            "elementType": {
+              "$type": "SimpleType",
+              "typeRef": {
+                "$ref": "#/interfaces@25"
+              }
+            }
+          },
+          "isOptional": false
+        }
+      ],
+      "superTypes": []
+    },
+    {
+      "$type": "Interface",
+      "name": "InfixRuleOperatorList",
+      "attributes": [
+        {
+          "$type": "TypeAttribute",
+          "name": "associativity",
+          "isOptional": true,
+          "type": {
+            "$type": "SimpleType",
+            "typeRef": {
+              "$ref": "#/types@2"
+            }
+          }
+        },
+        {
+          "$type": "TypeAttribute",
+          "name": "operators",
+          "type": {
+            "$type": "ArrayType",
+            "elementType": {
+              "$type": "SimpleType",
+              "typeRef": {
+                "$ref": "#/interfaces@20"
+              }
+            }
+          },
+          "isOptional": false
+        }
+      ],
+      "superTypes": []
+    },
+    {
+      "$type": "Interface",
+      "name": "InfixRuleOperators",
+      "attributes": [
+        {
+          "$type": "TypeAttribute",
+          "name": "precedences",
+          "type": {
+            "$type": "ArrayType",
+            "elementType": {
+              "$type": "SimpleType",
+              "typeRef": {
+                "$ref": "#/interfaces@17"
+              }
+            }
+          },
+          "isOptional": false
+        }
+      ],
+      "superTypes": []
+    },
+    {
+      "$type": "Interface",
+      "name": "Interface",
+      "attributes": [
+        {
+          "$type": "TypeAttribute",
+          "name": "attributes",
+          "type": {
+            "$type": "ArrayType",
+            "elementType": {
+              "$type": "SimpleType",
+              "typeRef": {
+                "$ref": "#/interfaces@40"
+              }
+            }
+          },
+          "isOptional": false
+        },
+        {
+          "$type": "TypeAttribute",
+          "name": "name",
+          "type": {
+            "$type": "SimpleType",
+            "primitiveType": "string"
+          },
+          "isOptional": false
+        },
+        {
+          "$type": "TypeAttribute",
+          "name": "superTypes",
+          "type": {
+            "$type": "ArrayType",
+            "elementType": {
+              "$type": "ReferenceType",
+              "referenceType": {
+                "$type": "SimpleType",
+                "typeRef": {
+                  "$ref": "#/types@1"
+                }
+              },
+              "isMulti": false
+            }
+          },
+          "isOptional": false
+        }
+      ],
+      "superTypes": []
+    },
+    {
+      "$type": "Interface",
+      "name": "Keyword",
+      "superTypes": [
+        {
+          "$ref": "#/interfaces@0"
+        }
+      ],
+      "attributes": [
+        {
+          "$type": "TypeAttribute",
+          "name": "predicate",
+          "isOptional": true,
+          "type": {
+            "$type": "UnionType",
+            "types": [
+              {
+                "$type": "SimpleType",
+                "stringType": "->"
+              },
+              {
+                "$type": "SimpleType",
+                "stringType": "=>"
+              }
+            ]
+          }
+        },
+        {
+          "$type": "TypeAttribute",
+          "name": "value",
+          "type": {
+            "$type": "SimpleType",
+            "primitiveType": "string"
+          },
+          "isOptional": false
+        }
+      ]
+    },
+    {
+      "$type": "Interface",
+      "name": "NamedArgument",
+      "attributes": [
+        {
+          "$type": "TypeAttribute",
+          "name": "calledByName",
+          "type": {
+            "$type": "SimpleType",
+            "primitiveType": "boolean"
+          },
+          "isOptional": false
+        },
+        {
+          "$type": "TypeAttribute",
+          "name": "parameter",
+          "isOptional": true,
+          "type": {
+            "$type": "ReferenceType",
+            "referenceType": {
+              "$type": "SimpleType",
+              "typeRef": {
+                "$ref": "#/interfaces@25"
+              }
+            },
+            "isMulti": false
+          }
+        },
+        {
+          "$type": "TypeAttribute",
+          "name": "value",
+          "type": {
+            "$type": "SimpleType",
+            "typeRef": {
+              "$ref": "#/types@3"
+            }
+          },
+          "isOptional": false
+        }
+      ],
+      "superTypes": []
+    },
+    {
+      "$type": "Interface",
+      "name": "NegatedToken",
+      "superTypes": [
+        {
+          "$ref": "#/interfaces@35"
+        }
+      ],
+      "attributes": [
+        {
+          "$type": "TypeAttribute",
+          "name": "terminal",
+          "type": {
+            "$type": "SimpleType",
+            "typeRef": {
+              "$ref": "#/interfaces@0"
+            }
+          },
+          "isOptional": false
+        }
+      ]
+    },
+    {
+      "$type": "Interface",
+      "name": "Negation",
+      "attributes": [
+        {
+          "$type": "TypeAttribute",
+          "name": "value",
+          "type": {
+            "$type": "SimpleType",
+            "typeRef": {
+              "$ref": "#/types@3"
+            }
+          },
+          "isOptional": false
+        }
+      ],
+      "superTypes": []
+    },
+    {
+      "$type": "Interface",
+      "name": "NumberLiteral",
+      "attributes": [
+        {
+          "$type": "TypeAttribute",
+          "name": "value",
+          "type": {
+            "$type": "SimpleType",
+            "primitiveType": "number"
+          },
+          "isOptional": false
+        }
+      ],
+      "superTypes": []
+    },
+    {
+      "$type": "Interface",
+      "name": "Parameter",
+      "attributes": [
+        {
+          "$type": "TypeAttribute",
+          "name": "name",
+          "type": {
+            "$type": "SimpleType",
+            "primitiveType": "string"
+          },
+          "isOptional": false
+        }
+      ],
+      "superTypes": []
+    },
+    {
+      "$type": "Interface",
+      "name": "ParameterReference",
+      "attributes": [
+        {
+          "$type": "TypeAttribute",
+          "name": "parameter",
+          "type": {
+            "$type": "ReferenceType",
+            "referenceType": {
+              "$type": "SimpleType",
+              "typeRef": {
+                "$ref": "#/interfaces@25"
+              }
+            },
+            "isMulti": false
+          },
+          "isOptional": false
+        }
+      ],
+      "superTypes": []
+    },
+    {
+      "$type": "Interface",
+      "name": "ParserRule",
+      "attributes": [
+        {
+          "$type": "TypeAttribute",
+          "name": "dataType",
+          "isOptional": true,
+          "type": {
+            "$type": "SimpleType",
+            "typeRef": {
+              "$ref": "#/types@5"
+            }
+          }
+        },
+        {
+          "$type": "TypeAttribute",
+          "name": "definition",
+          "type": {
+            "$type": "SimpleType",
+            "typeRef": {
+              "$ref": "#/interfaces@0"
+            }
+          },
+          "isOptional": false
+        },
+        {
+          "$type": "TypeAttribute",
+          "name": "entry",
+          "type": {
+            "$type": "SimpleType",
+            "primitiveType": "boolean"
+          },
+          "isOptional": false
+        },
+        {
+          "$type": "TypeAttribute",
+          "name": "fragment",
+          "type": {
+            "$type": "SimpleType",
+            "primitiveType": "boolean"
+          },
+          "isOptional": false
+        },
+        {
+          "$type": "TypeAttribute",
+          "name": "inferredType",
+          "isOptional": true,
+          "type": {
+            "$type": "SimpleType",
+            "typeRef": {
+              "$ref": "#/interfaces@15"
+            }
+          }
+        },
+        {
+          "$type": "TypeAttribute",
+          "name": "name",
+          "type": {
+            "$type": "SimpleType",
+            "primitiveType": "string"
+          },
+          "isOptional": false
+        },
+        {
+          "$type": "TypeAttribute",
+          "name": "parameters",
+          "type": {
+            "$type": "ArrayType",
+            "elementType": {
+              "$type": "SimpleType",
+              "typeRef": {
+                "$ref": "#/interfaces@25"
+              }
+            }
+          },
+          "isOptional": false
+        },
+        {
+          "$type": "TypeAttribute",
+          "name": "returnType",
+          "isOptional": true,
+          "type": {
+            "$type": "ReferenceType",
+            "referenceType": {
+              "$type": "SimpleType",
+              "typeRef": {
+                "$ref": "#/types@1"
+              }
+            },
+            "isMulti": false
+          }
+        }
+      ],
+      "superTypes": []
+    },
+    {
+      "$type": "Interface",
+      "name": "ReferenceType",
+      "attributes": [
+        {
+          "$type": "TypeAttribute",
+          "name": "isMulti",
+          "type": {
+            "$type": "SimpleType",
+            "primitiveType": "boolean"
+          },
+          "isOptional": false
+        },
+        {
+          "$type": "TypeAttribute",
+          "name": "referenceType",
+          "type": {
+            "$type": "SimpleType",
+            "typeRef": {
+              "$ref": "#/types@6"
+            }
+          },
+          "isOptional": false
+        }
+      ],
+      "superTypes": []
+    },
+    {
+      "$type": "Interface",
+      "name": "RegexToken",
+      "superTypes": [
+        {
+          "$ref": "#/interfaces@35"
+        }
+      ],
+      "attributes": [
+        {
+          "$type": "TypeAttribute",
+          "name": "regex",
+          "type": {
+            "$type": "SimpleType",
+            "primitiveType": "string"
+          },
+          "isOptional": false
+        }
+      ]
+    },
+    {
+      "$type": "Interface",
+      "name": "ReturnType",
+      "attributes": [
+        {
+          "$type": "TypeAttribute",
+          "name": "name",
+          "type": {
+            "$type": "UnionType",
+            "types": [
+              {
+                "$type": "SimpleType",
+                "typeRef": {
+                  "$ref": "#/types@5"
+                }
+              },
+              {
+                "$type": "SimpleType",
+                "primitiveType": "string"
+              }
+            ]
+          },
+          "isOptional": false
+        }
+      ],
+      "superTypes": []
+    },
+    {
+      "$type": "Interface",
+      "name": "RuleCall",
+      "superTypes": [
+        {
+          "$ref": "#/interfaces@0"
+        }
+      ],
+      "attributes": [
+        {
+          "$type": "TypeAttribute",
+          "name": "arguments",
+          "type": {
+            "$type": "ArrayType",
+            "elementType": {
+              "$type": "SimpleType",
+              "typeRef": {
+                "$ref": "#/interfaces@21"
+              }
+            }
+          },
+          "isOptional": false
+        },
+        {
+          "$type": "TypeAttribute",
+          "name": "predicate",
+          "isOptional": true,
+          "type": {
+            "$type": "UnionType",
+            "types": [
+              {
+                "$type": "SimpleType",
+                "stringType": "->"
+              },
+              {
+                "$type": "SimpleType",
+                "stringType": "=>"
+              }
+            ]
+          }
+        },
+        {
+          "$type": "TypeAttribute",
+          "name": "rule",
+          "type": {
+            "$type": "ReferenceType",
+            "referenceType": {
+              "$type": "SimpleType",
+              "typeRef": {
+                "$ref": "#/types@0"
+              }
+            },
+            "isMulti": false
+          },
+          "isOptional": false
+        }
+      ]
+    },
+    {
+      "$type": "Interface",
+      "name": "SimpleType",
+      "attributes": [
+        {
+          "$type": "TypeAttribute",
+          "name": "primitiveType",
+          "isOptional": true,
+          "type": {
+            "$type": "SimpleType",
+            "typeRef": {
+              "$ref": "#/types@5"
+            }
+          }
+        },
+        {
+          "$type": "TypeAttribute",
+          "name": "stringType",
+          "isOptional": true,
+          "type": {
+            "$type": "SimpleType",
+            "primitiveType": "string"
+          }
+        },
+        {
+          "$type": "TypeAttribute",
+          "name": "typeRef",
+          "isOptional": true,
+          "type": {
+            "$type": "ReferenceType",
+            "referenceType": {
+              "$type": "SimpleType",
+              "typeRef": {
+                "$ref": "#/types@1"
+              }
+            },
+            "isMulti": false
+          }
+        }
+      ],
+      "superTypes": []
+    },
+    {
+      "$type": "Interface",
+      "name": "StringLiteral",
+      "attributes": [
+        {
+          "$type": "TypeAttribute",
+          "name": "value",
+          "type": {
+            "$type": "SimpleType",
+            "primitiveType": "string"
+          },
+          "isOptional": false
+        }
+      ],
+      "superTypes": []
+    },
+    {
+      "$type": "Interface",
+      "name": "TerminalAlternatives",
+      "superTypes": [
+        {
+          "$ref": "#/interfaces@35"
+        }
+      ],
+      "attributes": [
+        {
+          "$type": "TypeAttribute",
+          "name": "elements",
+          "type": {
+            "$type": "ArrayType",
+            "elementType": {
+              "$type": "SimpleType",
+              "typeRef": {
+                "$ref": "#/interfaces@0"
+              }
+            }
+          },
+          "isOptional": false
+        }
+      ]
+    },
+    {
+      "$type": "Interface",
+      "name": "TerminalElement",
+      "superTypes": [
+        {
+          "$ref": "#/interfaces@0"
+        }
+      ],
+      "attributes": [
+        {
+          "$type": "TypeAttribute",
+          "name": "lookahead",
+          "isOptional": true,
+          "type": {
+            "$type": "UnionType",
+            "types": [
+              {
+                "$type": "SimpleType",
+                "stringType": "?!"
+              },
+              {
+                "$type": "SimpleType",
+                "stringType": "?<!"
+              },
+              {
+                "$type": "SimpleType",
+                "stringType": "?<="
+              },
+              {
+                "$type": "SimpleType",
+                "stringType": "?="
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "$type": "Interface",
+      "name": "TerminalGroup",
+      "superTypes": [
+        {
+          "$ref": "#/interfaces@35"
+        }
+      ],
+      "attributes": [
+        {
+          "$type": "TypeAttribute",
+          "name": "elements",
+          "type": {
+            "$type": "ArrayType",
+            "elementType": {
+              "$type": "SimpleType",
+              "typeRef": {
+                "$ref": "#/interfaces@0"
+              }
+            }
+          },
+          "isOptional": false
+        }
+      ]
+    },
+    {
+      "$type": "Interface",
+      "name": "TerminalRule",
+      "attributes": [
+        {
+          "$type": "TypeAttribute",
+          "name": "definition",
+          "type": {
+            "$type": "SimpleType",
+            "typeRef": {
+              "$ref": "#/interfaces@35"
+            }
+          },
+          "isOptional": false
+        },
+        {
+          "$type": "TypeAttribute",
+          "name": "fragment",
+          "type": {
+            "$type": "SimpleType",
+            "primitiveType": "boolean"
+          },
+          "isOptional": false
+        },
+        {
+          "$type": "TypeAttribute",
+          "name": "hidden",
+          "type": {
+            "$type": "SimpleType",
+            "primitiveType": "boolean"
+          },
+          "isOptional": false
+        },
+        {
+          "$type": "TypeAttribute",
+          "name": "name",
+          "type": {
+            "$type": "SimpleType",
+            "primitiveType": "string"
+          },
+          "isOptional": false
+        },
+        {
+          "$type": "TypeAttribute",
+          "name": "type",
+          "isOptional": true,
+          "type": {
+            "$type": "SimpleType",
+            "typeRef": {
+              "$ref": "#/interfaces@30"
+            }
+          }
+        }
+      ],
+      "superTypes": []
+    },
+    {
+      "$type": "Interface",
+      "name": "TerminalRuleCall",
+      "superTypes": [
+        {
+          "$ref": "#/interfaces@35"
+        }
+      ],
+      "attributes": [
+        {
+          "$type": "TypeAttribute",
+          "name": "rule",
+          "type": {
+            "$type": "ReferenceType",
+            "referenceType": {
+              "$type": "SimpleType",
+              "typeRef": {
+                "$ref": "#/interfaces@37"
+              }
+            },
+            "isMulti": false
+          },
+          "isOptional": false
+        }
+      ]
+    },
+    {
+      "$type": "Interface",
+      "name": "Type",
+      "attributes": [
+        {
+          "$type": "TypeAttribute",
+          "name": "name",
+          "type": {
+            "$type": "SimpleType",
+            "primitiveType": "string"
+          },
+          "isOptional": false
+        },
+        {
+          "$type": "TypeAttribute",
+          "name": "type",
+          "type": {
+            "$type": "SimpleType",
+            "typeRef": {
+              "$ref": "#/types@6"
+            }
+          },
+          "isOptional": false
+        }
+      ],
+      "superTypes": []
+    },
+    {
+      "$type": "Interface",
+      "name": "TypeAttribute",
+      "attributes": [
+        {
+          "$type": "TypeAttribute",
+          "name": "defaultValue",
+          "isOptional": true,
+          "type": {
+            "$type": "SimpleType",
+            "typeRef": {
+              "$ref": "#/types@7"
+            }
+          }
+        },
+        {
+          "$type": "TypeAttribute",
+          "name": "isOptional",
+          "type": {
+            "$type": "SimpleType",
+            "primitiveType": "boolean"
+          },
+          "isOptional": false
+        },
+        {
+          "$type": "TypeAttribute",
+          "name": "name",
+          "type": {
+            "$type": "SimpleType",
+            "typeRef": {
+              "$ref": "#/types@4"
+            }
+          },
+          "isOptional": false
+        },
+        {
+          "$type": "TypeAttribute",
+          "name": "type",
+          "type": {
+            "$type": "SimpleType",
+            "typeRef": {
+              "$ref": "#/types@6"
+            }
+          },
+          "isOptional": false
+        }
+      ],
+      "superTypes": []
+    },
+    {
+      "$type": "Interface",
+      "name": "UnionType",
+      "attributes": [
+        {
+          "$type": "TypeAttribute",
+          "name": "types",
+          "type": {
+            "$type": "ArrayType",
+            "elementType": {
+              "$type": "SimpleType",
+              "typeRef": {
+                "$ref": "#/types@6"
+              }
+            }
+          },
+          "isOptional": false
+        }
+      ],
+      "superTypes": []
+    },
+    {
+      "$type": "Interface",
+      "name": "UnorderedGroup",
+      "superTypes": [
+        {
+          "$ref": "#/interfaces@0"
+        }
+      ],
+      "attributes": [
+        {
+          "$type": "TypeAttribute",
+          "name": "elements",
+          "type": {
+            "$type": "ArrayType",
+            "elementType": {
+              "$type": "SimpleType",
+              "typeRef": {
+                "$ref": "#/interfaces@0"
+              }
+            }
+          },
+          "isOptional": false
+        }
+      ]
+    },
+    {
+      "$type": "Interface",
+      "name": "UntilToken",
+      "superTypes": [
+        {
+          "$ref": "#/interfaces@35"
+        }
+      ],
+      "attributes": [
+        {
+          "$type": "TypeAttribute",
+          "name": "terminal",
+          "type": {
+            "$type": "SimpleType",
+            "typeRef": {
+              "$ref": "#/interfaces@0"
+            }
+          },
+          "isOptional": false
+        }
+      ]
+    },
+    {
+      "$type": "Interface",
+      "name": "Wildcard",
+      "superTypes": [
+        {
+          "$ref": "#/interfaces@35"
+        }
+      ],
+      "attributes": []
+    }
+  ],
   "types": [
+    {
+      "$type": "Type",
+      "name": "AbstractRule",
+      "type": {
+        "$type": "UnionType",
+        "types": [
+          {
+            "$type": "SimpleType",
+            "typeRef": {
+              "$ref": "#/interfaces@16"
+            }
+          },
+          {
+            "$type": "SimpleType",
+            "typeRef": {
+              "$ref": "#/interfaces@27"
+            }
+          },
+          {
+            "$type": "SimpleType",
+            "typeRef": {
+              "$ref": "#/interfaces@37"
+            }
+          }
+        ]
+      }
+    },
     {
       "$type": "Type",
       "name": "AbstractType",
@@ -3765,37 +5322,289 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "SimpleType",
             "typeRef": {
-              "$ref": "#/rules@1"
+              "$ref": "#/interfaces@15"
             }
           },
           {
             "$type": "SimpleType",
             "typeRef": {
-              "$ref": "#/rules@14"
+              "$ref": "#/interfaces@16"
             }
           },
           {
             "$type": "SimpleType",
             "typeRef": {
-              "$ref": "#/rules@17"
+              "$ref": "#/interfaces@19"
             }
           },
           {
             "$type": "SimpleType",
             "typeRef": {
-              "$ref": "#/rules@18"
+              "$ref": "#/interfaces@27"
             }
           },
           {
             "$type": "SimpleType",
             "typeRef": {
-              "$ref": "#/rules@22"
+              "$ref": "#/interfaces@39"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "$type": "Type",
+      "name": "Associativity",
+      "type": {
+        "$type": "UnionType",
+        "types": [
+          {
+            "$type": "SimpleType",
+            "stringType": "left"
+          },
+          {
+            "$type": "SimpleType",
+            "stringType": "right"
+          }
+        ]
+      }
+    },
+    {
+      "$type": "Type",
+      "name": "Condition",
+      "type": {
+        "$type": "UnionType",
+        "types": [
+          {
+            "$type": "SimpleType",
+            "typeRef": {
+              "$ref": "#/interfaces@6"
+            }
+          },
+          {
+            "$type": "SimpleType",
+            "typeRef": {
+              "$ref": "#/interfaces@8"
+            }
+          },
+          {
+            "$type": "SimpleType",
+            "typeRef": {
+              "$ref": "#/interfaces@10"
+            }
+          },
+          {
+            "$type": "SimpleType",
+            "typeRef": {
+              "$ref": "#/interfaces@23"
+            }
+          },
+          {
+            "$type": "SimpleType",
+            "typeRef": {
+              "$ref": "#/interfaces@26"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "$type": "Type",
+      "name": "FeatureName",
+      "type": {
+        "$type": "UnionType",
+        "types": [
+          {
+            "$type": "SimpleType",
+            "stringType": "assoc"
+          },
+          {
+            "$type": "SimpleType",
+            "stringType": "current"
+          },
+          {
+            "$type": "SimpleType",
+            "stringType": "entry"
+          },
+          {
+            "$type": "SimpleType",
+            "stringType": "extends"
+          },
+          {
+            "$type": "SimpleType",
+            "stringType": "false"
+          },
+          {
+            "$type": "SimpleType",
+            "stringType": "fragment"
+          },
+          {
+            "$type": "SimpleType",
+            "stringType": "grammar"
+          },
+          {
+            "$type": "SimpleType",
+            "stringType": "hidden"
+          },
+          {
+            "$type": "SimpleType",
+            "stringType": "import"
+          },
+          {
+            "$type": "SimpleType",
+            "stringType": "infer"
+          },
+          {
+            "$type": "SimpleType",
+            "stringType": "infers"
+          },
+          {
+            "$type": "SimpleType",
+            "stringType": "infix"
+          },
+          {
+            "$type": "SimpleType",
+            "stringType": "interface"
+          },
+          {
+            "$type": "SimpleType",
+            "stringType": "left"
+          },
+          {
+            "$type": "SimpleType",
+            "stringType": "on"
+          },
+          {
+            "$type": "SimpleType",
+            "stringType": "returns"
+          },
+          {
+            "$type": "SimpleType",
+            "stringType": "right"
+          },
+          {
+            "$type": "SimpleType",
+            "stringType": "terminal"
+          },
+          {
+            "$type": "SimpleType",
+            "stringType": "true"
+          },
+          {
+            "$type": "SimpleType",
+            "stringType": "type"
+          },
+          {
+            "$type": "SimpleType",
+            "stringType": "with"
+          },
+          {
+            "$type": "SimpleType",
+            "typeRef": {
+              "$ref": "#/types@5"
+            }
+          },
+          {
+            "$type": "SimpleType",
+            "primitiveType": "string"
+          }
+        ]
+      }
+    },
+    {
+      "$type": "Type",
+      "name": "PrimitiveType",
+      "type": {
+        "$type": "UnionType",
+        "types": [
+          {
+            "$type": "SimpleType",
+            "stringType": "Date"
+          },
+          {
+            "$type": "SimpleType",
+            "stringType": "bigint"
+          },
+          {
+            "$type": "SimpleType",
+            "stringType": "boolean"
+          },
+          {
+            "$type": "SimpleType",
+            "stringType": "number"
+          },
+          {
+            "$type": "SimpleType",
+            "stringType": "string"
+          }
+        ]
+      }
+    },
+    {
+      "$type": "Type",
+      "name": "TypeDefinition",
+      "type": {
+        "$type": "UnionType",
+        "types": [
+          {
+            "$type": "SimpleType",
+            "typeRef": {
+              "$ref": "#/interfaces@4"
+            }
+          },
+          {
+            "$type": "SimpleType",
+            "typeRef": {
+              "$ref": "#/interfaces@28"
+            }
+          },
+          {
+            "$type": "SimpleType",
+            "typeRef": {
+              "$ref": "#/interfaces@32"
+            }
+          },
+          {
+            "$type": "SimpleType",
+            "typeRef": {
+              "$ref": "#/interfaces@41"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "$type": "Type",
+      "name": "ValueLiteral",
+      "type": {
+        "$type": "UnionType",
+        "types": [
+          {
+            "$type": "SimpleType",
+            "typeRef": {
+              "$ref": "#/interfaces@3"
+            }
+          },
+          {
+            "$type": "SimpleType",
+            "typeRef": {
+              "$ref": "#/interfaces@6"
+            }
+          },
+          {
+            "$type": "SimpleType",
+            "typeRef": {
+              "$ref": "#/interfaces@24"
+            }
+          },
+          {
+            "$type": "SimpleType",
+            "typeRef": {
+              "$ref": "#/interfaces@33"
             }
           }
         ]
       }
     }
-  ],
-  "imports": [],
-  "interfaces": []
+  ]
 }`));

--- a/packages/langium/src/grammar/langium-grammar.langium
+++ b/packages/langium/src/grammar/langium-grammar.langium
@@ -6,12 +6,14 @@
 
 grammar LangiumGrammar
 
-entry Grammar:
+import './langium-types'
+
+entry Grammar returns Grammar:
     (isDeclared?='grammar' name=ID)?
     imports+=GrammarImport*
     (rules+=AbstractRule | interfaces+=Interface | types+=Type)*;
 
-Interface:
+Interface returns Interface:
     'interface' name=ID
     ('extends' superTypes+=[AbstractType:ID] (',' superTypes+=[AbstractType:ID])*)?
     '{'
@@ -19,100 +21,99 @@ Interface:
     '}'
 ';'?;
 
-TypeAttribute:
+TypeAttribute returns TypeAttribute:
     name=FeatureName (isOptional?='?')? ':' type=TypeDefinition ('=' defaultValue=ValueLiteral)? ';'?;
 
-ValueLiteral:
+ValueLiteral returns ValueLiteral:
     StringLiteral | NumberLiteral | BooleanLiteral | ArrayLiteral;
 
-StringLiteral:
+StringLiteral returns StringLiteral:
     value=STRING;
-NumberLiteral:
+NumberLiteral returns NumberLiteral:
     value=NUMBER;
-BooleanLiteral:
+BooleanLiteral returns BooleanLiteral:
     true?='true' | 'false';
-ArrayLiteral:
+ArrayLiteral returns ArrayLiteral:
     '[' (elements+=ValueLiteral (',' elements+=ValueLiteral)*)? ']';
 
-TypeDefinition: UnionType;
+TypeDefinition returns TypeDefinition:
+    UnionType;
 
-UnionType infers TypeDefinition:
-    ArrayType ({infer UnionType.types+=current} ('|' types+=ArrayType)+)?;
+UnionType returns TypeDefinition:
+    ArrayType ({UnionType.types+=current} ('|' types+=ArrayType)+)?;
 
-ArrayType infers TypeDefinition:
-    ReferenceType ({infer ArrayType.elementType=current} '[' ']')? ;
+ArrayType returns TypeDefinition:
+    ReferenceType ({ArrayType.elementType=current} '[' ']')? ;
 
-ReferenceType infers TypeDefinition:
+ReferenceType returns TypeDefinition:
     SimpleType |
-    {infer ReferenceType} '@' referenceType=SimpleType (isMulti?='+')?;
+    {ReferenceType} '@' referenceType=SimpleType (isMulti?='+')?;
 
-SimpleType infers TypeDefinition:
+SimpleType returns TypeDefinition:
     '(' TypeDefinition ')' |
-    {infer SimpleType} (typeRef=[AbstractType:ID] | primitiveType=PrimitiveType | stringType=STRING);
+    {SimpleType} (typeRef=[AbstractType:ID] | primitiveType=PrimitiveType | stringType=STRING);
 
 PrimitiveType returns string:
     'string' | 'number' | 'boolean' | 'Date' | 'bigint';
 
-type AbstractType = Interface | Type | ParserRule | InfixRule | InferredType;
-
-Type:
+Type returns Type:
     'type' name=ID '=' type=TypeDefinition ';'?;
 
-AbstractRule:
+AbstractRule returns AbstractRule:
     ParserRule | TerminalRule | InfixRule;
 
-GrammarImport:
+GrammarImport returns GrammarImport:
     'import' path=STRING ';'?;
 
-ParserRule:
+ParserRule returns ParserRule:
     (entry?='entry' | fragment?='fragment')?
     RuleNameAndParams
     ('returns' (returnType=[AbstractType:ID] | dataType=PrimitiveType) | inferredType=InferredType<false>)? ':'
     definition=Alternatives ';';
 
-InfixRule: 'infix' RuleNameAndParams 'on' call=RuleCall ':' operators=InfixRuleOperators ';';
+InfixRule returns InfixRule: 'infix' RuleNameAndParams 'on' call=RuleCall ':' operators=InfixRuleOperators ';';
 
-InfixRuleOperators: precedences+=InfixRuleOperatorList ('>' precedences+=InfixRuleOperatorList)*;
+InfixRuleOperators returns InfixRuleOperators: precedences+=InfixRuleOperatorList ('>' precedences+=InfixRuleOperatorList)*;
 
-InfixRuleOperatorList:
+InfixRuleOperatorList returns InfixRuleOperatorList:
     (associativity=Associativity 'assoc')?
     operators+=Keyword ('|' operators+=Keyword)*;
 
 Associativity returns string: 'left' | 'right';
 
-InferredType<imperative>:
+InferredType<imperative> returns InferredType:
     (<imperative> 'infer' | <!imperative> 'infers') name=ID;
 
 fragment RuleNameAndParams:
     name=ID ('<' (parameters+=Parameter (',' parameters+=Parameter)*)? '>')?;
 
-Parameter:
+Parameter returns Parameter:
     name=ID;
 
-Alternatives infers AbstractElement:
-    ConditionalBranch ({infer Alternatives.elements+=current} ('|' elements+=ConditionalBranch)+)?;
+Alternatives returns AbstractElement:
+    ConditionalBranch ({Alternatives.elements+=current} ('|' elements+=ConditionalBranch)+)?;
 
-ConditionalBranch infers AbstractElement:
+ConditionalBranch returns AbstractElement:
     UnorderedGroup
-    | {infer Group} '<' guardCondition=Disjunction '>' (elements+=AbstractToken)+;
+    | {Group} '<' guardCondition=Disjunction '>' (elements+=AbstractToken)+;
 
-UnorderedGroup infers AbstractElement:
-    Group ({infer UnorderedGroup.elements+=current} ('&' elements+=Group)+)?;
+UnorderedGroup returns AbstractElement:
+    Group ({UnorderedGroup.elements+=current} ('&' elements+=Group)+)?;
 
-Group infers AbstractElement:
-    AbstractToken ({infer Group.elements+=current} elements+=AbstractToken+)?;
+Group returns AbstractElement:
+    AbstractToken ({Group.elements+=current} elements+=AbstractToken+)?;
 
-AbstractToken infers AbstractElement:
+AbstractToken returns AbstractElement:
     AbstractTokenWithCardinality |
     Action;
 
-AbstractTokenWithCardinality infers AbstractElement:
+AbstractTokenWithCardinality returns AbstractElement:
     (Assignment | AbstractTerminal) cardinality=('?'|'*'|'+')?;
 
-Action infers AbstractElement:
-    {infer Action} '{' (type=[AbstractType:ID] | inferredType=InferredType<true>) ('.' feature=FeatureName operator=('='|'+=') 'current')? '}';
+Action returns AbstractElement:
+    {Action} '{' (type=[AbstractType:ID] | inferredType=InferredType<true>) ('.' feature=FeatureName operator=('='|'+=') 'current')? '}';
 
-AbstractTerminal infers AbstractElement:
+AbstractTerminal returns AbstractElement:
     Keyword |
     RuleCall |
     ParenthesizedElement |
@@ -121,106 +122,106 @@ AbstractTerminal infers AbstractElement:
     PredicatedGroup |
     EndOfFile;
 
-EndOfFile:
-    {infer EndOfFile} 'EOF';
+EndOfFile returns EndOfFile:
+    {EndOfFile} 'EOF';
 
-Keyword:
+Keyword returns Keyword:
     value=STRING;
 
-RuleCall:
+RuleCall returns RuleCall:
     rule=[AbstractRule:ID] ('<' arguments+=NamedArgument (',' arguments+=NamedArgument)* '>')?;
 
-NamedArgument:
+NamedArgument returns NamedArgument:
     (parameter=[Parameter:ID] calledByName?='=')? value=Disjunction;
 
-Disjunction infers Condition:
-    Conjunction ({infer Disjunction.left=current} '|' right=Conjunction)*;
+Disjunction returns Condition:
+    Conjunction ({Disjunction.left=current} '|' right=Conjunction)*;
 
-Conjunction infers Condition:
-    Negation ({infer Conjunction.left=current} '&' right=Negation)*;
+Conjunction returns Condition:
+    Negation ({Conjunction.left=current} '&' right=Negation)*;
 
-Negation infers Condition:
-    Atom | {infer Negation} '!' value=Negation;
+Negation returns Condition:
+    Atom | {Negation} '!' value=Negation;
 
-Atom infers Condition:
+Atom returns Condition:
     ParameterReference | ParenthesizedCondition | BooleanLiteral;
 
-ParenthesizedCondition infers Condition:
+ParenthesizedCondition returns Condition:
     '(' Disjunction ')';
 
-ParameterReference:
+ParameterReference returns ParameterReference:
     parameter=[Parameter:ID];
 
-PredicatedKeyword infers Keyword:
+PredicatedKeyword returns Keyword:
     (predicate=('=>'|'->')) value=STRING;
 
-PredicatedRuleCall infers RuleCall:
+PredicatedRuleCall returns RuleCall:
     (predicate=('=>'|'->')) rule=[AbstractRule:ID] ('<' arguments+=NamedArgument (',' arguments+=NamedArgument)* '>')?;
 
-Assignment infers AbstractElement:
-    {infer Assignment} (predicate=('=>'|'->'))? feature=FeatureName operator=('+='|'='|'?=') terminal=AssignableTerminal;
+Assignment returns AbstractElement:
+    {Assignment} (predicate=('=>'|'->'))? feature=FeatureName operator=('+='|'='|'?=') terminal=AssignableTerminal;
 
-AssignableTerminal infers AbstractElement:
+AssignableTerminal returns AbstractElement:
     Keyword | RuleCall | ParenthesizedAssignableElement | CrossReference;
 
-ParenthesizedAssignableElement infers AbstractElement:
+ParenthesizedAssignableElement returns AbstractElement:
     '(' AssignableAlternatives ')';
 
-AssignableAlternatives infers AbstractElement:
-    AssignableTerminal ({infer Alternatives.elements+=current} ('|' elements+=AssignableTerminal)+)?;
+AssignableAlternatives returns AbstractElement:
+    AssignableTerminal ({Alternatives.elements+=current} ('|' elements+=AssignableTerminal)+)?;
 
-CrossReference infers AbstractElement:
-    {infer CrossReference} '[' isMulti?='+'? type=[AbstractType] ((deprecatedSyntax?='|' | ':') terminal=CrossReferenceableTerminal )? ']';
+CrossReference returns AbstractElement:
+    {CrossReference} '[' isMulti?='+'? type=[AbstractType:ID] ((deprecatedSyntax?='|' | ':') terminal=CrossReferenceableTerminal )? ']';
 
-CrossReferenceableTerminal infers AbstractElement:
+CrossReferenceableTerminal returns AbstractElement:
     Keyword | RuleCall;
 
-ParenthesizedElement infers AbstractElement:
+ParenthesizedElement returns AbstractElement:
     '(' Alternatives ')';
 
-PredicatedGroup infers Group:
+PredicatedGroup returns Group:
     (predicate=('=>'|'->')) '(' elements+=Alternatives ')';
 
-ReturnType:
+ReturnType returns ReturnType:
     name=(PrimitiveType | ID);
 
-TerminalRule:
+TerminalRule returns TerminalRule:
     hidden?='hidden'? 'terminal' (fragment?='fragment' name=ID | name=ID ('returns' type=ReturnType)?) ':'
         definition=TerminalAlternatives
     ';';
 
-TerminalAlternatives infers AbstractElement:
-    TerminalGroup ({infer TerminalAlternatives.elements+=current} '|' elements+=TerminalGroup)*;
+TerminalAlternatives returns TerminalElement:
+    TerminalGroup ({TerminalAlternatives.elements+=current} '|' elements+=TerminalGroup)*;
 
-TerminalGroup infers AbstractElement:
-    TerminalToken ({infer TerminalGroup.elements+=current} elements+=TerminalToken+)?;
+TerminalGroup returns TerminalElement:
+    TerminalToken ({TerminalGroup.elements+=current} elements+=TerminalToken+)?;
 
-TerminalToken infers AbstractElement:
+TerminalToken returns TerminalElement:
     TerminalTokenElement cardinality=('?'|'*'|'+')?;
 
-TerminalTokenElement infers AbstractElement:
+TerminalTokenElement returns TerminalElement:
     CharacterRange | TerminalRuleCall | ParenthesizedTerminalElement | NegatedToken | UntilToken | RegexToken | Wildcard;
 
-ParenthesizedTerminalElement infers AbstractElement:
+ParenthesizedTerminalElement returns TerminalElement:
     '(' (lookahead=('?='|'?!'|'?<='|'?<!'))? TerminalAlternatives ')';
 
-TerminalRuleCall infers AbstractElement:
-    {infer TerminalRuleCall} rule=[TerminalRule:ID];
+TerminalRuleCall returns TerminalElement:
+    {TerminalRuleCall} rule=[TerminalRule:ID];
 
-NegatedToken infers AbstractElement:
-    {infer NegatedToken} '!' terminal=TerminalTokenElement;
+NegatedToken returns TerminalElement:
+    {NegatedToken} '!' terminal=TerminalTokenElement;
 
-UntilToken infers AbstractElement:
-    {infer UntilToken} '->' terminal=TerminalTokenElement;
+UntilToken returns TerminalElement:
+    {UntilToken} '->' terminal=TerminalTokenElement;
 
-RegexToken infers AbstractElement:
-    {infer RegexToken} regex=RegexLiteral;
+RegexToken returns TerminalElement:
+    {RegexToken} regex=RegexLiteral;
 
-Wildcard infers AbstractElement:
-    {infer Wildcard} '.';
+Wildcard returns TerminalElement:
+    {Wildcard} '.';
 
-CharacterRange infers AbstractElement:
-    {infer CharacterRange} left=Keyword ('..' right=Keyword)?;
+CharacterRange returns TerminalElement:
+    {CharacterRange} left=Keyword ('..' right=Keyword)?;
 
 FeatureName returns string:
     'infix' | 'on' | 'right' | 'left' | 'assoc' | 'current' | 'entry' | 'extends' | 'false' | 'fragment' | 'grammar' | 'hidden' | 'import' | 'interface' | 'returns' | 'terminal' | 'true' | 'type' | 'infer' | 'infers' | 'with' | PrimitiveType | ID;

--- a/packages/langium/src/grammar/langium-grammar.langium
+++ b/packages/langium/src/grammar/langium-grammar.langium
@@ -203,7 +203,7 @@ TerminalTokenElement returns TerminalElement:
     CharacterRange | TerminalRuleCall | ParenthesizedTerminalElement | NegatedToken | UntilToken | RegexToken | Wildcard;
 
 ParenthesizedTerminalElement returns TerminalElement:
-    '(' (lookahead=('?='|'?!'|'?<='|'?<!'))? TerminalAlternatives ')';
+    '(' (lookahead=('?='|'?!'|'?<='|'?<!'))? TerminalAlternatives parenthesized?=')';
 
 TerminalRuleCall returns TerminalElement:
     {TerminalRuleCall} rule=[TerminalRule:ID];

--- a/packages/langium/src/grammar/langium-types.langium
+++ b/packages/langium/src/grammar/langium-types.langium
@@ -1,0 +1,248 @@
+// ******************************************************************************
+// Copyright 2025 TypeFox GmbH
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+// *****************************************************************************
+
+type AbstractRule = InfixRule | ParserRule | TerminalRule;
+
+type AbstractType = InferredType | InfixRule | Interface | ParserRule | Type;
+
+type Associativity = "left" | "right";
+
+type Condition = BooleanLiteral | Conjunction | Disjunction | Negation | ParameterReference;
+
+type FeatureName = "assoc" | "current" | "entry" | "extends" | "false" | "fragment" | "grammar" | "hidden" | "import" | "infer" | "infers" | "infix" | "interface" | "left" | "on" | "returns" | "right" | "terminal" | "true" | "type" | "with" | PrimitiveType | string;
+
+type PrimitiveType = "Date" | "bigint" | "boolean" | "number" | "string";
+
+type TypeDefinition = ArrayType | ReferenceType | SimpleType | UnionType;
+
+type ValueLiteral = ArrayLiteral | BooleanLiteral | NumberLiteral | StringLiteral;
+
+interface AbstractElement {
+    cardinality?: "*" | "+" | "?";
+}
+
+interface Action extends AbstractElement {
+    feature?: FeatureName;
+    inferredType?: InferredType;
+    operator?: "+=" | "=";
+    type?: @AbstractType;
+}
+
+interface Alternatives extends AbstractElement {
+    elements: AbstractElement[];
+}
+
+interface ArrayLiteral {
+    elements: ValueLiteral[];
+}
+
+interface ArrayType {
+    elementType: TypeDefinition;
+}
+
+interface Assignment extends AbstractElement {
+    feature: FeatureName;
+    operator: "+=" | "=" | "?=";
+    predicate?: "->" | "=>";
+    terminal: AbstractElement;
+}
+
+interface BooleanLiteral {
+    true: boolean;
+}
+
+interface CharacterRange extends TerminalElement {
+    left: Keyword;
+    right?: Keyword;
+}
+
+interface Conjunction {
+    left: Condition;
+    right: Condition;
+}
+
+interface CrossReference extends AbstractElement {
+    deprecatedSyntax: boolean;
+    isMulti: boolean;
+    terminal?: AbstractElement;
+    type: @AbstractType;
+}
+
+interface Disjunction {
+    left: Condition;
+    right: Condition;
+}
+
+interface EndOfFile extends AbstractElement {
+}
+
+interface Grammar {
+    imports: GrammarImport[];
+    interfaces: Interface[];
+    isDeclared: boolean;
+    name?: string;
+    rules: AbstractRule[];
+    types: Type[];
+}
+
+interface GrammarImport {
+    path: string;
+}
+
+interface Group extends AbstractElement {
+    elements: AbstractElement[];
+    guardCondition?: Condition;
+    predicate?: "->" | "=>";
+}
+
+interface InferredType {
+    name: string;
+}
+
+interface InfixRule {
+    call: RuleCall;
+    name: string;
+    operators: InfixRuleOperators;
+    parameters: Parameter[];
+}
+
+interface InfixRuleOperatorList {
+    associativity?: Associativity;
+    operators: Keyword[];
+}
+
+interface InfixRuleOperators {
+    precedences: InfixRuleOperatorList[];
+}
+
+interface Interface {
+    attributes: TypeAttribute[];
+    name: string;
+    superTypes: @AbstractType[];
+}
+
+interface Keyword extends AbstractElement {
+    predicate?: "->" | "=>";
+    value: string;
+}
+
+interface NamedArgument {
+    calledByName: boolean;
+    parameter?: @Parameter;
+    value: Condition;
+}
+
+interface NegatedToken extends TerminalElement {
+    terminal: AbstractElement;
+}
+
+interface Negation {
+    value: Condition;
+}
+
+interface NumberLiteral {
+    value: number;
+}
+
+interface Parameter {
+    name: string;
+}
+
+interface ParameterReference {
+    parameter: @Parameter;
+}
+
+interface ParserRule {
+    dataType?: PrimitiveType;
+    definition: AbstractElement;
+    entry: boolean;
+    fragment: boolean;
+    inferredType?: InferredType;
+    name: string;
+    parameters: Parameter[];
+    returnType?: @AbstractType;
+}
+
+interface ReferenceType {
+    isMulti: boolean;
+    referenceType: TypeDefinition;
+}
+
+interface RegexToken extends TerminalElement {
+    regex: string;
+}
+
+interface ReturnType {
+    name: PrimitiveType | string;
+}
+
+interface RuleCall extends AbstractElement {
+    arguments: NamedArgument[];
+    predicate?: "->" | "=>";
+    rule: @AbstractRule;
+}
+
+interface SimpleType {
+    primitiveType?: PrimitiveType;
+    stringType?: string;
+    typeRef?: @AbstractType;
+}
+
+interface StringLiteral {
+    value: string;
+}
+
+interface TerminalAlternatives extends TerminalElement {
+    elements: AbstractElement[];
+}
+
+interface TerminalElement extends AbstractElement {
+    lookahead?: "?!" | "?<!" | "?<=" | "?=";
+}
+
+interface TerminalGroup extends TerminalElement {
+    elements: AbstractElement[];
+}
+
+interface TerminalRule {
+    definition: TerminalElement;
+    fragment: boolean;
+    hidden: boolean;
+    name: string;
+    type?: ReturnType;
+}
+
+interface TerminalRuleCall extends TerminalElement {
+    rule: @TerminalRule;
+}
+
+interface Type {
+    name: string;
+    type: TypeDefinition;
+}
+
+interface TypeAttribute {
+    defaultValue?: ValueLiteral;
+    isOptional: boolean;
+    name: FeatureName;
+    type: TypeDefinition;
+}
+
+interface UnionType {
+    types: TypeDefinition[];
+}
+
+interface UnorderedGroup extends AbstractElement {
+    elements: AbstractElement[];
+}
+
+interface UntilToken extends TerminalElement {
+    terminal: AbstractElement;
+}
+
+interface Wildcard extends TerminalElement {
+}
+

--- a/packages/langium/src/grammar/langium-types.langium
+++ b/packages/langium/src/grammar/langium-types.langium
@@ -201,6 +201,7 @@ interface TerminalAlternatives extends TerminalElement {
 
 interface TerminalElement extends AbstractElement {
     lookahead?: "?!" | "?<!" | "?<=" | "?=";
+    parenthesized?: boolean;
 }
 
 interface TerminalGroup extends TerminalElement {

--- a/packages/langium/src/grammar/type-system/ast-collector.ts
+++ b/packages/langium/src/grammar/type-system/ast-collector.ts
@@ -9,7 +9,7 @@ import type { LangiumCoreServices } from '../../index.js';
 import type { AstTypes, InterfaceType, PropertyType, TypeOption, UnionType } from './type-collector/types.js';
 import type { ValidationAstTypes } from './type-collector/all-types.js';
 import type { PlainAstTypes, PlainInterface, PlainUnion } from './type-collector/plain-types.js';
-import { findAstTypes, sortInterfacesTopologically } from './types-util.js';
+import { findAstTypes } from './types-util.js';
 import { isInterfaceType, isPrimitiveType, isPropertyUnion, isStringType, isUnionType, isValueType } from './type-collector/types.js';
 import { collectTypeResources } from './type-collector/all-types.js';
 import { plainToTypes } from './type-collector/plain-types.js';
@@ -44,7 +44,7 @@ export function collectValidationAst(grammars: Grammar | Grammar[], services?: L
 
 export function createAstTypes(first: PlainAstTypes, second?: PlainAstTypes): AstTypes {
     const astTypes: PlainAstTypes = {
-        interfaces: sortInterfacesTopologically(mergeAndRemoveDuplicates<PlainInterface>(...first.interfaces, ...second?.interfaces ?? [])),
+        interfaces: mergeAndRemoveDuplicates<PlainInterface>(...first.interfaces, ...second?.interfaces ?? []),
         unions: mergeAndRemoveDuplicates<PlainUnion>(...first.unions, ...second?.unions ?? []),
     };
 

--- a/packages/langium/src/grammar/type-system/types-util.ts
+++ b/packages/langium/src/grammar/type-system/types-util.ts
@@ -140,37 +140,6 @@ export function mergeTypesAndInterfaces(astTypes: AstTypes): TypeOption[] {
     return (astTypes.interfaces as TypeOption[]).concat(astTypes.unions);
 }
 
-/**
- * Performs topological sorting on the generated interfaces.
- * @param interfaces The interfaces to sort topologically.
- * @returns A topologically sorted set of interfaces.
- */
-export function sortInterfacesTopologically(interfaces: PlainInterface[]): PlainInterface[] {
-    type TypeNode = {
-        value: PlainInterface;
-        nodes: TypeNode[];
-    }
-
-    const nodes: TypeNode[] = interfaces
-        .sort((a, b) => a.name.localeCompare(b.name))
-        .map(e => <TypeNode>{ value: e, nodes: [] });
-    for (const node of nodes) {
-        node.nodes = nodes.filter(e => node.value.superTypes.has(e.value.name));
-    }
-    const l: TypeNode[] = [];
-    const s = nodes.filter(e => e.nodes.length === 0);
-    while (s.length > 0) {
-        const n = s.shift()!;
-        if (!l.includes(n)) {
-            l.push(n);
-            nodes
-                .filter(e => e.nodes.includes(n))
-                .forEach(m => s.push(m));
-        }
-    }
-    return l.map(e => e.value);
-}
-
 export function hasArrayType(type: PropertyType): boolean {
     if (isPropertyUnion(type)) {
         return type.types.some(e => hasArrayType(e));

--- a/packages/langium/src/grammar/validation/validator.ts
+++ b/packages/langium/src/grammar/validation/validator.ts
@@ -558,7 +558,7 @@ export class LangiumGrammarValidator {
                 return;
             }
 
-            if (ruleCall.lookahead) {
+            if ('lookahead' in ruleCall && ruleCall.lookahead) {
                 return;
             }
 

--- a/packages/langium/src/languages/generated/ast.ts
+++ b/packages/langium/src/languages/generated/ast.ts
@@ -99,10 +99,6 @@ export function isAbstractType(item: unknown): item is AbstractType {
 
 export type Associativity = 'left' | 'right';
 
-export function isAssociativity(item: unknown): item is Associativity {
-    return item === 'left' || item === 'right';
-}
-
 export type Condition = BooleanLiteral | Conjunction | Disjunction | Negation | ParameterReference;
 
 export const Condition = {
@@ -115,15 +111,7 @@ export function isCondition(item: unknown): item is Condition {
 
 export type FeatureName = 'assoc' | 'current' | 'entry' | 'extends' | 'false' | 'fragment' | 'grammar' | 'hidden' | 'import' | 'infer' | 'infers' | 'infix' | 'interface' | 'left' | 'on' | 'returns' | 'right' | 'terminal' | 'true' | 'type' | 'with' | PrimitiveType | string;
 
-export function isFeatureName(item: unknown): item is FeatureName {
-    return isPrimitiveType(item) || item === 'infix' || item === 'on' || item === 'right' || item === 'left' || item === 'assoc' || item === 'current' || item === 'entry' || item === 'extends' || item === 'false' || item === 'fragment' || item === 'grammar' || item === 'hidden' || item === 'import' || item === 'interface' || item === 'returns' || item === 'terminal' || item === 'true' || item === 'type' || item === 'infer' || item === 'infers' || item === 'with' || (typeof item === 'string' && (/\^?[_a-zA-Z][\w_]*/.test(item)));
-}
-
 export type PrimitiveType = 'Date' | 'bigint' | 'boolean' | 'number' | 'string';
-
-export function isPrimitiveType(item: unknown): item is PrimitiveType {
-    return item === 'string' || item === 'number' || item === 'boolean' || item === 'Date' || item === 'bigint';
-}
 
 export type TypeDefinition = ArrayType | ReferenceType | SimpleType | UnionType;
 
@@ -146,19 +134,53 @@ export function isValueLiteral(item: unknown): item is ValueLiteral {
 }
 
 export interface AbstractElement extends langium.AstNode {
-    readonly $type: 'AbstractElement' | 'Action' | 'Alternatives' | 'Assignment' | 'CharacterRange' | 'CrossReference' | 'EndOfFile' | 'Group' | 'Keyword' | 'NegatedToken' | 'RegexToken' | 'RuleCall' | 'TerminalAlternatives' | 'TerminalGroup' | 'TerminalRuleCall' | 'UnorderedGroup' | 'UntilToken' | 'Wildcard';
+    readonly $type: 'AbstractElement' | 'Action' | 'Alternatives' | 'Assignment' | 'CharacterRange' | 'CrossReference' | 'EndOfFile' | 'Group' | 'Keyword' | 'NegatedToken' | 'RegexToken' | 'RuleCall' | 'TerminalAlternatives' | 'TerminalElement' | 'TerminalGroup' | 'TerminalRuleCall' | 'UnorderedGroup' | 'UntilToken' | 'Wildcard';
     cardinality?: '*' | '+' | '?';
-    lookahead?: '?!' | '?<!' | '?<=' | '?=';
 }
 
 export const AbstractElement = {
     $type: 'AbstractElement',
-    cardinality: 'cardinality',
-    lookahead: 'lookahead'
+    cardinality: 'cardinality'
 } as const;
 
 export function isAbstractElement(item: unknown): item is AbstractElement {
     return reflection.isInstance(item, AbstractElement.$type);
+}
+
+export interface Action extends AbstractElement {
+    readonly $type: 'Action';
+    feature?: FeatureName;
+    inferredType?: InferredType;
+    operator?: '+=' | '=';
+    type?: langium.Reference<AbstractType>;
+}
+
+export const Action = {
+    $type: 'Action',
+    cardinality: 'cardinality',
+    feature: 'feature',
+    inferredType: 'inferredType',
+    operator: 'operator',
+    type: 'type'
+} as const;
+
+export function isAction(item: unknown): item is Action {
+    return reflection.isInstance(item, Action.$type);
+}
+
+export interface Alternatives extends AbstractElement {
+    readonly $type: 'Alternatives';
+    elements: Array<AbstractElement>;
+}
+
+export const Alternatives = {
+    $type: 'Alternatives',
+    cardinality: 'cardinality',
+    elements: 'elements'
+} as const;
+
+export function isAlternatives(item: unknown): item is Alternatives {
+    return reflection.isInstance(item, Alternatives.$type);
 }
 
 export interface ArrayLiteral extends langium.AstNode {
@@ -191,6 +213,27 @@ export function isArrayType(item: unknown): item is ArrayType {
     return reflection.isInstance(item, ArrayType.$type);
 }
 
+export interface Assignment extends AbstractElement {
+    readonly $type: 'Assignment';
+    feature: FeatureName;
+    operator: '+=' | '=' | '?=';
+    predicate?: '->' | '=>';
+    terminal: AbstractElement;
+}
+
+export const Assignment = {
+    $type: 'Assignment',
+    cardinality: 'cardinality',
+    feature: 'feature',
+    operator: 'operator',
+    predicate: 'predicate',
+    terminal: 'terminal'
+} as const;
+
+export function isAssignment(item: unknown): item is Assignment {
+    return reflection.isInstance(item, Assignment.$type);
+}
+
 export interface BooleanLiteral extends langium.AstNode {
     readonly $container: ArrayLiteral | Conjunction | Disjunction | Group | NamedArgument | Negation | TypeAttribute;
     readonly $type: 'BooleanLiteral';
@@ -204,6 +247,24 @@ export const BooleanLiteral = {
 
 export function isBooleanLiteral(item: unknown): item is BooleanLiteral {
     return reflection.isInstance(item, BooleanLiteral.$type);
+}
+
+export interface CharacterRange extends TerminalElement {
+    readonly $type: 'CharacterRange';
+    left: Keyword;
+    right?: Keyword;
+}
+
+export const CharacterRange = {
+    $type: 'CharacterRange',
+    cardinality: 'cardinality',
+    left: 'left',
+    lookahead: 'lookahead',
+    right: 'right'
+} as const;
+
+export function isCharacterRange(item: unknown): item is CharacterRange {
+    return reflection.isInstance(item, CharacterRange.$type);
 }
 
 export interface Conjunction extends langium.AstNode {
@@ -223,6 +284,27 @@ export function isConjunction(item: unknown): item is Conjunction {
     return reflection.isInstance(item, Conjunction.$type);
 }
 
+export interface CrossReference extends AbstractElement {
+    readonly $type: 'CrossReference';
+    deprecatedSyntax: boolean;
+    isMulti: boolean;
+    terminal?: AbstractElement;
+    type: langium.Reference<AbstractType>;
+}
+
+export const CrossReference = {
+    $type: 'CrossReference',
+    cardinality: 'cardinality',
+    deprecatedSyntax: 'deprecatedSyntax',
+    isMulti: 'isMulti',
+    terminal: 'terminal',
+    type: 'type'
+} as const;
+
+export function isCrossReference(item: unknown): item is CrossReference {
+    return reflection.isInstance(item, CrossReference.$type);
+}
+
 export interface Disjunction extends langium.AstNode {
     readonly $container: Conjunction | Disjunction | Group | NamedArgument | Negation;
     readonly $type: 'Disjunction';
@@ -238,6 +320,19 @@ export const Disjunction = {
 
 export function isDisjunction(item: unknown): item is Disjunction {
     return reflection.isInstance(item, Disjunction.$type);
+}
+
+export interface EndOfFile extends AbstractElement {
+    readonly $type: 'EndOfFile';
+}
+
+export const EndOfFile = {
+    $type: 'EndOfFile',
+    cardinality: 'cardinality'
+} as const;
+
+export function isEndOfFile(item: unknown): item is EndOfFile {
+    return reflection.isInstance(item, EndOfFile.$type);
 }
 
 export interface Grammar extends langium.AstNode {
@@ -277,6 +372,25 @@ export const GrammarImport = {
 
 export function isGrammarImport(item: unknown): item is GrammarImport {
     return reflection.isInstance(item, GrammarImport.$type);
+}
+
+export interface Group extends AbstractElement {
+    readonly $type: 'Group';
+    elements: Array<AbstractElement>;
+    guardCondition?: Condition;
+    predicate?: '->' | '=>';
+}
+
+export const Group = {
+    $type: 'Group',
+    cardinality: 'cardinality',
+    elements: 'elements',
+    guardCondition: 'guardCondition',
+    predicate: 'predicate'
+} as const;
+
+export function isGroup(item: unknown): item is Group {
+    return reflection.isInstance(item, Group.$type);
 }
 
 export interface InferredType extends langium.AstNode {
@@ -366,6 +480,24 @@ export function isInterface(item: unknown): item is Interface {
     return reflection.isInstance(item, Interface.$type);
 }
 
+export interface Keyword extends AbstractElement {
+    readonly $container: CharacterRange | InfixRuleOperatorList;
+    readonly $type: 'Keyword';
+    predicate?: '->' | '=>';
+    value: string;
+}
+
+export const Keyword = {
+    $type: 'Keyword',
+    cardinality: 'cardinality',
+    predicate: 'predicate',
+    value: 'value'
+} as const;
+
+export function isKeyword(item: unknown): item is Keyword {
+    return reflection.isInstance(item, Keyword.$type);
+}
+
 export interface NamedArgument extends langium.AstNode {
     readonly $container: RuleCall;
     readonly $type: 'NamedArgument';
@@ -383,6 +515,22 @@ export const NamedArgument = {
 
 export function isNamedArgument(item: unknown): item is NamedArgument {
     return reflection.isInstance(item, NamedArgument.$type);
+}
+
+export interface NegatedToken extends TerminalElement {
+    readonly $type: 'NegatedToken';
+    terminal: AbstractElement;
+}
+
+export const NegatedToken = {
+    $type: 'NegatedToken',
+    cardinality: 'cardinality',
+    lookahead: 'lookahead',
+    terminal: 'terminal'
+} as const;
+
+export function isNegatedToken(item: unknown): item is NegatedToken {
+    return reflection.isInstance(item, NegatedToken.$type);
 }
 
 export interface Negation extends langium.AstNode {
@@ -491,6 +639,22 @@ export function isReferenceType(item: unknown): item is ReferenceType {
     return reflection.isInstance(item, ReferenceType.$type);
 }
 
+export interface RegexToken extends TerminalElement {
+    readonly $type: 'RegexToken';
+    regex: string;
+}
+
+export const RegexToken = {
+    $type: 'RegexToken',
+    cardinality: 'cardinality',
+    lookahead: 'lookahead',
+    regex: 'regex'
+} as const;
+
+export function isRegexToken(item: unknown): item is RegexToken {
+    return reflection.isInstance(item, RegexToken.$type);
+}
+
 export interface ReturnType extends langium.AstNode {
     readonly $container: TerminalRule;
     readonly $type: 'ReturnType';
@@ -504,6 +668,26 @@ export const ReturnType = {
 
 export function isReturnType(item: unknown): item is ReturnType {
     return reflection.isInstance(item, ReturnType.$type);
+}
+
+export interface RuleCall extends AbstractElement {
+    readonly $container: InfixRule;
+    readonly $type: 'RuleCall';
+    arguments: Array<NamedArgument>;
+    predicate?: '->' | '=>';
+    rule: langium.Reference<AbstractRule>;
+}
+
+export const RuleCall = {
+    $type: 'RuleCall',
+    arguments: 'arguments',
+    cardinality: 'cardinality',
+    predicate: 'predicate',
+    rule: 'rule'
+} as const;
+
+export function isRuleCall(item: unknown): item is RuleCall {
+    return reflection.isInstance(item, RuleCall.$type);
 }
 
 export interface SimpleType extends langium.AstNode {
@@ -540,10 +724,57 @@ export function isStringLiteral(item: unknown): item is StringLiteral {
     return reflection.isInstance(item, StringLiteral.$type);
 }
 
+export interface TerminalAlternatives extends TerminalElement {
+    readonly $type: 'TerminalAlternatives';
+    elements: Array<AbstractElement>;
+}
+
+export const TerminalAlternatives = {
+    $type: 'TerminalAlternatives',
+    cardinality: 'cardinality',
+    elements: 'elements',
+    lookahead: 'lookahead'
+} as const;
+
+export function isTerminalAlternatives(item: unknown): item is TerminalAlternatives {
+    return reflection.isInstance(item, TerminalAlternatives.$type);
+}
+
+export interface TerminalElement extends AbstractElement {
+    readonly $type: 'CharacterRange' | 'NegatedToken' | 'RegexToken' | 'TerminalAlternatives' | 'TerminalElement' | 'TerminalGroup' | 'TerminalRuleCall' | 'UntilToken' | 'Wildcard';
+    lookahead?: '?!' | '?<!' | '?<=' | '?=';
+}
+
+export const TerminalElement = {
+    $type: 'TerminalElement',
+    cardinality: 'cardinality',
+    lookahead: 'lookahead'
+} as const;
+
+export function isTerminalElement(item: unknown): item is TerminalElement {
+    return reflection.isInstance(item, TerminalElement.$type);
+}
+
+export interface TerminalGroup extends TerminalElement {
+    readonly $type: 'TerminalGroup';
+    elements: Array<AbstractElement>;
+}
+
+export const TerminalGroup = {
+    $type: 'TerminalGroup',
+    cardinality: 'cardinality',
+    elements: 'elements',
+    lookahead: 'lookahead'
+} as const;
+
+export function isTerminalGroup(item: unknown): item is TerminalGroup {
+    return reflection.isInstance(item, TerminalGroup.$type);
+}
+
 export interface TerminalRule extends langium.AstNode {
     readonly $container: Grammar;
     readonly $type: 'TerminalRule';
-    definition: AbstractElement;
+    definition: TerminalElement;
     fragment: boolean;
     hidden: boolean;
     name: string;
@@ -561,6 +792,22 @@ export const TerminalRule = {
 
 export function isTerminalRule(item: unknown): item is TerminalRule {
     return reflection.isInstance(item, TerminalRule.$type);
+}
+
+export interface TerminalRuleCall extends TerminalElement {
+    readonly $type: 'TerminalRuleCall';
+    rule: langium.Reference<TerminalRule>;
+}
+
+export const TerminalRuleCall = {
+    $type: 'TerminalRuleCall',
+    cardinality: 'cardinality',
+    lookahead: 'lookahead',
+    rule: 'rule'
+} as const;
+
+export function isTerminalRuleCall(item: unknown): item is TerminalRuleCall {
+    return reflection.isInstance(item, TerminalRuleCall.$type);
 }
 
 export interface Type extends langium.AstNode {
@@ -616,260 +863,6 @@ export function isUnionType(item: unknown): item is UnionType {
     return reflection.isInstance(item, UnionType.$type);
 }
 
-export interface Action extends AbstractElement {
-    readonly $type: 'Action';
-    feature?: FeatureName;
-    inferredType?: InferredType;
-    operator?: '+=' | '=';
-    type?: langium.Reference<AbstractType>;
-}
-
-export const Action = {
-    $type: 'Action',
-    cardinality: 'cardinality',
-    feature: 'feature',
-    inferredType: 'inferredType',
-    lookahead: 'lookahead',
-    operator: 'operator',
-    type: 'type'
-} as const;
-
-export function isAction(item: unknown): item is Action {
-    return reflection.isInstance(item, Action.$type);
-}
-
-export interface Alternatives extends AbstractElement {
-    readonly $type: 'Alternatives';
-    elements: Array<AbstractElement>;
-}
-
-export const Alternatives = {
-    $type: 'Alternatives',
-    cardinality: 'cardinality',
-    elements: 'elements',
-    lookahead: 'lookahead'
-} as const;
-
-export function isAlternatives(item: unknown): item is Alternatives {
-    return reflection.isInstance(item, Alternatives.$type);
-}
-
-export interface Assignment extends AbstractElement {
-    readonly $type: 'Assignment';
-    feature: FeatureName;
-    operator: '+=' | '=' | '?=';
-    predicate?: '->' | '=>';
-    terminal: AbstractElement;
-}
-
-export const Assignment = {
-    $type: 'Assignment',
-    cardinality: 'cardinality',
-    feature: 'feature',
-    lookahead: 'lookahead',
-    operator: 'operator',
-    predicate: 'predicate',
-    terminal: 'terminal'
-} as const;
-
-export function isAssignment(item: unknown): item is Assignment {
-    return reflection.isInstance(item, Assignment.$type);
-}
-
-export interface CharacterRange extends AbstractElement {
-    readonly $type: 'CharacterRange';
-    left: Keyword;
-    right?: Keyword;
-}
-
-export const CharacterRange = {
-    $type: 'CharacterRange',
-    cardinality: 'cardinality',
-    left: 'left',
-    lookahead: 'lookahead',
-    right: 'right'
-} as const;
-
-export function isCharacterRange(item: unknown): item is CharacterRange {
-    return reflection.isInstance(item, CharacterRange.$type);
-}
-
-export interface CrossReference extends AbstractElement {
-    readonly $type: 'CrossReference';
-    deprecatedSyntax: boolean;
-    isMulti: boolean;
-    terminal?: AbstractElement;
-    type: langium.Reference<AbstractType>;
-}
-
-export const CrossReference = {
-    $type: 'CrossReference',
-    cardinality: 'cardinality',
-    deprecatedSyntax: 'deprecatedSyntax',
-    isMulti: 'isMulti',
-    lookahead: 'lookahead',
-    terminal: 'terminal',
-    type: 'type'
-} as const;
-
-export function isCrossReference(item: unknown): item is CrossReference {
-    return reflection.isInstance(item, CrossReference.$type);
-}
-
-export interface EndOfFile extends AbstractElement {
-    readonly $type: 'EndOfFile';
-}
-
-export const EndOfFile = {
-    $type: 'EndOfFile',
-    cardinality: 'cardinality',
-    lookahead: 'lookahead'
-} as const;
-
-export function isEndOfFile(item: unknown): item is EndOfFile {
-    return reflection.isInstance(item, EndOfFile.$type);
-}
-
-export interface Group extends AbstractElement {
-    readonly $type: 'Group';
-    elements: Array<AbstractElement>;
-    guardCondition?: Condition;
-    predicate?: '->' | '=>';
-}
-
-export const Group = {
-    $type: 'Group',
-    cardinality: 'cardinality',
-    elements: 'elements',
-    guardCondition: 'guardCondition',
-    lookahead: 'lookahead',
-    predicate: 'predicate'
-} as const;
-
-export function isGroup(item: unknown): item is Group {
-    return reflection.isInstance(item, Group.$type);
-}
-
-export interface Keyword extends AbstractElement {
-    readonly $container: CharacterRange | InfixRuleOperatorList;
-    readonly $type: 'Keyword';
-    predicate?: '->' | '=>';
-    value: string;
-}
-
-export const Keyword = {
-    $type: 'Keyword',
-    cardinality: 'cardinality',
-    lookahead: 'lookahead',
-    predicate: 'predicate',
-    value: 'value'
-} as const;
-
-export function isKeyword(item: unknown): item is Keyword {
-    return reflection.isInstance(item, Keyword.$type);
-}
-
-export interface NegatedToken extends AbstractElement {
-    readonly $type: 'NegatedToken';
-    terminal: AbstractElement;
-}
-
-export const NegatedToken = {
-    $type: 'NegatedToken',
-    cardinality: 'cardinality',
-    lookahead: 'lookahead',
-    terminal: 'terminal'
-} as const;
-
-export function isNegatedToken(item: unknown): item is NegatedToken {
-    return reflection.isInstance(item, NegatedToken.$type);
-}
-
-export interface RegexToken extends AbstractElement {
-    readonly $type: 'RegexToken';
-    regex: string;
-}
-
-export const RegexToken = {
-    $type: 'RegexToken',
-    cardinality: 'cardinality',
-    lookahead: 'lookahead',
-    regex: 'regex'
-} as const;
-
-export function isRegexToken(item: unknown): item is RegexToken {
-    return reflection.isInstance(item, RegexToken.$type);
-}
-
-export interface RuleCall extends AbstractElement {
-    readonly $container: InfixRule;
-    readonly $type: 'RuleCall';
-    arguments: Array<NamedArgument>;
-    predicate?: '->' | '=>';
-    rule: langium.Reference<AbstractRule>;
-}
-
-export const RuleCall = {
-    $type: 'RuleCall',
-    arguments: 'arguments',
-    cardinality: 'cardinality',
-    lookahead: 'lookahead',
-    predicate: 'predicate',
-    rule: 'rule'
-} as const;
-
-export function isRuleCall(item: unknown): item is RuleCall {
-    return reflection.isInstance(item, RuleCall.$type);
-}
-
-export interface TerminalAlternatives extends AbstractElement {
-    readonly $type: 'TerminalAlternatives';
-    elements: Array<AbstractElement>;
-}
-
-export const TerminalAlternatives = {
-    $type: 'TerminalAlternatives',
-    cardinality: 'cardinality',
-    elements: 'elements',
-    lookahead: 'lookahead'
-} as const;
-
-export function isTerminalAlternatives(item: unknown): item is TerminalAlternatives {
-    return reflection.isInstance(item, TerminalAlternatives.$type);
-}
-
-export interface TerminalGroup extends AbstractElement {
-    readonly $type: 'TerminalGroup';
-    elements: Array<AbstractElement>;
-}
-
-export const TerminalGroup = {
-    $type: 'TerminalGroup',
-    cardinality: 'cardinality',
-    elements: 'elements',
-    lookahead: 'lookahead'
-} as const;
-
-export function isTerminalGroup(item: unknown): item is TerminalGroup {
-    return reflection.isInstance(item, TerminalGroup.$type);
-}
-
-export interface TerminalRuleCall extends AbstractElement {
-    readonly $type: 'TerminalRuleCall';
-    rule: langium.Reference<TerminalRule>;
-}
-
-export const TerminalRuleCall = {
-    $type: 'TerminalRuleCall',
-    cardinality: 'cardinality',
-    lookahead: 'lookahead',
-    rule: 'rule'
-} as const;
-
-export function isTerminalRuleCall(item: unknown): item is TerminalRuleCall {
-    return reflection.isInstance(item, TerminalRuleCall.$type);
-}
-
 export interface UnorderedGroup extends AbstractElement {
     readonly $type: 'UnorderedGroup';
     elements: Array<AbstractElement>;
@@ -878,15 +871,14 @@ export interface UnorderedGroup extends AbstractElement {
 export const UnorderedGroup = {
     $type: 'UnorderedGroup',
     cardinality: 'cardinality',
-    elements: 'elements',
-    lookahead: 'lookahead'
+    elements: 'elements'
 } as const;
 
 export function isUnorderedGroup(item: unknown): item is UnorderedGroup {
     return reflection.isInstance(item, UnorderedGroup.$type);
 }
 
-export interface UntilToken extends AbstractElement {
+export interface UntilToken extends TerminalElement {
     readonly $type: 'UntilToken';
     terminal: AbstractElement;
 }
@@ -902,7 +894,7 @@ export function isUntilToken(item: unknown): item is UntilToken {
     return reflection.isInstance(item, UntilToken.$type);
 }
 
-export interface Wildcard extends AbstractElement {
+export interface Wildcard extends TerminalElement {
     readonly $type: 'Wildcard';
 }
 
@@ -955,6 +947,7 @@ export type LangiumGrammarAstType = {
     SimpleType: SimpleType
     StringLiteral: StringLiteral
     TerminalAlternatives: TerminalAlternatives
+    TerminalElement: TerminalElement
     TerminalGroup: TerminalGroup
     TerminalRule: TerminalRule
     TerminalRuleCall: TerminalRuleCall
@@ -975,9 +968,6 @@ export class LangiumGrammarAstReflection extends langium.AbstractAstReflection {
             properties: {
                 cardinality: {
                     name: AbstractElement.cardinality
-                },
-                lookahead: {
-                    name: AbstractElement.lookahead
                 }
             },
             superTypes: []
@@ -993,9 +983,6 @@ export class LangiumGrammarAstReflection extends langium.AbstractAstReflection {
                 },
                 inferredType: {
                     name: Action.inferredType
-                },
-                lookahead: {
-                    name: Action.lookahead
                 },
                 operator: {
                     name: Action.operator
@@ -1016,9 +1003,6 @@ export class LangiumGrammarAstReflection extends langium.AbstractAstReflection {
                 elements: {
                     name: Alternatives.elements,
                     defaultValue: []
-                },
-                lookahead: {
-                    name: Alternatives.lookahead
                 }
             },
             superTypes: [AbstractElement.$type]
@@ -1050,9 +1034,6 @@ export class LangiumGrammarAstReflection extends langium.AbstractAstReflection {
                 },
                 feature: {
                     name: Assignment.feature
-                },
-                lookahead: {
-                    name: Assignment.lookahead
                 },
                 operator: {
                     name: Assignment.operator
@@ -1092,7 +1073,7 @@ export class LangiumGrammarAstReflection extends langium.AbstractAstReflection {
                     name: CharacterRange.right
                 }
             },
-            superTypes: [AbstractElement.$type]
+            superTypes: [TerminalElement.$type]
         },
         Conjunction: {
             name: Conjunction.$type,
@@ -1119,9 +1100,6 @@ export class LangiumGrammarAstReflection extends langium.AbstractAstReflection {
                 isMulti: {
                     name: CrossReference.isMulti,
                     defaultValue: false
-                },
-                lookahead: {
-                    name: CrossReference.lookahead
                 },
                 terminal: {
                     name: CrossReference.terminal
@@ -1150,9 +1128,6 @@ export class LangiumGrammarAstReflection extends langium.AbstractAstReflection {
             properties: {
                 cardinality: {
                     name: EndOfFile.cardinality
-                },
-                lookahead: {
-                    name: EndOfFile.lookahead
                 }
             },
             superTypes: [AbstractElement.$type]
@@ -1207,9 +1182,6 @@ export class LangiumGrammarAstReflection extends langium.AbstractAstReflection {
                 },
                 guardCondition: {
                     name: Group.guardCondition
-                },
-                lookahead: {
-                    name: Group.lookahead
                 },
                 predicate: {
                     name: Group.predicate
@@ -1292,9 +1264,6 @@ export class LangiumGrammarAstReflection extends langium.AbstractAstReflection {
                 cardinality: {
                     name: Keyword.cardinality
                 },
-                lookahead: {
-                    name: Keyword.lookahead
-                },
                 predicate: {
                     name: Keyword.predicate
                 },
@@ -1334,7 +1303,7 @@ export class LangiumGrammarAstReflection extends langium.AbstractAstReflection {
                     name: NegatedToken.terminal
                 }
             },
-            superTypes: [AbstractElement.$type]
+            superTypes: [TerminalElement.$type]
         },
         Negation: {
             name: Negation.$type,
@@ -1433,7 +1402,7 @@ export class LangiumGrammarAstReflection extends langium.AbstractAstReflection {
                     name: RegexToken.regex
                 }
             },
-            superTypes: [AbstractElement.$type]
+            superTypes: [TerminalElement.$type]
         },
         ReturnType: {
             name: ReturnType.$type,
@@ -1453,9 +1422,6 @@ export class LangiumGrammarAstReflection extends langium.AbstractAstReflection {
                 },
                 cardinality: {
                     name: RuleCall.cardinality
-                },
-                lookahead: {
-                    name: RuleCall.lookahead
                 },
                 predicate: {
                     name: RuleCall.predicate
@@ -1506,6 +1472,18 @@ export class LangiumGrammarAstReflection extends langium.AbstractAstReflection {
                     name: TerminalAlternatives.lookahead
                 }
             },
+            superTypes: [TerminalElement.$type]
+        },
+        TerminalElement: {
+            name: TerminalElement.$type,
+            properties: {
+                cardinality: {
+                    name: TerminalElement.cardinality
+                },
+                lookahead: {
+                    name: TerminalElement.lookahead
+                }
+            },
             superTypes: [AbstractElement.$type]
         },
         TerminalGroup: {
@@ -1522,7 +1500,7 @@ export class LangiumGrammarAstReflection extends langium.AbstractAstReflection {
                     name: TerminalGroup.lookahead
                 }
             },
-            superTypes: [AbstractElement.$type]
+            superTypes: [TerminalElement.$type]
         },
         TerminalRule: {
             name: TerminalRule.$type,
@@ -1561,7 +1539,7 @@ export class LangiumGrammarAstReflection extends langium.AbstractAstReflection {
                     referenceType: TerminalRule.$type
                 }
             },
-            superTypes: [AbstractElement.$type]
+            superTypes: [TerminalElement.$type]
         },
         Type: {
             name: Type.$type,
@@ -1613,9 +1591,6 @@ export class LangiumGrammarAstReflection extends langium.AbstractAstReflection {
                 elements: {
                     name: UnorderedGroup.elements,
                     defaultValue: []
-                },
-                lookahead: {
-                    name: UnorderedGroup.lookahead
                 }
             },
             superTypes: [AbstractElement.$type]
@@ -1633,7 +1608,7 @@ export class LangiumGrammarAstReflection extends langium.AbstractAstReflection {
                     name: UntilToken.terminal
                 }
             },
-            superTypes: [AbstractElement.$type]
+            superTypes: [TerminalElement.$type]
         },
         Wildcard: {
             name: Wildcard.$type,
@@ -1645,7 +1620,7 @@ export class LangiumGrammarAstReflection extends langium.AbstractAstReflection {
                     name: Wildcard.lookahead
                 }
             },
-            superTypes: [AbstractElement.$type]
+            superTypes: [TerminalElement.$type]
         }
     } as const satisfies langium.AstMetaData
 }

--- a/packages/langium/src/languages/generated/ast.ts
+++ b/packages/langium/src/languages/generated/ast.ts
@@ -260,6 +260,7 @@ export const CharacterRange = {
     cardinality: 'cardinality',
     left: 'left',
     lookahead: 'lookahead',
+    parenthesized: 'parenthesized',
     right: 'right'
 } as const;
 
@@ -526,6 +527,7 @@ export const NegatedToken = {
     $type: 'NegatedToken',
     cardinality: 'cardinality',
     lookahead: 'lookahead',
+    parenthesized: 'parenthesized',
     terminal: 'terminal'
 } as const;
 
@@ -648,6 +650,7 @@ export const RegexToken = {
     $type: 'RegexToken',
     cardinality: 'cardinality',
     lookahead: 'lookahead',
+    parenthesized: 'parenthesized',
     regex: 'regex'
 } as const;
 
@@ -733,7 +736,8 @@ export const TerminalAlternatives = {
     $type: 'TerminalAlternatives',
     cardinality: 'cardinality',
     elements: 'elements',
-    lookahead: 'lookahead'
+    lookahead: 'lookahead',
+    parenthesized: 'parenthesized'
 } as const;
 
 export function isTerminalAlternatives(item: unknown): item is TerminalAlternatives {
@@ -743,12 +747,14 @@ export function isTerminalAlternatives(item: unknown): item is TerminalAlternati
 export interface TerminalElement extends AbstractElement {
     readonly $type: 'CharacterRange' | 'NegatedToken' | 'RegexToken' | 'TerminalAlternatives' | 'TerminalElement' | 'TerminalGroup' | 'TerminalRuleCall' | 'UntilToken' | 'Wildcard';
     lookahead?: '?!' | '?<!' | '?<=' | '?=';
+    parenthesized: boolean;
 }
 
 export const TerminalElement = {
     $type: 'TerminalElement',
     cardinality: 'cardinality',
-    lookahead: 'lookahead'
+    lookahead: 'lookahead',
+    parenthesized: 'parenthesized'
 } as const;
 
 export function isTerminalElement(item: unknown): item is TerminalElement {
@@ -764,7 +770,8 @@ export const TerminalGroup = {
     $type: 'TerminalGroup',
     cardinality: 'cardinality',
     elements: 'elements',
-    lookahead: 'lookahead'
+    lookahead: 'lookahead',
+    parenthesized: 'parenthesized'
 } as const;
 
 export function isTerminalGroup(item: unknown): item is TerminalGroup {
@@ -803,6 +810,7 @@ export const TerminalRuleCall = {
     $type: 'TerminalRuleCall',
     cardinality: 'cardinality',
     lookahead: 'lookahead',
+    parenthesized: 'parenthesized',
     rule: 'rule'
 } as const;
 
@@ -887,6 +895,7 @@ export const UntilToken = {
     $type: 'UntilToken',
     cardinality: 'cardinality',
     lookahead: 'lookahead',
+    parenthesized: 'parenthesized',
     terminal: 'terminal'
 } as const;
 
@@ -901,7 +910,8 @@ export interface Wildcard extends TerminalElement {
 export const Wildcard = {
     $type: 'Wildcard',
     cardinality: 'cardinality',
-    lookahead: 'lookahead'
+    lookahead: 'lookahead',
+    parenthesized: 'parenthesized'
 } as const;
 
 export function isWildcard(item: unknown): item is Wildcard {
@@ -1068,6 +1078,10 @@ export class LangiumGrammarAstReflection extends langium.AbstractAstReflection {
                 },
                 lookahead: {
                     name: CharacterRange.lookahead
+                },
+                parenthesized: {
+                    name: CharacterRange.parenthesized,
+                    defaultValue: false
                 },
                 right: {
                     name: CharacterRange.right
@@ -1299,6 +1313,10 @@ export class LangiumGrammarAstReflection extends langium.AbstractAstReflection {
                 lookahead: {
                     name: NegatedToken.lookahead
                 },
+                parenthesized: {
+                    name: NegatedToken.parenthesized,
+                    defaultValue: false
+                },
                 terminal: {
                     name: NegatedToken.terminal
                 }
@@ -1398,6 +1416,10 @@ export class LangiumGrammarAstReflection extends langium.AbstractAstReflection {
                 lookahead: {
                     name: RegexToken.lookahead
                 },
+                parenthesized: {
+                    name: RegexToken.parenthesized,
+                    defaultValue: false
+                },
                 regex: {
                     name: RegexToken.regex
                 }
@@ -1470,6 +1492,10 @@ export class LangiumGrammarAstReflection extends langium.AbstractAstReflection {
                 },
                 lookahead: {
                     name: TerminalAlternatives.lookahead
+                },
+                parenthesized: {
+                    name: TerminalAlternatives.parenthesized,
+                    defaultValue: false
                 }
             },
             superTypes: [TerminalElement.$type]
@@ -1482,6 +1508,10 @@ export class LangiumGrammarAstReflection extends langium.AbstractAstReflection {
                 },
                 lookahead: {
                     name: TerminalElement.lookahead
+                },
+                parenthesized: {
+                    name: TerminalElement.parenthesized,
+                    defaultValue: false
                 }
             },
             superTypes: [AbstractElement.$type]
@@ -1498,6 +1528,10 @@ export class LangiumGrammarAstReflection extends langium.AbstractAstReflection {
                 },
                 lookahead: {
                     name: TerminalGroup.lookahead
+                },
+                parenthesized: {
+                    name: TerminalGroup.parenthesized,
+                    defaultValue: false
                 }
             },
             superTypes: [TerminalElement.$type]
@@ -1533,6 +1567,10 @@ export class LangiumGrammarAstReflection extends langium.AbstractAstReflection {
                 },
                 lookahead: {
                     name: TerminalRuleCall.lookahead
+                },
+                parenthesized: {
+                    name: TerminalRuleCall.parenthesized,
+                    defaultValue: false
                 },
                 rule: {
                     name: TerminalRuleCall.rule,
@@ -1604,6 +1642,10 @@ export class LangiumGrammarAstReflection extends langium.AbstractAstReflection {
                 lookahead: {
                     name: UntilToken.lookahead
                 },
+                parenthesized: {
+                    name: UntilToken.parenthesized,
+                    defaultValue: false
+                },
                 terminal: {
                     name: UntilToken.terminal
                 }
@@ -1618,6 +1660,10 @@ export class LangiumGrammarAstReflection extends langium.AbstractAstReflection {
                 },
                 lookahead: {
                     name: Wildcard.lookahead
+                },
+                parenthesized: {
+                    name: Wildcard.parenthesized,
+                    defaultValue: false
                 }
             },
             superTypes: [TerminalElement.$type]

--- a/packages/langium/test/grammar/type-system/inferred-types.test.ts
+++ b/packages/langium/test/grammar/type-system/inferred-types.test.ts
@@ -53,6 +53,14 @@ describe('Inferred types', () => {
             terminal ID returns string: /string/;
             terminal NUMBER returns number: /number/;
         `, expandToString`
+            export interface A extends D {
+                readonly $type: 'A';
+                name: number | string;
+            }
+            export interface B extends D {
+                readonly $type: 'B';
+                name: number | string;
+            }
             export interface D extends langium.AstNode {
                 readonly $type: 'A' | 'B' | 'D';
                 name: string;
@@ -61,14 +69,6 @@ describe('Inferred types', () => {
                 readonly $type: 'E';
                 name?: string;
                 value?: number;
-            }
-            export interface A extends D {
-                readonly $type: 'A';
-                name: number | string;
-            }
-            export interface B extends D {
-                readonly $type: 'B';
-                name: number | string;
             }
             export type C = A | B;
         `);
@@ -473,11 +473,11 @@ describe('expression rules with inferred and declared interfaces', () => {
                 member: langium.Reference<Symbol>;
                 receiver: PrimaryExpression;
             }
-            export interface Symbol extends langium.AstNode {
-                readonly $type: 'Symbol';
-            }
             export interface SuperMemberAccess extends MemberAccess {
                 readonly $type: 'SuperMemberAccess';
+            }
+            export interface Symbol extends langium.AstNode {
+                readonly $type: 'Symbol';
             }
             export type Expression = MemberAccess | PrimaryExpression | SuperMemberAccess;
             export type PrimaryExpression = BooleanLiteral;
@@ -505,6 +505,10 @@ describe('types of `$container` and `$type` are correct', () => {
                 readonly $type: 'B' | 'C';
                 strB: string;
             }
+            export interface C extends A, B {
+                readonly $type: 'C';
+                strC: string;
+            }
             export interface D extends langium.AstNode {
                 readonly $type: 'D';
                 a: A;
@@ -512,10 +516,6 @@ describe('types of `$container` and `$type` are correct', () => {
             export interface E extends langium.AstNode {
                 readonly $type: 'E';
                 b: B;
-            }
-            export interface C extends A, B {
-                readonly $type: 'C';
-                strC: string;
             }
         `);
     });
@@ -538,6 +538,10 @@ describe('types of `$container` and `$type` are correct', () => {
                 readonly $type: 'B' | 'C';
                 strB: string;
             }
+            export interface C extends A, B {
+                readonly $type: 'C';
+                strC: string;
+            }
             export interface D extends langium.AstNode {
                 readonly $type: 'D';
                 a: A;
@@ -545,10 +549,6 @@ describe('types of `$container` and `$type` are correct', () => {
             export interface E extends langium.AstNode {
                 readonly $type: 'E';
                 b: B;
-            }
-            export interface C extends A, B {
-                readonly $type: 'C';
-                strC: string;
             }
         `);
     });
@@ -601,6 +601,16 @@ describe('types of `$container` and `$type` are correct', () => {
                 readonly $type: 'B' | 'C' | 'D';
                 strB: string;
             }
+            export interface C extends A, B {
+                readonly $container: E;
+                readonly $type: 'C';
+                strC: string;
+            }
+            export interface D extends A, B {
+                readonly $container: F;
+                readonly $type: 'D';
+                strC: string;
+            }
             export interface E extends langium.AstNode {
                 readonly $type: 'E';
                 c: C;
@@ -616,16 +626,6 @@ describe('types of `$container` and `$type` are correct', () => {
             export interface H extends langium.AstNode {
                 readonly $type: 'H';
                 b: B;
-            }
-            export interface C extends A, B {
-                readonly $container: E;
-                readonly $type: 'C';
-                strC: string;
-            }
-            export interface D extends A, B {
-                readonly $container: F;
-                readonly $type: 'D';
-                strC: string;
             }
         `);
     });
@@ -652,6 +652,16 @@ describe('types of `$container` and `$type` are correct', () => {
                 readonly $type: 'B' | 'C' | 'D' | 'X';
                 strB: string;
             }
+            export interface C extends A, B {
+                readonly $container: E;
+                readonly $type: 'C';
+                strC: string;
+            }
+            export interface D extends A, B {
+                readonly $container: F;
+                readonly $type: 'D';
+                strC: string;
+            }
             export interface E extends langium.AstNode {
                 readonly $type: 'E';
                 c: C;
@@ -667,16 +677,6 @@ describe('types of `$container` and `$type` are correct', () => {
             export interface H extends langium.AstNode {
                 readonly $type: 'H';
                 b: B;
-            }
-            export interface C extends A, B {
-                readonly $container: E;
-                readonly $type: 'C';
-                strC: string;
-            }
-            export interface D extends A, B {
-                readonly $container: F;
-                readonly $type: 'D';
-                strC: string;
             }
             export interface X extends A, B {
                 readonly $type: 'X';
@@ -705,6 +705,10 @@ describe('types of `$container` and `$type` are correct', () => {
                 readonly $type: 'B' | 'C';
                 strB: string;
             }
+            export interface C extends A, B {
+                readonly $type: 'C';
+                strC: string;
+            }
             export interface D extends langium.AstNode {
                 readonly $type: 'D';
                 a: A;
@@ -712,10 +716,6 @@ describe('types of `$container` and `$type` are correct', () => {
             export interface E extends langium.AstNode {
                 readonly $type: 'E';
                 b: B;
-            }
-            export interface C extends A, B {
-                readonly $type: 'C';
-                strC: string;
             }
         `);
     });
@@ -795,9 +795,6 @@ describe('types of `$container` and `$type` are correct', () => {
             export interface B extends A {
                 readonly $type: 'B' | 'C' | 'D' | 'E' | 'F' | 'G';
             }
-            export interface H extends A {
-                readonly $type: 'H';
-            }
             export interface C extends B {
                 readonly $type: 'C' | 'D' | 'E' | 'F' | 'G';
             }
@@ -812,6 +809,9 @@ describe('types of `$container` and `$type` are correct', () => {
             }
             export interface G extends D {
                 readonly $type: 'G';
+            }
+            export interface H extends A {
+                readonly $type: 'H';
             }
         `);
     });


### PR DESCRIPTION
This PR introduces `langium-types.langium` defining all the AST types of Langium's grammar language.
As an initial customization it contributes interface `TerminalElement extends AbstractElement`, and `AbstractElement#lookahead` is moved to `TerminalElement`.

The second commit refines the synthesis of RegExps representing the terminals s.t. synthetic pairs of parentheses that are added to the RegExp are marked as non-capturing groups `(?:...)`, while parentheses being present in the terminal definition are transferred as capturing groups `(...)`. To enable that an additional flag `TerminalElement#parenthesized` is introduced for capturing the information wether a sub terminal is enclosed in parenthesizes.
This gives adopters more control over the capturing groups within the RegExp, which is relevant when re-using the generated RegExps e.g. for value conversion, like
```js
const match = LangiumGrammarTerminals.RegexLiteral.exec(input);
const result = match && convert(match[1], match[2], match[3], match[4]);
```