### PR TITLE
Improved the AST reflection

### DIFF
--- a/examples/arithmetics/src/language-server/generated/ast.ts
+++ b/examples/arithmetics/src/language-server/generated/ast.ts
@@ -198,73 +198,73 @@ export class ArithmeticsAstReflection extends langium.AbstractAstReflection {
             name: BinaryExpression.$type,
             properties: {
                 left: {
-                    name: 'left'
+                    name: BinaryExpression.left
                 },
                 operator: {
-                    name: 'operator'
+                    name: BinaryExpression.operator
                 },
                 right: {
-                    name: 'right'
+                    name: BinaryExpression.right
                 }
             },
-            superTypes: ['Expression']
+            superTypes: [Expression.$type]
         },
         DeclaredParameter: {
             name: DeclaredParameter.$type,
             properties: {
                 name: {
-                    name: 'name'
+                    name: DeclaredParameter.name
                 }
             },
-            superTypes: ['AbstractDefinition']
+            superTypes: [AbstractDefinition.$type]
         },
         Definition: {
             name: Definition.$type,
             properties: {
                 args: {
-                    name: 'args',
+                    name: Definition.args,
                     defaultValue: []
                 },
                 expr: {
-                    name: 'expr'
+                    name: Definition.expr
                 },
                 name: {
-                    name: 'name'
+                    name: Definition.name
                 }
             },
-            superTypes: ['AbstractDefinition', 'Statement']
+            superTypes: [AbstractDefinition.$type, Statement.$type]
         },
         Evaluation: {
             name: Evaluation.$type,
             properties: {
                 expression: {
-                    name: 'expression'
+                    name: Evaluation.expression
                 }
             },
-            superTypes: ['Statement']
+            superTypes: [Statement.$type]
         },
         FunctionCall: {
             name: FunctionCall.$type,
             properties: {
                 args: {
-                    name: 'args',
+                    name: FunctionCall.args,
                     defaultValue: []
                 },
                 func: {
-                    name: 'func',
-                    referenceType: 'AbstractDefinition'
+                    name: FunctionCall.func,
+                    referenceType: AbstractDefinition.$type
                 }
             },
-            superTypes: ['Expression']
+            superTypes: [Expression.$type]
         },
         Module: {
             name: Module.$type,
             properties: {
                 name: {
-                    name: 'name'
+                    name: Module.name
                 },
                 statements: {
-                    name: 'statements',
+                    name: Module.statements,
                     defaultValue: []
                 }
             },
@@ -274,10 +274,10 @@ export class ArithmeticsAstReflection extends langium.AbstractAstReflection {
             name: NumberLiteral.$type,
             properties: {
                 value: {
-                    name: 'value'
+                    name: NumberLiteral.value
                 }
             },
-            superTypes: ['Expression']
+            superTypes: [Expression.$type]
         },
     } as const satisfies langium.AstMetaData
 }

--- a/examples/domainmodel/src/language-server/generated/ast.ts
+++ b/examples/domainmodel/src/language-server/generated/ast.ts
@@ -154,16 +154,16 @@ export class DomainModelAstReflection extends langium.AbstractAstReflection {
             name: DataType.$type,
             properties: {
                 name: {
-                    name: 'name'
+                    name: DataType.name
                 }
             },
-            superTypes: ['Type']
+            superTypes: [Type.$type]
         },
         Domainmodel: {
             name: Domainmodel.$type,
             properties: {
                 elements: {
-                    name: 'elements',
+                    name: Domainmodel.elements,
                     defaultValue: []
                 }
             },
@@ -173,32 +173,32 @@ export class DomainModelAstReflection extends langium.AbstractAstReflection {
             name: Entity.$type,
             properties: {
                 features: {
-                    name: 'features',
+                    name: Entity.features,
                     defaultValue: []
                 },
                 name: {
-                    name: 'name'
+                    name: Entity.name
                 },
                 superType: {
-                    name: 'superType',
-                    referenceType: 'Entity'
+                    name: Entity.superType,
+                    referenceType: Entity.$type
                 }
             },
-            superTypes: ['Type']
+            superTypes: [Type.$type]
         },
         Feature: {
             name: Feature.$type,
             properties: {
                 many: {
-                    name: 'many',
+                    name: Feature.many,
                     defaultValue: false
                 },
                 name: {
-                    name: 'name'
+                    name: Feature.name
                 },
                 type: {
-                    name: 'type',
-                    referenceType: 'Type'
+                    name: Feature.type,
+                    referenceType: Type.$type
                 }
             },
             superTypes: []
@@ -207,14 +207,14 @@ export class DomainModelAstReflection extends langium.AbstractAstReflection {
             name: PackageDeclaration.$type,
             properties: {
                 elements: {
-                    name: 'elements',
+                    name: PackageDeclaration.elements,
                     defaultValue: []
                 },
                 name: {
-                    name: 'name'
+                    name: PackageDeclaration.name
                 }
             },
-            superTypes: ['AbstractElement']
+            superTypes: [AbstractElement.$type]
         },
     } as const satisfies langium.AstMetaData
 }

--- a/examples/requirements/src/language-server/generated/ast.ts
+++ b/examples/requirements/src/language-server/generated/ast.ts
@@ -152,7 +152,7 @@ export class RequirementsAndTestsAstReflection extends langium.AbstractAstReflec
             name: Contact.$type,
             properties: {
                 user_name: {
-                    name: 'user_name'
+                    name: Contact.user_name
                 }
             },
             superTypes: []
@@ -161,10 +161,10 @@ export class RequirementsAndTestsAstReflection extends langium.AbstractAstReflec
             name: Environment.$type,
             properties: {
                 description: {
-                    name: 'description'
+                    name: Environment.description
                 },
                 name: {
-                    name: 'name'
+                    name: Environment.name
                 }
             },
             superTypes: []
@@ -173,15 +173,15 @@ export class RequirementsAndTestsAstReflection extends langium.AbstractAstReflec
             name: Requirement.$type,
             properties: {
                 environments: {
-                    name: 'environments',
+                    name: Requirement.environments,
                     defaultValue: [],
-                    referenceType: 'Environment'
+                    referenceType: Environment.$type
                 },
                 name: {
-                    name: 'name'
+                    name: Requirement.name
                 },
                 text: {
-                    name: 'text'
+                    name: Requirement.text
                 }
             },
             superTypes: []
@@ -190,14 +190,14 @@ export class RequirementsAndTestsAstReflection extends langium.AbstractAstReflec
             name: RequirementModel.$type,
             properties: {
                 contact: {
-                    name: 'contact'
+                    name: RequirementModel.contact
                 },
                 environments: {
-                    name: 'environments',
+                    name: RequirementModel.environments,
                     defaultValue: []
                 },
                 requirements: {
-                    name: 'requirements',
+                    name: RequirementModel.requirements,
                     defaultValue: []
                 }
             },
@@ -207,20 +207,20 @@ export class RequirementsAndTestsAstReflection extends langium.AbstractAstReflec
             name: Test.$type,
             properties: {
                 environments: {
-                    name: 'environments',
+                    name: Test.environments,
                     defaultValue: [],
-                    referenceType: 'Environment'
+                    referenceType: Environment.$type
                 },
                 name: {
-                    name: 'name'
+                    name: Test.name
                 },
                 requirements: {
-                    name: 'requirements',
+                    name: Test.requirements,
                     defaultValue: [],
-                    referenceType: 'Requirement'
+                    referenceType: Requirement.$type
                 },
                 testFile: {
-                    name: 'testFile'
+                    name: Test.testFile
                 }
             },
             superTypes: []
@@ -229,10 +229,10 @@ export class RequirementsAndTestsAstReflection extends langium.AbstractAstReflec
             name: TestModel.$type,
             properties: {
                 contact: {
-                    name: 'contact'
+                    name: TestModel.contact
                 },
                 tests: {
-                    name: 'tests',
+                    name: TestModel.tests,
                     defaultValue: []
                 }
             },

--- a/examples/statemachine/src/language-server/generated/ast.ts
+++ b/examples/statemachine/src/language-server/generated/ast.ts
@@ -142,7 +142,7 @@ export class StatemachineAstReflection extends langium.AbstractAstReflection {
             name: Command.$type,
             properties: {
                 name: {
-                    name: 'name'
+                    name: Command.name
                 }
             },
             superTypes: []
@@ -151,7 +151,7 @@ export class StatemachineAstReflection extends langium.AbstractAstReflection {
             name: Event.$type,
             properties: {
                 name: {
-                    name: 'name'
+                    name: Event.name
                 }
             },
             superTypes: []
@@ -160,15 +160,15 @@ export class StatemachineAstReflection extends langium.AbstractAstReflection {
             name: State.$type,
             properties: {
                 actions: {
-                    name: 'actions',
+                    name: State.actions,
                     defaultValue: [],
-                    referenceType: 'Command'
+                    referenceType: Command.$type
                 },
                 name: {
-                    name: 'name'
+                    name: State.name
                 },
                 transitions: {
-                    name: 'transitions',
+                    name: State.transitions,
                     defaultValue: []
                 }
             },
@@ -178,22 +178,22 @@ export class StatemachineAstReflection extends langium.AbstractAstReflection {
             name: Statemachine.$type,
             properties: {
                 commands: {
-                    name: 'commands',
+                    name: Statemachine.commands,
                     defaultValue: []
                 },
                 events: {
-                    name: 'events',
+                    name: Statemachine.events,
                     defaultValue: []
                 },
                 init: {
-                    name: 'init',
-                    referenceType: 'State'
+                    name: Statemachine.init,
+                    referenceType: State.$type
                 },
                 name: {
-                    name: 'name'
+                    name: Statemachine.name
                 },
                 states: {
-                    name: 'states',
+                    name: Statemachine.states,
                     defaultValue: []
                 }
             },
@@ -203,12 +203,12 @@ export class StatemachineAstReflection extends langium.AbstractAstReflection {
             name: Transition.$type,
             properties: {
                 event: {
-                    name: 'event',
-                    referenceType: 'Event'
+                    name: Transition.event,
+                    referenceType: Event.$type
                 },
                 state: {
-                    name: 'state',
-                    referenceType: 'State'
+                    name: Transition.state,
+                    referenceType: State.$type
                 }
             },
             superTypes: []

--- a/packages/langium-cli/src/generator/ast-generator.ts
+++ b/packages/langium-cli/src/generator/ast-generator.ts
@@ -55,9 +55,9 @@ function generateAstReflection(config: LangiumConfig, astTypes: AstTypes): Gener
                             ${typeName}: {
                                 name: ${typeName}.$type,
                                 properties: {
-                                    ${buildPropertyMetaData(props)}
+                                    ${buildPropertyMetaData(props, typeName)}
                                 },
-                                superTypes: [${superTypes.map(t => `'${t}'`).join(', ')}]
+                                superTypes: [${superTypes.map(t => `${t}.$type`).join(', ')}]
                             }
                         `;
                     }
@@ -70,7 +70,7 @@ function generateAstReflection(config: LangiumConfig, astTypes: AstTypes): Gener
     `.appendNewLine();
 }
 
-function buildPropertyMetaData(props: Property[]): Generated {
+function buildPropertyMetaData(props: Property[], ownerTypeName: string): Generated {
     const all = props.sort((a, b) => a.name.localeCompare(b.name));
 
     return joinToNode(
@@ -80,12 +80,12 @@ function buildPropertyMetaData(props: Property[]): Generated {
             const refTypes = findReferenceTypes(property.type);
             const refType = refTypes.length > 0 ? refTypes[0] : undefined;
 
-            const attributes: string[] = [`name: '${escapeQuotes(property.name, "'")}'`];
+            const attributes: string[] = [`name: ${ownerTypeName}.${property.name}`];
             if (defaultValue) {
                 attributes.push(`defaultValue: ${defaultValue}`);
             }
             if (refType) {
-                attributes.push(`referenceType: '${refType}'`);
+                attributes.push(`referenceType: ${refType}.$type`);
             }
 
             return expandToNode`

--- a/packages/langium-cli/test/generator/ast-generator.test.ts
+++ b/packages/langium-cli/test/generator/ast-generator.test.ts
@@ -411,6 +411,42 @@ describe('Ast generator', () => {
         }`
     );
 
+    testTypeMetaData('should generate property metadata for empty types', `
+        grammar TestGrammar
+
+        interface IAmArray { }
+        interface DeclaredArray extends IAmArray{
+            elements: ArrayContent[];
+        }
+
+        DeclaredArray returns DeclaredArray:
+            'declared' (elements+=ArrayContent)* ';';
+
+        hidden terminal WS: /\\s+/;
+        terminal ID: /[_a-zA-Z][\\w_]*/;
+    `, expandToString`
+        export class testAstReflection extends langium.AbstractAstReflection {
+            override readonly types = {
+                DeclaredArray: {
+                    name: DeclaredArray.$type,
+                    properties: {
+                        elements: {
+                            name: 'elements',
+                            defaultValue: []
+                        }
+                    },
+                    superTypes: ['IAmArray']
+                },
+                IAmArray: {
+                    name: IAmArray.$type,
+                    properties: {
+                    },
+                    superTypes: []
+                }
+            } as const satisfies langium.AstMetaData
+        }`
+    );
+
     testTypeMetaData('should generate escaped default value', `
         grammar TestGrammar
 

--- a/packages/langium-cli/test/generator/ast-generator.test.ts
+++ b/packages/langium-cli/test/generator/ast-generator.test.ts
@@ -391,17 +391,17 @@ describe('Ast generator', () => {
                     name: DeclaredArray.$type,
                     properties: {
                         elements: {
-                            name: 'elements',
+                            name: DeclaredArray.elements,
                             defaultValue: []
                         }
                     },
-                    superTypes: ['IAmArray']
+                    superTypes: [IAmArray.$type]
                 },
                 IAmArray: {
                     name: IAmArray.$type,
                     properties: {
                         elements: {
-                            name: 'elements',
+                            name: IAmArray.elements,
                             defaultValue: []
                         }
                     },
@@ -431,11 +431,11 @@ describe('Ast generator', () => {
                     name: DeclaredArray.$type,
                     properties: {
                         elements: {
-                            name: 'elements',
+                            name: DeclaredArray.elements,
                             defaultValue: []
                         }
                     },
-                    superTypes: ['IAmArray']
+                    superTypes: [IAmArray.$type]
                 },
                 IAmArray: {
                     name: IAmArray.$type,
@@ -466,7 +466,7 @@ describe('Ast generator', () => {
                     name: Test.$type,
                     properties: {
                         value: {
-                            name: 'value',
+                            name: Test.value,
                             defaultValue: '\\'test\\''
                         }
                     },
@@ -499,12 +499,12 @@ describe('Ast generator', () => {
                     name: A.$type,
                     properties: {
                         refA1: {
-                            name: 'refA1',
-                            referenceType: 'A'
+                            name: A.refA1,
+                            referenceType: A.$type
                         },
                         refB1: {
-                            name: 'refB1',
-                            referenceType: 'B'
+                            name: A.refB1,
+                            referenceType: B.$type
                         }
                     },
                     superTypes: []
@@ -513,63 +513,63 @@ describe('Ast generator', () => {
                     name: B.$type,
                     properties: {
                         refA1: {
-                            name: 'refA1',
-                            referenceType: 'A'
+                            name: B.refA1,
+                            referenceType: A.$type
                         },
                         refB1: {
-                            name: 'refB1',
-                            referenceType: 'B'
+                            name: B.refB1,
+                            referenceType: B.$type
                         },
                         refB2: {
-                            name: 'refB2',
-                            referenceType: 'B'
+                            name: B.refB2,
+                            referenceType: B.$type
                         }
                     },
-                    superTypes: ['A']
+                    superTypes: [A.$type]
                 },
                 C: {
                     name: C.$type,
                     properties: {
                         refA1: {
-                            name: 'refA1',
-                            referenceType: 'A'
+                            name: C.refA1,
+                            referenceType: A.$type
                         },
                         refB1: {
-                            name: 'refB1',
-                            referenceType: 'B'
+                            name: C.refB1,
+                            referenceType: B.$type
                         },
                         refB2: {
-                            name: 'refB2',
-                            referenceType: 'B'
+                            name: C.refB2,
+                            referenceType: B.$type
                         },
                         refC1: {
-                            name: 'refC1',
-                            referenceType: 'C'
+                            name: C.refC1,
+                            referenceType: C.$type
                         }
                     },
-                    superTypes: ['A', 'B']
+                    superTypes: [A.$type, B.$type]
                 },
                 D: {
                     name: D.$type,
                     properties: {
                         refA1: {
-                            name: 'refA1',
-                            referenceType: 'A'
+                            name: D.refA1,
+                            referenceType: A.$type
                         },
                         refB1: {
-                            name: 'refB1',
-                            referenceType: 'B'
+                            name: D.refB1,
+                            referenceType: B.$type
                         },
                         refB2: {
-                            name: 'refB2',
-                            referenceType: 'B'
+                            name: D.refB2,
+                            referenceType: B.$type
                         },
                         refD1: {
-                            name: 'refD1',
-                            referenceType: 'D'
+                            name: D.refD1,
+                            referenceType: D.$type
                         }
                     },
-                    superTypes: ['A', 'B']
+                    superTypes: [A.$type, B.$type]
                 }
             } as const satisfies langium.AstMetaData
         }`

--- a/packages/langium/src/languages/generated/ast.ts
+++ b/packages/langium/src/languages/generated/ast.ts
@@ -974,10 +974,10 @@ export class LangiumGrammarAstReflection extends langium.AbstractAstReflection {
             name: AbstractElement.$type,
             properties: {
                 cardinality: {
-                    name: 'cardinality'
+                    name: AbstractElement.cardinality
                 },
                 lookahead: {
-                    name: 'lookahead'
+                    name: AbstractElement.lookahead
                 }
             },
             superTypes: []
@@ -986,201 +986,201 @@ export class LangiumGrammarAstReflection extends langium.AbstractAstReflection {
             name: Action.$type,
             properties: {
                 cardinality: {
-                    name: 'cardinality'
+                    name: Action.cardinality
                 },
                 feature: {
-                    name: 'feature'
+                    name: Action.feature
                 },
                 inferredType: {
-                    name: 'inferredType'
+                    name: Action.inferredType
                 },
                 lookahead: {
-                    name: 'lookahead'
+                    name: Action.lookahead
                 },
                 operator: {
-                    name: 'operator'
+                    name: Action.operator
                 },
                 type: {
-                    name: 'type',
-                    referenceType: 'AbstractType'
+                    name: Action.type,
+                    referenceType: AbstractType.$type
                 }
             },
-            superTypes: ['AbstractElement']
+            superTypes: [AbstractElement.$type]
         },
         Alternatives: {
             name: Alternatives.$type,
             properties: {
                 cardinality: {
-                    name: 'cardinality'
+                    name: Alternatives.cardinality
                 },
                 elements: {
-                    name: 'elements',
+                    name: Alternatives.elements,
                     defaultValue: []
                 },
                 lookahead: {
-                    name: 'lookahead'
+                    name: Alternatives.lookahead
                 }
             },
-            superTypes: ['AbstractElement']
+            superTypes: [AbstractElement.$type]
         },
         ArrayLiteral: {
             name: ArrayLiteral.$type,
             properties: {
                 elements: {
-                    name: 'elements',
+                    name: ArrayLiteral.elements,
                     defaultValue: []
                 }
             },
-            superTypes: ['ValueLiteral']
+            superTypes: [ValueLiteral.$type]
         },
         ArrayType: {
             name: ArrayType.$type,
             properties: {
                 elementType: {
-                    name: 'elementType'
+                    name: ArrayType.elementType
                 }
             },
-            superTypes: ['TypeDefinition']
+            superTypes: [TypeDefinition.$type]
         },
         Assignment: {
             name: Assignment.$type,
             properties: {
                 cardinality: {
-                    name: 'cardinality'
+                    name: Assignment.cardinality
                 },
                 feature: {
-                    name: 'feature'
+                    name: Assignment.feature
                 },
                 lookahead: {
-                    name: 'lookahead'
+                    name: Assignment.lookahead
                 },
                 operator: {
-                    name: 'operator'
+                    name: Assignment.operator
                 },
                 predicate: {
-                    name: 'predicate'
+                    name: Assignment.predicate
                 },
                 terminal: {
-                    name: 'terminal'
+                    name: Assignment.terminal
                 }
             },
-            superTypes: ['AbstractElement']
+            superTypes: [AbstractElement.$type]
         },
         BooleanLiteral: {
             name: BooleanLiteral.$type,
             properties: {
                 true: {
-                    name: 'true',
+                    name: BooleanLiteral.true,
                     defaultValue: false
                 }
             },
-            superTypes: ['Condition', 'ValueLiteral']
+            superTypes: [Condition.$type, ValueLiteral.$type]
         },
         CharacterRange: {
             name: CharacterRange.$type,
             properties: {
                 cardinality: {
-                    name: 'cardinality'
+                    name: CharacterRange.cardinality
                 },
                 left: {
-                    name: 'left'
+                    name: CharacterRange.left
                 },
                 lookahead: {
-                    name: 'lookahead'
+                    name: CharacterRange.lookahead
                 },
                 right: {
-                    name: 'right'
+                    name: CharacterRange.right
                 }
             },
-            superTypes: ['AbstractElement']
+            superTypes: [AbstractElement.$type]
         },
         Conjunction: {
             name: Conjunction.$type,
             properties: {
                 left: {
-                    name: 'left'
+                    name: Conjunction.left
                 },
                 right: {
-                    name: 'right'
+                    name: Conjunction.right
                 }
             },
-            superTypes: ['Condition']
+            superTypes: [Condition.$type]
         },
         CrossReference: {
             name: CrossReference.$type,
             properties: {
                 cardinality: {
-                    name: 'cardinality'
+                    name: CrossReference.cardinality
                 },
                 deprecatedSyntax: {
-                    name: 'deprecatedSyntax',
+                    name: CrossReference.deprecatedSyntax,
                     defaultValue: false
                 },
                 isMulti: {
-                    name: 'isMulti',
+                    name: CrossReference.isMulti,
                     defaultValue: false
                 },
                 lookahead: {
-                    name: 'lookahead'
+                    name: CrossReference.lookahead
                 },
                 terminal: {
-                    name: 'terminal'
+                    name: CrossReference.terminal
                 },
                 type: {
-                    name: 'type',
-                    referenceType: 'AbstractType'
+                    name: CrossReference.type,
+                    referenceType: AbstractType.$type
                 }
             },
-            superTypes: ['AbstractElement']
+            superTypes: [AbstractElement.$type]
         },
         Disjunction: {
             name: Disjunction.$type,
             properties: {
                 left: {
-                    name: 'left'
+                    name: Disjunction.left
                 },
                 right: {
-                    name: 'right'
+                    name: Disjunction.right
                 }
             },
-            superTypes: ['Condition']
+            superTypes: [Condition.$type]
         },
         EndOfFile: {
             name: EndOfFile.$type,
             properties: {
                 cardinality: {
-                    name: 'cardinality'
+                    name: EndOfFile.cardinality
                 },
                 lookahead: {
-                    name: 'lookahead'
+                    name: EndOfFile.lookahead
                 }
             },
-            superTypes: ['AbstractElement']
+            superTypes: [AbstractElement.$type]
         },
         Grammar: {
             name: Grammar.$type,
             properties: {
                 imports: {
-                    name: 'imports',
+                    name: Grammar.imports,
                     defaultValue: []
                 },
                 interfaces: {
-                    name: 'interfaces',
+                    name: Grammar.interfaces,
                     defaultValue: []
                 },
                 isDeclared: {
-                    name: 'isDeclared',
+                    name: Grammar.isDeclared,
                     defaultValue: false
                 },
                 name: {
-                    name: 'name'
+                    name: Grammar.name
                 },
                 rules: {
-                    name: 'rules',
+                    name: Grammar.rules,
                     defaultValue: []
                 },
                 types: {
-                    name: 'types',
+                    name: Grammar.types,
                     defaultValue: []
                 }
             },
@@ -1190,7 +1190,7 @@ export class LangiumGrammarAstReflection extends langium.AbstractAstReflection {
             name: GrammarImport.$type,
             properties: {
                 path: {
-                    name: 'path'
+                    name: GrammarImport.path
                 }
             },
             superTypes: []
@@ -1199,60 +1199,60 @@ export class LangiumGrammarAstReflection extends langium.AbstractAstReflection {
             name: Group.$type,
             properties: {
                 cardinality: {
-                    name: 'cardinality'
+                    name: Group.cardinality
                 },
                 elements: {
-                    name: 'elements',
+                    name: Group.elements,
                     defaultValue: []
                 },
                 guardCondition: {
-                    name: 'guardCondition'
+                    name: Group.guardCondition
                 },
                 lookahead: {
-                    name: 'lookahead'
+                    name: Group.lookahead
                 },
                 predicate: {
-                    name: 'predicate'
+                    name: Group.predicate
                 }
             },
-            superTypes: ['AbstractElement']
+            superTypes: [AbstractElement.$type]
         },
         InferredType: {
             name: InferredType.$type,
             properties: {
                 name: {
-                    name: 'name'
+                    name: InferredType.name
                 }
             },
-            superTypes: ['AbstractType']
+            superTypes: [AbstractType.$type]
         },
         InfixRule: {
             name: InfixRule.$type,
             properties: {
                 call: {
-                    name: 'call'
+                    name: InfixRule.call
                 },
                 name: {
-                    name: 'name'
+                    name: InfixRule.name
                 },
                 operators: {
-                    name: 'operators'
+                    name: InfixRule.operators
                 },
                 parameters: {
-                    name: 'parameters',
+                    name: InfixRule.parameters,
                     defaultValue: []
                 }
             },
-            superTypes: ['AbstractRule', 'AbstractType']
+            superTypes: [AbstractRule.$type, AbstractType.$type]
         },
         InfixRuleOperatorList: {
             name: InfixRuleOperatorList.$type,
             properties: {
                 associativity: {
-                    name: 'associativity'
+                    name: InfixRuleOperatorList.associativity
                 },
                 operators: {
-                    name: 'operators',
+                    name: InfixRuleOperatorList.operators,
                     defaultValue: []
                 }
             },
@@ -1262,7 +1262,7 @@ export class LangiumGrammarAstReflection extends langium.AbstractAstReflection {
             name: InfixRuleOperators.$type,
             properties: {
                 precedences: {
-                    name: 'precedences',
+                    name: InfixRuleOperators.precedences,
                     defaultValue: []
                 }
             },
@@ -1272,51 +1272,51 @@ export class LangiumGrammarAstReflection extends langium.AbstractAstReflection {
             name: Interface.$type,
             properties: {
                 attributes: {
-                    name: 'attributes',
+                    name: Interface.attributes,
                     defaultValue: []
                 },
                 name: {
-                    name: 'name'
+                    name: Interface.name
                 },
                 superTypes: {
-                    name: 'superTypes',
+                    name: Interface.superTypes,
                     defaultValue: [],
-                    referenceType: 'AbstractType'
+                    referenceType: AbstractType.$type
                 }
             },
-            superTypes: ['AbstractType']
+            superTypes: [AbstractType.$type]
         },
         Keyword: {
             name: Keyword.$type,
             properties: {
                 cardinality: {
-                    name: 'cardinality'
+                    name: Keyword.cardinality
                 },
                 lookahead: {
-                    name: 'lookahead'
+                    name: Keyword.lookahead
                 },
                 predicate: {
-                    name: 'predicate'
+                    name: Keyword.predicate
                 },
                 value: {
-                    name: 'value'
+                    name: Keyword.value
                 }
             },
-            superTypes: ['AbstractElement']
+            superTypes: [AbstractElement.$type]
         },
         NamedArgument: {
             name: NamedArgument.$type,
             properties: {
                 calledByName: {
-                    name: 'calledByName',
+                    name: NamedArgument.calledByName,
                     defaultValue: false
                 },
                 parameter: {
-                    name: 'parameter',
-                    referenceType: 'Parameter'
+                    name: NamedArgument.parameter,
+                    referenceType: Parameter.$type
                 },
                 value: {
-                    name: 'value'
+                    name: NamedArgument.value
                 }
             },
             superTypes: []
@@ -1325,40 +1325,40 @@ export class LangiumGrammarAstReflection extends langium.AbstractAstReflection {
             name: NegatedToken.$type,
             properties: {
                 cardinality: {
-                    name: 'cardinality'
+                    name: NegatedToken.cardinality
                 },
                 lookahead: {
-                    name: 'lookahead'
+                    name: NegatedToken.lookahead
                 },
                 terminal: {
-                    name: 'terminal'
+                    name: NegatedToken.terminal
                 }
             },
-            superTypes: ['AbstractElement']
+            superTypes: [AbstractElement.$type]
         },
         Negation: {
             name: Negation.$type,
             properties: {
                 value: {
-                    name: 'value'
+                    name: Negation.value
                 }
             },
-            superTypes: ['Condition']
+            superTypes: [Condition.$type]
         },
         NumberLiteral: {
             name: NumberLiteral.$type,
             properties: {
                 value: {
-                    name: 'value'
+                    name: NumberLiteral.value
                 }
             },
-            superTypes: ['ValueLiteral']
+            superTypes: [ValueLiteral.$type]
         },
         Parameter: {
             name: Parameter.$type,
             properties: {
                 name: {
-                    name: 'name'
+                    name: Parameter.name
                 }
             },
             superTypes: []
@@ -1367,79 +1367,79 @@ export class LangiumGrammarAstReflection extends langium.AbstractAstReflection {
             name: ParameterReference.$type,
             properties: {
                 parameter: {
-                    name: 'parameter',
-                    referenceType: 'Parameter'
+                    name: ParameterReference.parameter,
+                    referenceType: Parameter.$type
                 }
             },
-            superTypes: ['Condition']
+            superTypes: [Condition.$type]
         },
         ParserRule: {
             name: ParserRule.$type,
             properties: {
                 dataType: {
-                    name: 'dataType'
+                    name: ParserRule.dataType
                 },
                 definition: {
-                    name: 'definition'
+                    name: ParserRule.definition
                 },
                 entry: {
-                    name: 'entry',
+                    name: ParserRule.entry,
                     defaultValue: false
                 },
                 fragment: {
-                    name: 'fragment',
+                    name: ParserRule.fragment,
                     defaultValue: false
                 },
                 inferredType: {
-                    name: 'inferredType'
+                    name: ParserRule.inferredType
                 },
                 name: {
-                    name: 'name'
+                    name: ParserRule.name
                 },
                 parameters: {
-                    name: 'parameters',
+                    name: ParserRule.parameters,
                     defaultValue: []
                 },
                 returnType: {
-                    name: 'returnType',
-                    referenceType: 'AbstractType'
+                    name: ParserRule.returnType,
+                    referenceType: AbstractType.$type
                 }
             },
-            superTypes: ['AbstractRule', 'AbstractType']
+            superTypes: [AbstractRule.$type, AbstractType.$type]
         },
         ReferenceType: {
             name: ReferenceType.$type,
             properties: {
                 isMulti: {
-                    name: 'isMulti',
+                    name: ReferenceType.isMulti,
                     defaultValue: false
                 },
                 referenceType: {
-                    name: 'referenceType'
+                    name: ReferenceType.referenceType
                 }
             },
-            superTypes: ['TypeDefinition']
+            superTypes: [TypeDefinition.$type]
         },
         RegexToken: {
             name: RegexToken.$type,
             properties: {
                 cardinality: {
-                    name: 'cardinality'
+                    name: RegexToken.cardinality
                 },
                 lookahead: {
-                    name: 'lookahead'
+                    name: RegexToken.lookahead
                 },
                 regex: {
-                    name: 'regex'
+                    name: RegexToken.regex
                 }
             },
-            superTypes: ['AbstractElement']
+            superTypes: [AbstractElement.$type]
         },
         ReturnType: {
             name: ReturnType.$type,
             properties: {
                 name: {
-                    name: 'name'
+                    name: ReturnType.name
                 }
             },
             superTypes: []
@@ -1448,148 +1448,148 @@ export class LangiumGrammarAstReflection extends langium.AbstractAstReflection {
             name: RuleCall.$type,
             properties: {
                 arguments: {
-                    name: 'arguments',
+                    name: RuleCall.arguments,
                     defaultValue: []
                 },
                 cardinality: {
-                    name: 'cardinality'
+                    name: RuleCall.cardinality
                 },
                 lookahead: {
-                    name: 'lookahead'
+                    name: RuleCall.lookahead
                 },
                 predicate: {
-                    name: 'predicate'
+                    name: RuleCall.predicate
                 },
                 rule: {
-                    name: 'rule',
-                    referenceType: 'AbstractRule'
+                    name: RuleCall.rule,
+                    referenceType: AbstractRule.$type
                 }
             },
-            superTypes: ['AbstractElement']
+            superTypes: [AbstractElement.$type]
         },
         SimpleType: {
             name: SimpleType.$type,
             properties: {
                 primitiveType: {
-                    name: 'primitiveType'
+                    name: SimpleType.primitiveType
                 },
                 stringType: {
-                    name: 'stringType'
+                    name: SimpleType.stringType
                 },
                 typeRef: {
-                    name: 'typeRef',
-                    referenceType: 'AbstractType'
+                    name: SimpleType.typeRef,
+                    referenceType: AbstractType.$type
                 }
             },
-            superTypes: ['TypeDefinition']
+            superTypes: [TypeDefinition.$type]
         },
         StringLiteral: {
             name: StringLiteral.$type,
             properties: {
                 value: {
-                    name: 'value'
+                    name: StringLiteral.value
                 }
             },
-            superTypes: ['ValueLiteral']
+            superTypes: [ValueLiteral.$type]
         },
         TerminalAlternatives: {
             name: TerminalAlternatives.$type,
             properties: {
                 cardinality: {
-                    name: 'cardinality'
+                    name: TerminalAlternatives.cardinality
                 },
                 elements: {
-                    name: 'elements',
+                    name: TerminalAlternatives.elements,
                     defaultValue: []
                 },
                 lookahead: {
-                    name: 'lookahead'
+                    name: TerminalAlternatives.lookahead
                 }
             },
-            superTypes: ['AbstractElement']
+            superTypes: [AbstractElement.$type]
         },
         TerminalGroup: {
             name: TerminalGroup.$type,
             properties: {
                 cardinality: {
-                    name: 'cardinality'
+                    name: TerminalGroup.cardinality
                 },
                 elements: {
-                    name: 'elements',
+                    name: TerminalGroup.elements,
                     defaultValue: []
                 },
                 lookahead: {
-                    name: 'lookahead'
+                    name: TerminalGroup.lookahead
                 }
             },
-            superTypes: ['AbstractElement']
+            superTypes: [AbstractElement.$type]
         },
         TerminalRule: {
             name: TerminalRule.$type,
             properties: {
                 definition: {
-                    name: 'definition'
+                    name: TerminalRule.definition
                 },
                 fragment: {
-                    name: 'fragment',
+                    name: TerminalRule.fragment,
                     defaultValue: false
                 },
                 hidden: {
-                    name: 'hidden',
+                    name: TerminalRule.hidden,
                     defaultValue: false
                 },
                 name: {
-                    name: 'name'
+                    name: TerminalRule.name
                 },
                 type: {
-                    name: 'type'
+                    name: TerminalRule.type
                 }
             },
-            superTypes: ['AbstractRule']
+            superTypes: [AbstractRule.$type]
         },
         TerminalRuleCall: {
             name: TerminalRuleCall.$type,
             properties: {
                 cardinality: {
-                    name: 'cardinality'
+                    name: TerminalRuleCall.cardinality
                 },
                 lookahead: {
-                    name: 'lookahead'
+                    name: TerminalRuleCall.lookahead
                 },
                 rule: {
-                    name: 'rule',
-                    referenceType: 'TerminalRule'
+                    name: TerminalRuleCall.rule,
+                    referenceType: TerminalRule.$type
                 }
             },
-            superTypes: ['AbstractElement']
+            superTypes: [AbstractElement.$type]
         },
         Type: {
             name: Type.$type,
             properties: {
                 name: {
-                    name: 'name'
+                    name: Type.name
                 },
                 type: {
-                    name: 'type'
+                    name: Type.type
                 }
             },
-            superTypes: ['AbstractType']
+            superTypes: [AbstractType.$type]
         },
         TypeAttribute: {
             name: TypeAttribute.$type,
             properties: {
                 defaultValue: {
-                    name: 'defaultValue'
+                    name: TypeAttribute.defaultValue
                 },
                 isOptional: {
-                    name: 'isOptional',
+                    name: TypeAttribute.isOptional,
                     defaultValue: false
                 },
                 name: {
-                    name: 'name'
+                    name: TypeAttribute.name
                 },
                 type: {
-                    name: 'type'
+                    name: TypeAttribute.type
                 }
             },
             superTypes: []
@@ -1598,54 +1598,54 @@ export class LangiumGrammarAstReflection extends langium.AbstractAstReflection {
             name: UnionType.$type,
             properties: {
                 types: {
-                    name: 'types',
+                    name: UnionType.types,
                     defaultValue: []
                 }
             },
-            superTypes: ['TypeDefinition']
+            superTypes: [TypeDefinition.$type]
         },
         UnorderedGroup: {
             name: UnorderedGroup.$type,
             properties: {
                 cardinality: {
-                    name: 'cardinality'
+                    name: UnorderedGroup.cardinality
                 },
                 elements: {
-                    name: 'elements',
+                    name: UnorderedGroup.elements,
                     defaultValue: []
                 },
                 lookahead: {
-                    name: 'lookahead'
+                    name: UnorderedGroup.lookahead
                 }
             },
-            superTypes: ['AbstractElement']
+            superTypes: [AbstractElement.$type]
         },
         UntilToken: {
             name: UntilToken.$type,
             properties: {
                 cardinality: {
-                    name: 'cardinality'
+                    name: UntilToken.cardinality
                 },
                 lookahead: {
-                    name: 'lookahead'
+                    name: UntilToken.lookahead
                 },
                 terminal: {
-                    name: 'terminal'
+                    name: UntilToken.terminal
                 }
             },
-            superTypes: ['AbstractElement']
+            superTypes: [AbstractElement.$type]
         },
         Wildcard: {
             name: Wildcard.$type,
             properties: {
                 cardinality: {
-                    name: 'cardinality'
+                    name: Wildcard.cardinality
                 },
                 lookahead: {
-                    name: 'lookahead'
+                    name: Wildcard.lookahead
                 }
             },
-            superTypes: ['AbstractElement']
+            superTypes: [AbstractElement.$type]
         }
     } as const satisfies langium.AstMetaData
 }

--- a/packages/langium/src/syntax-tree.ts
+++ b/packages/langium/src/syntax-tree.ts
@@ -272,8 +272,6 @@ export interface TypeMetaData {
     }
     /** The super types of this AST node type. */
     superTypes: string[]
-    /** All property names of this AST node type, as a shortcut `_p` corresponding to `properties[p].name`. */
-    [name: `_${string}`]: string
 }
 
 /**


### PR DESCRIPTION
This is a follow-up for #1942:

- removed outdated left-over code
- Another interesting change of #1942 is documented by a new test case: meta-data are now generated even for types without properties
- The meta-data contained hard-coded string values (`'MyType'`) and constants (`MyType.$type`): Now constants are used everywhere