### PR TITLE
Improve generated `ast.ts` regarding multiple files and languages

### DIFF
--- a/examples/requirements/src/language-server/generated/ast.ts
+++ b/examples/requirements/src/language-server/generated/ast.ts
@@ -6,28 +6,85 @@
 /* eslint-disable */
 import * as langium from 'langium';
 
-export const RequirementsAndTestsTerminals = {
+export const RequirementsAndTestsFileCommonTerminals = {
     WS: /\s+/,
     ID: /[_a-zA-Z][\w_]*/,
+    INT: /[0-9]+/,
     STRING: /"(\\.|[^"\\])*"|'(\\.|[^'\\])*'/,
     ML_COMMENT: /\/\*[\s\S]*?\*\//,
     SL_COMMENT: /\/\/[^\n\r]*/,
 };
 
-export type RequirementsAndTestsTerminalNames = keyof typeof RequirementsAndTestsTerminals;
+export type RequirementsAndTestsFileCommonTerminalNames = keyof typeof RequirementsAndTestsFileCommonTerminals;
 
-export type RequirementsAndTestsKeywordNames =
+export type RequirementsAndTestsFileCommonKeywordNames =
+    | ":"
+    | "contact";
+
+export type RequirementsAndTestsFileCommonTokenNames = RequirementsAndTestsFileCommonTerminalNames | RequirementsAndTestsFileCommonKeywordNames;
+
+export const RequirementsAndTestsFileRequirementsTerminals = {
+};
+
+export type RequirementsAndTestsFileRequirementsTerminalNames = keyof typeof RequirementsAndTestsFileRequirementsTerminals;
+
+export type RequirementsAndTestsFileRequirementsKeywordNames =
     | ","
     | ":"
-    | "="
     | "applicable"
-    | "contact"
     | "environment"
     | "for"
-    | "req"
+    | "req";
+
+export type RequirementsAndTestsFileRequirementsTokenNames = RequirementsAndTestsFileRequirementsTerminalNames | RequirementsAndTestsFileRequirementsKeywordNames;
+
+export const RequirementsAndTestsFileTestsTerminals = {
+};
+
+export type RequirementsAndTestsFileTestsTerminalNames = keyof typeof RequirementsAndTestsFileTestsTerminals;
+
+export type RequirementsAndTestsFileTestsKeywordNames =
+    | ","
+    | "="
+    | "applicable"
+    | "for"
     | "testFile"
     | "tests"
     | "tst";
+
+export type RequirementsAndTestsFileTestsTokenNames = RequirementsAndTestsFileTestsTerminalNames | RequirementsAndTestsFileTestsKeywordNames;
+
+export const RequirementsAndTestsLanguageRequirementsTerminals = {
+    ...RequirementsAndTestsFileCommonTerminals,
+    ...RequirementsAndTestsFileRequirementsTerminals,
+};
+
+export type RequirementsAndTestsLanguageRequirementsTerminalNames = keyof typeof RequirementsAndTestsLanguageRequirementsTerminals;
+
+export type RequirementsAndTestsLanguageRequirementsKeywordNames = RequirementsAndTestsFileCommonKeywordNames | RequirementsAndTestsFileRequirementsKeywordNames;
+
+export type RequirementsAndTestsLanguageRequirementsTokenNames = RequirementsAndTestsLanguageRequirementsTerminalNames | RequirementsAndTestsLanguageRequirementsKeywordNames;
+
+export const RequirementsAndTestsLanguageTestsTerminals = {
+    ...RequirementsAndTestsFileCommonTerminals,
+    ...RequirementsAndTestsFileRequirementsTerminals,
+    ...RequirementsAndTestsFileTestsTerminals,
+};
+
+export type RequirementsAndTestsLanguageTestsTerminalNames = keyof typeof RequirementsAndTestsLanguageTestsTerminals;
+
+export type RequirementsAndTestsLanguageTestsKeywordNames = RequirementsAndTestsFileCommonKeywordNames | RequirementsAndTestsFileRequirementsKeywordNames | RequirementsAndTestsFileTestsKeywordNames;
+
+export type RequirementsAndTestsLanguageTestsTokenNames = RequirementsAndTestsLanguageTestsTerminalNames | RequirementsAndTestsLanguageTestsKeywordNames;
+
+export const RequirementsAndTestsTerminals = {
+    ...RequirementsAndTestsLanguageRequirementsTerminals,
+    ...RequirementsAndTestsLanguageTestsTerminals,
+};
+
+export type RequirementsAndTestsTerminalNames = keyof typeof RequirementsAndTestsTerminals;
+
+export type RequirementsAndTestsKeywordNames = RequirementsAndTestsLanguageRequirementsKeywordNames | RequirementsAndTestsLanguageTestsKeywordNames;
 
 export type RequirementsAndTestsTokenNames = RequirementsAndTestsTerminalNames | RequirementsAndTestsKeywordNames;
 
@@ -137,7 +194,18 @@ export function isTestModel(item: unknown): item is TestModel {
     return reflection.isInstance(item, TestModel.$type);
 }
 
-export type RequirementsAndTestsAstType = {
+export type RequirementsAndTestsFileCommonAstType = {
+    Contact: Contact
+}
+
+export type RequirementsAndTestsFileRequirementsAstType = {
+    Contact: Contact
+    Environment: Environment
+    Requirement: Requirement
+    RequirementModel: RequirementModel
+}
+
+export type RequirementsAndTestsFileTestsAstType = {
     Contact: Contact
     Environment: Environment
     Requirement: Requirement
@@ -145,6 +213,12 @@ export type RequirementsAndTestsAstType = {
     Test: Test
     TestModel: TestModel
 }
+
+export type RequirementsAndTestsLanguageRequirementsAstType = RequirementsAndTestsFileCommonAstType & RequirementsAndTestsFileRequirementsAstType
+
+export type RequirementsAndTestsLanguageTestsAstType = RequirementsAndTestsFileCommonAstType & RequirementsAndTestsFileRequirementsAstType & RequirementsAndTestsFileTestsAstType
+
+export type RequirementsAndTestsAstType = RequirementsAndTestsLanguageRequirementsAstType & RequirementsAndTestsLanguageTestsAstType
 
 export class RequirementsAndTestsAstReflection extends langium.AbstractAstReflection {
     override readonly types = {

--- a/examples/requirements/syntaxes/tests.tmLanguage.json
+++ b/examples/requirements/syntaxes/tests.tmLanguage.json
@@ -10,7 +10,7 @@
     },
     {
       "name": "keyword.control.tests-lang",
-      "match": "\\b(applicable|contact|for|testFile|tests|tst)\\b"
+      "match": "\\b(applicable|contact|environment|for|req|testFile|tests|tst)\\b"
     },
     {
       "name": "string.quoted.double.tests-lang",

--- a/packages/langium-cli/src/generate.ts
+++ b/packages/langium-cli/src/generate.ts
@@ -4,31 +4,29 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import type { AstNode, Grammar, LangiumDocument, Mutable } from 'langium';
-import type { LangiumConfig, LangiumLanguageConfig } from './package-types.js';
-import { URI } from 'langium';
-import { loadConfig } from './package.js';
-import { AstUtils, GrammarAST } from 'langium';
+import chalk from 'chalk';
+import fs from 'fs-extra';
+import { validate } from 'jsonschema';
+import { MultiMap, type AstNode, type Grammar, type LangiumDocument, type Mutable } from 'langium';
+import { AstUtils, GrammarAST, URI } from 'langium';
+import { createGrammarDiagramHtml, createGrammarDiagramSvg } from 'langium-railroad';
 import { createLangiumGrammarServices, resolveImport, resolveImportUri, resolveTransitiveImports } from 'langium/grammar';
 import { NodeFileSystem } from 'langium/node';
-import { generateAst } from './generator/ast-generator.js';
-import { serializeGrammar } from './generator/grammar-serializer.js';
-import { generateModule } from './generator/module-generator.js';
+import * as path from 'path';
+import { generateAstMultiFileProject, generateAstMultiLanguageProject, generateAstSingleFileProject } from './generator/ast-generator.js';
 import { generateBnf } from './generator/bnf-generator.js';
-import { generateTextMate } from './generator/highlighting/textmate-generator.js';
+import { serializeGrammar } from './generator/grammar-serializer.js';
 import { generateMonarch } from './generator/highlighting/monarch-generator.js';
 import { generatePrismHighlighting } from './generator/highlighting/prism-generator.js';
-import { getTime, log } from './generator/langium-util.js';
+import { generateTextMate } from './generator/highlighting/textmate-generator.js';
+import { getAstIdentifierForGrammarFile, getTime, log } from './generator/langium-util.js';
+import { generateModule } from './generator/module-generator.js';
 import { elapsedTime, getUserChoice, schema } from './generator/node-util.js';
-import { RelativePath } from './package-types.js';
-import { getFilePath } from './package.js';
-import { validateParser } from './parser-validation.js';
 import { generateTypesFile } from './generator/types-generator.js';
-import { createGrammarDiagramHtml, createGrammarDiagramSvg } from 'langium-railroad';
-import { validate } from 'jsonschema';
-import chalk from 'chalk';
-import * as path from 'path';
-import fs from 'fs-extra';
+import type { LangiumConfig, LangiumLanguageConfig } from './package-types.js';
+import { RelativePath } from './package-types.js';
+import { getFilePath, loadConfig } from './package.js';
+import { validateParser } from './parser-validation.js';
 
 export async function generate(options: GenerateOptions): Promise<boolean> {
     const config = await loadConfig(options);
@@ -260,7 +258,7 @@ export async function runGenerator(config: LangiumConfig, options: GenerateOptio
         grammarServices.validation.LangiumGrammarValidator.options = config.validation;
     }
 
-    const all = await buildAll(config);
+    const all = await buildAll(config); // all parsed *.langium documents with their "doc.uri.fsPath" as key
     const buildResult: (success: boolean) => GeneratorResult = (success: boolean) => ({
         success,
         files: Array.from(all.keys())
@@ -290,7 +288,8 @@ export async function runGenerator(config: LangiumConfig, options: GenerateOptio
         return buildResult(false);
     }
 
-    const grammars: Grammar[] = [];
+    // identify all relevant grammars
+    const topLevelGrammars: Grammar[] = [];
     const configMap: Map<Grammar, LangiumLanguageConfig> = new Map();
     const relPath = config[RelativePath];
     for (const languageConfig of config.languages) {
@@ -302,28 +301,20 @@ export async function runGenerator(config: LangiumConfig, options: GenerateOptio
                 log('error', options, chalk.red(`${absGrammarPath}: The entry grammar must start with the 'grammar' keyword.`));
                 return buildResult(false);
             }
-            grammars.push(grammar);
+            topLevelGrammars.push(grammar);
             configMap.set(grammar, languageConfig);
         }
     }
-
-    const grammarElements = mapGrammarElements(grammars);
-
-    const embeddedGrammars: Grammar[] = [];
-    for (const grammar of grammars) {
-        const embeddedGrammar = embedReferencedGrammar(grammar, grammarElements);
-        embeddedGrammars.push(embeddedGrammar);
-        configMap.set(embeddedGrammar, configMap.get(grammar)!);
-    }
-    // We need to rescope the grammars again
-    // They need to pick up on the embedded references
-    await relinkGrammars(embeddedGrammars);
-
-    for (const grammar of embeddedGrammars) {
-        // Create and validate the in-memory parser
-        const parserAnalysis = await validateParser(grammar, config, configMap, grammarServices);
-        if (parserAnalysis instanceof Error) {
-            log('error', options, chalk.red(parserAnalysis.toString()));
+    const importedGrammars = topLevelGrammars.flatMap(g => resolveTransitiveImports(sharedServices.workspace.LangiumDocuments, g));
+    const allGrammars = [ ...topLevelGrammars, ...importedGrammars ]
+        .filter((grammar, index, array) => array.indexOf(grammar) === index) // keep only the 1st occurance of each grammar => filter out duplicates in in-place way
+        .sort((g1, g2) => getAstIdentifierForGrammarFile(g1).localeCompare(getAstIdentifierForGrammarFile(g2))); // sort regarding their file names
+    // check that the identifiers of the grammars are unique
+    const mapCheckUnique: MultiMap<string, Grammar> = new MultiMap();
+    allGrammars.forEach(grammar => mapCheckUnique.add(getAstIdentifierForGrammarFile(grammar), grammar));
+    for (const [identifier, grammars] of mapCheckUnique.entriesGroupedByKey()) {
+        if (grammars.length >= 2) {
+            log('error', options, chalk.red(`The grammars ${grammars.map(g => AstUtils.getDocument(g).uri.toString()).join(', ')} result in the same identifier '${identifier}': Rename the file name(s) to make the grammar identifiers unique.`));
             return buildResult(false);
         }
     }
@@ -339,15 +330,57 @@ export async function runGenerator(config: LangiumConfig, options: GenerateOptio
         return buildResult(false);
     }
 
-    const genAst = generateAst(grammarServices, embeddedGrammars, config);
-    await writeWithFail(path.resolve(updateLangiumInternalAstPath(output, config), 'ast.ts'), genAst, options);
+    // ast.ts
+    const isSingleLanguage = config.languages.length === 1;
+    const isSingleFile = allGrammars.length === 1 && isSingleLanguage /* handle special case: multiple languages use the same *.langium file */;
+    let embeddedGrammars: Grammar[];
+    if (isSingleFile) {
+        // merge all grammars into a single grammar and use it
+        embeddedGrammars = topLevelGrammars;
 
+        const genAst = generateAstSingleFileProject(grammarServices, embeddedGrammars, config);
+        await writeWithFail(path.resolve(updateLangiumInternalAstPath(output, config), 'ast.ts'), genAst, options);
+    } else {
+        if (isSingleLanguage) {
+            // only a single language, but with multiple *.langium files
+            const genAst = generateAstMultiFileProject(grammarServices, config, allGrammars);
+            await writeWithFail(path.resolve(updateLangiumInternalAstPath(output, config), 'ast.ts'), genAst, options);
+        } else {
+            // multiple languages
+            const genAst = generateAstMultiLanguageProject(grammarServices, configMap, config, allGrammars);
+            await writeWithFail(path.resolve(updateLangiumInternalAstPath(output, config), 'ast.ts'), genAst, options);
+        }
+
+        // merge all grammars into a single grammar and use it in the following steps
+        const grammarElements = mapGrammarElements(topLevelGrammars);
+        embeddedGrammars = [];
+        for (const grammar of topLevelGrammars) {
+            const embeddedGrammar = embedReferencedGrammar(grammar, grammarElements);
+            embeddedGrammars.push(embeddedGrammar);
+            configMap.set(embeddedGrammar, configMap.get(grammar)!);
+        }
+        // We need to rescope the grammars again
+        // They need to pick up on the embedded references
+        await relinkGrammars(embeddedGrammars);
+        // Create and validate the in-memory parser
+        for (const grammar of embeddedGrammars) {
+            const parserAnalysis = await validateParser(grammar, config, configMap, grammarServices);
+            if (parserAnalysis instanceof Error) {
+                log('error', options, chalk.red(parserAnalysis.toString()));
+                return buildResult(false);
+            }
+        }
+    }
+
+    // grammar.ts
     const serializedGrammar = serializeGrammar(grammarServices, embeddedGrammars, config);
     await writeWithFail(path.resolve(output, 'grammar.ts'), serializedGrammar, options);
 
+    // module.ts
     const genModule = generateModule(embeddedGrammars, config, configMap);
     await writeWithFail(path.resolve(output, 'module.ts'), genModule, options);
 
+    // additional artifacts
     for (const grammar of embeddedGrammars) {
         const languageConfig = configMap.get(grammar);
 

--- a/packages/langium-cli/src/generate.ts
+++ b/packages/langium-cli/src/generate.ts
@@ -332,7 +332,7 @@ export async function runGenerator(config: LangiumConfig, options: GenerateOptio
 
     // ast.ts
     const isSingleLanguage = config.languages.length === 1;
-    const isSingleFile = allGrammars.length === 1 && isSingleLanguage /* handle special case: multiple languages use the same *.langium file */;
+    const isSingleFile = allGrammars.length === 1 && isSingleLanguage /* handles a special case: multiple languages use the same *.langium file */;
     let embeddedGrammars: Grammar[];
     if (isSingleFile) {
         // merge all grammars into a single grammar and use it

--- a/packages/langium-cli/src/generator/ast-generator.ts
+++ b/packages/langium-cli/src/generator/ast-generator.ts
@@ -256,7 +256,6 @@ function generateTerminalConstants(grammars: Grammar[], name: string): Generated
 
 function generateTerminalConstantsComposed(identifiers: string[], name: string): Generated {
     identifiers.sort(); // in-place, for a stable order
-    // Note that type definitions (type X, constant X, function isX) can be imported from their 'ast-xxx.ts' files and don't need to be repeated here
     return expandToNode`
         export const ${name}Terminals = {
             ${joinToNode(

--- a/packages/langium-cli/src/generator/ast-generator.ts
+++ b/packages/langium-cli/src/generator/ast-generator.ts
@@ -4,47 +4,166 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import type { Grammar, LangiumCoreServices } from 'langium';
-import { EOL, type Generated, expandToNode, joinToNode, toString } from 'langium/generate';
+import { type Grammar, type LangiumCoreServices } from 'langium';
+import type { CompositeGeneratorNode } from 'langium/generate';
+import { EOL, expandToNode, joinToNode, toString, type Generated } from 'langium/generate';
 import type { AstTypes, Property, PropertyDefaultValue } from 'langium/grammar';
-import type { LangiumConfig } from '../package-types.js';
-import { collectAst, collectTypeHierarchy, findReferenceTypes, isAstType, mergeTypesAndInterfaces, escapeQuotes } from 'langium/grammar';
+import { collectAst, collectTypeHierarchy, escapeQuotes, findReferenceTypes, isAstType, mergeTypesAndInterfaces, resolveTransitiveImports } from 'langium/grammar';
+import type { LangiumConfig, LangiumLanguageConfig } from '../package-types.js';
+import { collectKeywords, collectTerminalRegexps, getAstIdentifierForGrammarFile } from './langium-util.js';
 import { generatedHeader } from './node-util.js';
-import { collectKeywords, collectTerminalRegexps } from './langium-util.js';
 
-export function generateAst(services: LangiumCoreServices, grammars: Grammar[], config: LangiumConfig): string {
-    const astTypes = collectAst(grammars, services);
-    const importFrom = config.langiumInternal ? `../../syntax-tree${config.importExtension}` : 'langium';
-    const fileNode = expandToNode`
+// TODO test cases: transitive Imports von utility-Langium documents, *.langium files in different folders (oder limitation?), no keywords in grammar file at all
+
+function generateAstHeader(langiumConfig: LangiumConfig): CompositeGeneratorNode {
+    const importFrom = langiumConfig.langiumInternal ? `../../syntax-tree${langiumConfig.importExtension}` : 'langium';
+    return expandToNode`
         ${generatedHeader}
 
         /* eslint-disable */
         import * as langium from '${importFrom}';
-
-        ${generateTerminalConstants(grammars, config)}
-
-        ${joinToNode(astTypes.unions, union => union.toAstTypesString(isAstType(union.type)), { appendNewLineIfNotEmpty: true })}
-        ${joinToNode(astTypes.interfaces, iFace => iFace.toAstTypesString(true), { appendNewLineIfNotEmpty: true })}
-        ${
-            astTypes.unions = astTypes.unions.filter(e => isAstType(e.type)),
-            generateAstReflection(config, astTypes)
-        }
     `;
+}
+
+export function generateAstSingleFileProject(services: LangiumCoreServices, grammars: Grammar[], config: LangiumConfig): string {
+    const astTypes = collectAst(grammars, { services });
+    const astTypesFiltered: AstTypes = { // some operations with in-place changes are done on these filtered AsTypes!
+        interfaces: [...astTypes.interfaces],
+        unions: astTypes.unions.filter(e => isAstType(e.type)),
+    };
+    const fileNode = expandToNode`
+        ${generateAstHeader(config)}
+
+        ${generateTerminalConstants(grammars, config.projectName)}
+        ${joinToNode(astTypes.unions, union => union.toAstTypesString(isAstType(union.type)), { appendNewLineIfNotEmpty: true })}
+        ${joinToNode(astTypes.interfaces, iFace => iFace.toAstTypesString(true), { appendNewLineIfNotEmpty: true, skipNewLineAfterLastItem: true })}
+        ${generateAstType(config.projectName, astTypesFiltered)}
+        ${generateAstReflection(config.projectName, astTypesFiltered)}
+    `.appendNewLine();
     return toString(fileNode);
 }
 
-function generateAstReflection(config: LangiumConfig, astTypes: AstTypes): Generated {
+export function generateAstMultiFileProject(services: LangiumCoreServices, config: LangiumConfig, allGrammarFiles: Grammar[]): string {
+    const astTypes = collectAst(allGrammarFiles, { services });
+    const fileNode = expandToNode`
+        ${generateAstHeader(config)}
+
+        ${joinToNode( // terminals & keywords for each *.langium file (without terminals & keywords from imported grammars)
+            allGrammarFiles,
+            grammar => generateTerminalConstants([grammar], getFileIdentifier(config, grammar)),
+        )}
+        ${ // terminals & keywords for the whole project
+            generateTerminalConstantsComposed(allGrammarFiles.map(f => getFileIdentifier(config, f)), config.projectName)
+        }
+        ${joinToNode(astTypes.unions, union => union.toAstTypesString(isAstType(union.type)), { appendNewLineIfNotEmpty: true })}
+        ${joinToNode(astTypes.interfaces, iFace => iFace.toAstTypesString(true), { appendNewLineIfNotEmpty: true, skipNewLineAfterLastItem: true })}
+        ${joinToNode( // AstType list for each *.langium file (with types from imported grammars)
+            allGrammarFiles,
+            grammar => generateAstType(getFileIdentifier(config, grammar), collectAst([grammar], { services, filterNonAstTypeUnions: true })),
+        )}
+        ${ // AstType list for the whole project
+            generateAstTypeComposed(allGrammarFiles.map(f => getFileIdentifier(config, f)), config.projectName)
+        }
+        ${ // reflection for the whole project
+            astTypes.unions = astTypes.unions.filter(e => isAstType(e.type)), // Note that the `unions` are changed in-place here!
+            generateAstReflection(config.projectName, astTypes) // Note that here are some more in-place changes!
+        }
+    `.appendNewLine();
+    return toString(fileNode);
+}
+
+export function generateAstMultiLanguageProject(services: LangiumCoreServices, configMap: Map<Grammar, LangiumLanguageConfig>, config: LangiumConfig, allGrammarFiles: Grammar[]): string {
+    const astTypes = collectAst(allGrammarFiles, { services });
+    const languages = Array.from(configMap.entries())
+        .map(e => <LanguageInfo>{
+            grammar: e[0],
+            config: e[1],
+            allImported: resolveTransitiveImports(services.shared.workspace.LangiumDocuments, e[0]),
+            identifier: getLanguageIdentifier(config, e[0]), // the name defined after the 'grammar' keyword inside the *.langium file
+        })
+        .sort((e1, e2) => e1.identifier.localeCompare(e2.identifier));
+
+    const fileNode = expandToNode`
+        ${generateAstHeader(config)}
+
+        ${joinToNode( // terminals & keywords for each *.langium file (without terminals & keywords from imported grammars)
+            allGrammarFiles,
+            grammar => generateTerminalConstants([grammar], getFileIdentifier(config, grammar)),
+        )}
+        ${joinToNode( // terminals & keywords for each language
+            languages,
+            language => generateTerminalConstantsComposed([language.grammar, ...language.allImported].map(g => getFileIdentifier(config, g)), language.identifier),
+        )}
+        ${ // terminals & keywords for the whole project
+            generateTerminalConstantsComposed(languages.map(l => l.identifier), config.projectName)
+        }
+        ${joinToNode(astTypes.unions, union => union.toAstTypesString(isAstType(union.type)), { appendNewLineIfNotEmpty: true })}
+        ${joinToNode(astTypes.interfaces, iFace => iFace.toAstTypesString(true), { appendNewLineIfNotEmpty: true, skipNewLineAfterLastItem: true })}
+        ${joinToNode( // AstType list for each *.langium file (with types from imported grammars)
+            allGrammarFiles,
+            grammar => generateAstType(getFileIdentifier(config, grammar), collectAst([grammar], { services, filterNonAstTypeUnions: true })),
+        )}
+        ${joinToNode( // AstType list for each language
+            languages,
+            language => generateAstTypeComposed([language.grammar, ...language.allImported].map(g => getFileIdentifier(config, g)), language.identifier),
+        )}
+        ${ // AstType list for the whole project
+            generateAstTypeComposed(languages.map(l => l.identifier), config.projectName)
+        }
+        ${ // reflection for the whole project
+            astTypes.unions = astTypes.unions.filter(e => isAstType(e.type)), // Note that the `unions` are changed in-place here!
+            generateAstReflection(config.projectName, astTypes) // Note that here are some more in-place changes!
+        }
+    `.appendNewLine();
+    return toString(fileNode);
+}
+
+interface LanguageInfo {
+    grammar: Grammar
+    allImported: Grammar[]
+    config: LangiumLanguageConfig
+    identifier: string
+}
+
+function getLanguageIdentifier(config: LangiumConfig, grammar: Grammar): string {
+    return `${config.projectName}Language${grammar.name!}`; // there is a check, that the top-level grammar of a language has a 'name' value!
+}
+
+function getFileIdentifier(config: LangiumConfig, grammar: Grammar): string {
+    return `${config.projectName}File${getAstIdentifierForGrammarFile(grammar)}`;
+}
+
+function generateAstType(name: string, astTypes: AstTypes): CompositeGeneratorNode {
+    const typeNames: string[] = astTypes.interfaces.map(t => t.name)
+        .concat(astTypes.unions.map(t => t.name))
+        .sort();
+
+    return expandToNode`
+        export type ${name}AstType = {
+            ${joinToNode(typeNames, name => name + ': ' + name, { appendNewLineIfNotEmpty: true })}
+        }
+    `.appendNewLine().appendNewLine();
+}
+
+function generateAstTypeComposed(identifiers: string[], name: string): CompositeGeneratorNode {
+    identifiers.sort(); // in-place, for a stable order
+    return expandToNode`
+        export type ${name}AstType = ${joinToNode(
+            identifiers.sort(),
+            identifier => `${identifier}AstType`,
+            { separator: ' & ' }
+        )}
+    `.appendNewLine().appendNewLine();
+}
+
+function generateAstReflection(name: string, astTypes: AstTypes): CompositeGeneratorNode {
     const typeNames: string[] = astTypes.interfaces.map(t => t.name)
         .concat(astTypes.unions.map(t => t.name))
         .sort();
     const typeHierarchy = collectTypeHierarchy(mergeTypesAndInterfaces(astTypes));
 
     return expandToNode`
-        export type ${config.projectName}AstType = {
-            ${joinToNode(typeNames, name => name + ': ' + name, { appendNewLineIfNotEmpty: true })}
-        }
-
-        export class ${config.projectName}AstReflection extends langium.AbstractAstReflection {
+        export class ${name}AstReflection extends langium.AbstractAstReflection {
             override readonly types = {
                 ${joinToNode(typeNames, typeName => {
                     const interfaceType = astTypes.interfaces.find(t => t.name === typeName);
@@ -66,8 +185,8 @@ function generateAstReflection(config: LangiumConfig, astTypes: AstTypes): Gener
             } as const satisfies langium.AstMetaData
         }
 
-        export const reflection = new ${config.projectName}AstReflection();
-    `.appendNewLine();
+        export const reflection = new ${name}AstReflection();
+    `;
 }
 
 function buildPropertyMetaData(props: Property[], ownerTypeName: string): Generated {
@@ -111,11 +230,11 @@ function stringifyDefaultValue(value?: PropertyDefaultValue): string | undefined
     }
 }
 
-function generateTerminalConstants(grammars: Grammar[], config: LangiumConfig): Generated {
+function generateTerminalConstants(grammars: Grammar[], name: string): Generated {
     let collection: Record<string, RegExp> = {};
     const keywordTokens = new Set<string>();
     grammars.forEach(grammar => {
-        const terminalConstants = collectTerminalRegexps(grammar);
+        const terminalConstants = collectTerminalRegexps(grammar); // ignores imported grammars
         collection = {...collection, ...terminalConstants};
         for (const keyword of collectKeywords(grammar)) {
             keywordTokens.add(keyword);
@@ -125,14 +244,38 @@ function generateTerminalConstants(grammars: Grammar[], config: LangiumConfig): 
     const keywordStrings = Array.from(keywordTokens).sort().map((keyword) => JSON.stringify(keyword));
 
     return expandToNode`
-        export const ${config.projectName}Terminals = {
+        export const ${name}Terminals = {
             ${joinToNode(Object.entries(collection), ([name, regexp]) => `${name}: ${regexp.toString()},`, { appendNewLineIfNotEmpty: true })}
         };
 
-        export type ${config.projectName}TerminalNames = keyof typeof ${config.projectName}Terminals;
+        export type ${name}TerminalNames = keyof typeof ${name}Terminals;
 
-        export type ${config.projectName}KeywordNames =${keywordStrings.length > 0 ? keywordStrings.map(keyword => `${EOL}    | ${keyword}`).join('') : ' never'};
+        export type ${name}KeywordNames =${keywordStrings.length > 0 ? keywordStrings.map(keyword => `${EOL}    | ${keyword}`).join('') : ' never'};
 
-        export type ${config.projectName}TokenNames = ${config.projectName}TerminalNames | ${config.projectName}KeywordNames;
-    `.appendNewLine();
+        export type ${name}TokenNames = ${name}TerminalNames | ${name}KeywordNames;
+    `.appendNewLine().appendNewLine();
+}
+
+function generateTerminalConstantsComposed(identifiers: string[], name: string): Generated {
+    identifiers.sort(); // in-place, for a stable order
+    // Note that type definitions (type X, constant X, function isX) can be imported from their 'ast-xxx.ts' files and don't need to be repeated here
+    return expandToNode`
+        export const ${name}Terminals = {
+            ${joinToNode(
+                identifiers,
+                identifier => `...${identifier}Terminals,`,
+                { appendNewLineIfNotEmpty: true }
+            )}
+        };
+
+        export type ${name}TerminalNames = keyof typeof ${name}Terminals;
+
+        export type ${name}KeywordNames = ${joinToNode(
+            identifiers,
+            identifier => `${identifier}KeywordNames`,
+            { separator: ' | ' }
+        )};
+
+        export type ${name}TokenNames = ${name}TerminalNames | ${name}KeywordNames;
+    `.appendNewLine().appendNewLine();
 }

--- a/packages/langium-cli/src/generator/ast-generator.ts
+++ b/packages/langium-cli/src/generator/ast-generator.ts
@@ -13,8 +13,6 @@ import type { LangiumConfig, LangiumLanguageConfig } from '../package-types.js';
 import { collectKeywords, collectTerminalRegexps, getAstIdentifierForGrammarFile } from './langium-util.js';
 import { generatedHeader } from './node-util.js';
 
-// TODO test cases: transitive Imports von utility-Langium documents, *.langium files in different folders (oder limitation?), no keywords in grammar file at all
-
 function generateAstHeader(langiumConfig: LangiumConfig): CompositeGeneratorNode {
     const importFrom = langiumConfig.langiumInternal ? `../../syntax-tree${langiumConfig.importExtension}` : 'langium';
     return expandToNode`

--- a/packages/langium-cli/src/generator/langium-util.ts
+++ b/packages/langium-cli/src/generator/langium-util.ts
@@ -3,8 +3,9 @@
  * This program and the accompanying materials are made available under the
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
-import { AstUtils, type Grammar, GrammarAST, GrammarUtils, stream } from 'langium';
 import chalk from 'chalk';
+import { AstUtils, type Grammar, GrammarAST, GrammarUtils, type LangiumDocument, stream } from 'langium';
+import * as path from 'path';
 
 //eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function log(level: 'log' | 'warn' | 'error', options: { watch?: boolean }, message: string, ...args: any[]): void {
@@ -46,4 +47,25 @@ export function collectTerminalRegexps(grammar: Grammar): Record<string, RegExp>
         result[name] = regexp;
     }
     return result;
+}
+
+export function getAstIdentifierForGrammarFile(grammar: Grammar): string {
+    const doc: LangiumDocument = AstUtils.getDocument(grammar);
+    const p1 = doc.uri.fsPath.toLowerCase();
+    // use the file name, since not each grammar contains a "grammar XXX"-declaration
+    return replaceSpecialSignsForCamelCase(path.basename(p1, '.langium'));
+}
+
+export function replaceSpecialSignsForCamelCase(value: string): string {
+    return value.split('.').flatMap(p => p.split(' ')).flatMap(p => p.split('-')).flatMap(p => p.split('_')) // replace some signs: . -_
+        .map(ensureCamelCase) // camel case for each single part of the value after removing the special signs
+        .join('');
+}
+
+export function ensureCamelCase(value: string): string {
+    if (value.length >= 1 && value[0].toLocaleUpperCase() !== value[0]) {
+        return value[0].toLocaleUpperCase() + value.substring(1);
+    } else {
+        return value;
+    }
 }

--- a/packages/langium-cli/src/generator/langium-util.ts
+++ b/packages/langium-cli/src/generator/langium-util.ts
@@ -27,9 +27,9 @@ function padZeroes(i: number): string {
 
 export function collectKeywords(grammar: Grammar): string[] {
     const keywords = new Set<string>();
-    const reachableRules = GrammarUtils.getAllReachableRules(grammar, false);
+    const allRules = grammar.rules; // since this grammar might be imported by other grammars, all rules need to be investigated
 
-    for (const keyword of stream(reachableRules)
+    for (const keyword of stream(allRules)
         .filter(rule => GrammarAST.isParserRule(rule) || GrammarAST.isInfixRule(rule))
         .flatMap(rule => AstUtils.streamAllContents(rule).filter(GrammarAST.isKeyword))) {
         keywords.add(keyword.value);
@@ -40,8 +40,8 @@ export function collectKeywords(grammar: Grammar): string[] {
 
 export function collectTerminalRegexps(grammar: Grammar): Record<string, RegExp> {
     const result: Record<string, RegExp> = {};
-    const reachableRules = GrammarUtils.getAllReachableRules(grammar, false);
-    for (const terminalRule of stream(reachableRules).filter(GrammarAST.isTerminalRule)) {
+    const allRules = grammar.rules; // since this grammar might be imported by other grammars, all rules need to be investigated
+    for (const terminalRule of stream(allRules).filter(GrammarAST.isTerminalRule)) {
         const name = terminalRule.name;
         const regexp = GrammarUtils.terminalRegex(terminalRule);
         result[name] = regexp;

--- a/packages/langium-cli/src/generator/types-generator.ts
+++ b/packages/langium-cli/src/generator/types-generator.ts
@@ -9,7 +9,7 @@ import { collectAst, LangiumGrammarGrammar } from 'langium/grammar';
 import { collectKeywords } from './langium-util.js';
 
 export function generateTypesFile(services: LangiumCoreServices, grammars: Grammar[]): string {
-    const { unions, interfaces } = collectAst(grammars, services);
+    const { unions, interfaces } = collectAst(grammars, { services });
     const reservedWords = new Set(collectKeywords(LangiumGrammarGrammar()));
 
     const fileNode = joinToNode([

--- a/packages/langium-cli/test/generator/ast-generator.test.ts
+++ b/packages/langium-cli/test/generator/ast-generator.test.ts
@@ -4,17 +4,17 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import { AstUtils, EmptyFileSystem, MultiMap, URI, type Grammar, type LangiumDocument } from 'langium';
+import { AstUtils, EmptyFileSystem, type Grammar, MultiMap, stream, URI, type LangiumDocument } from 'langium';
 import { CompositeGeneratorNode, expandToNode, expandToString, IndentNode, normalizeEOL, toString, type Generated } from 'langium/generate';
 import { createLangiumGrammarServices } from 'langium/grammar';
 import { clearDocuments, expectNoIssues, parseHelper } from 'langium/test';
 import { beforeEach, describe, expect, test } from 'vitest';
-import { generate } from '../../src/generate.js';
-import { generateAstMultiFileProject, generateAstSingleFileProject } from '../../src/generator/ast-generator.js';
-import { getAstIdentifierForGrammarFile } from '../../src/generator/langium-util.js';
-import type { LangiumConfig } from '../../src/package-types.js';
-import { RelativePath } from '../../src/package-types.js';
 import { DiagnosticSeverity } from 'vscode-languageserver-types';
+import { generate } from '../../src/generate.js';
+import { generateAstMultiFileProject, generateAstMultiLanguageProject, generateAstSingleFileProject } from '../../src/generator/ast-generator.js';
+import { getAstIdentifierForGrammarFile } from '../../src/generator/langium-util.js';
+import type { LangiumConfig, LangiumLanguageConfig } from '../../src/package-types.js';
+import { RelativePath } from '../../src/package-types.js';
 
 const services = createLangiumGrammarServices(EmptyFileSystem);
 const parse = parseHelper<Grammar>(services.grammar);
@@ -717,11 +717,8 @@ describe('Ast generator (with multiple *.langium files)', () => {
         await clearDocuments(services.shared); // ensure that *.langium files from previous test cases are not existing anymore
     });
 
-    // TODO no ID conflict with unrelated grammars!
-    // TODO multi-language projects
-
     test('Multi-file project: Grammar "one" uses a type which is inferred in file "two"', async () => {
-        await testMultiFilesProject(
+        await testMultiProject(
             [{
                 path: 'one.langium',
                 languageID: 'one',
@@ -838,9 +835,8 @@ describe('Ast generator (with multiple *.langium files)', () => {
         );
     });
 
-    // TODO alle aufgelisteten Typen korrekt?
     test('Multi-file project: Types use types which are declared in (transitively) imported files', async () => {
-        await testMultiFilesProject(
+        await testMultiProject(
             [{
                 path: 'one.langium',
                 languageID: 'one',
@@ -991,7 +987,7 @@ describe('Ast generator (with multiple *.langium files)', () => {
     });
 
     test('Multi-file project: Same name "test" for project, file name and language id', async () => {
-        await testMultiFilesProject(
+        await testMultiProject(
             [{
                 path: 'test.langium',
                 languageID: 'test',
@@ -1060,7 +1056,7 @@ describe('Ast generator (with multiple *.langium files)', () => {
     });
 
     test('Multi-file project: Same name "test" for project, file name and language id (fails with grammar file names which produce non-unique identifiers)', async () => {
-        expect(async () => await testMultiFilesProject(
+        expect(async () => await testMultiProject(
             [{
                 path: 'test.langium',
                 languageID: 'test',
@@ -1087,7 +1083,7 @@ describe('Ast generator (with multiple *.langium files)', () => {
     });
 
     test('Multi-file project: All unused terminals are listed, since they might be used by other grammars', async () => {
-        await testMultiFilesProject(
+        await testMultiProject(
             [{
                 path: 'one.langium',
                 languageID: 'one',
@@ -1152,6 +1148,288 @@ describe('Ast generator (with multiple *.langium files)', () => {
         );
     });
 
+    test('Multi-language project: 2 languages, both import another grammar file', async () => {
+        await testMultiProject(
+            [{
+                path: 'one.langium',
+                languageID: 'one',
+                grammarContent: `
+                    grammar OneGrammar
+                    import "three";
+                    entry Entry1: 'a' a1=ID;
+                `,
+                expectedAstContentParts: [
+                    expandToString`
+                        export const testFileOneTerminals = {
+                        };
+
+                        export type testFileOneTerminalNames = keyof typeof testFileOneTerminals;
+
+                        export type testFileOneKeywordNames =
+                            | "a";
+
+                        export type testFileOneTokenNames = testFileOneTerminalNames | testFileOneKeywordNames;
+                    `, expandToString`
+                        export const testLanguageOneGrammarTerminals = {
+                            ...testFileOneTerminals,
+                            ...testFileThreeTerminals,
+                        };
+
+                        export type testLanguageOneGrammarTerminalNames = keyof typeof testLanguageOneGrammarTerminals;
+
+                        export type testLanguageOneGrammarKeywordNames = testFileOneKeywordNames | testFileThreeKeywordNames;
+
+                        export type testLanguageOneGrammarTokenNames = testLanguageOneGrammarTerminalNames | testLanguageOneGrammarKeywordNames;
+                    `
+                ],
+            }, {
+                path: 'two.langium',
+                languageID: 'two',
+                grammarContent: `
+                    grammar TwoGrammar
+                    import "three";
+                    entry Entry2: 'b' b1=INT;
+                `,
+                expectedAstContentParts: [
+                    expandToString`
+                        export const testFileTwoTerminals = {
+                        };
+
+                        export type testFileTwoTerminalNames = keyof typeof testFileTwoTerminals;
+
+                        export type testFileTwoKeywordNames =
+                            | "b";
+
+                        export type testFileTwoTokenNames = testFileTwoTerminalNames | testFileTwoKeywordNames;
+                    `, expandToString`
+                        export const testLanguageTwoGrammarTerminals = {
+                            ...testFileThreeTerminals,
+                            ...testFileTwoTerminals,
+                        };
+
+                        export type testLanguageTwoGrammarTerminalNames = keyof typeof testLanguageTwoGrammarTerminals;
+
+                        export type testLanguageTwoGrammarKeywordNames = testFileThreeKeywordNames | testFileTwoKeywordNames;
+
+                        export type testLanguageTwoGrammarTokenNames = testLanguageTwoGrammarTerminalNames | testLanguageTwoGrammarKeywordNames;
+                    `
+                ],
+            }, {
+                path: 'three.langium',
+                languageID: undefined,
+                grammarContent: `
+                    terminal ID: /[a-zA-Z]+/;
+                    terminal INT: /[0-9]+/;
+                    hidden terminal WS: /\s+/;
+                `,
+                expectedAstContentParts: [
+                    expandToString`
+                        export const testFileThreeTerminals = {
+                            ID: /[a-zA-Z]+/,
+                            INT: /[0-9]+/,
+                            WS: /s+/,
+                        };
+
+                        export type testFileThreeTerminalNames = keyof typeof testFileThreeTerminals;
+
+                        export type testFileThreeKeywordNames = never;
+
+                        export type testFileThreeTokenNames = testFileThreeTerminalNames | testFileThreeKeywordNames;
+                    `
+                ],
+            }],
+            [expandToString`
+                export const testTerminals = {
+                    ...testLanguageOneGrammarTerminals,
+                    ...testLanguageTwoGrammarTerminals,
+                };
+
+                export type testTerminalNames = keyof typeof testTerminals;
+
+                export type testKeywordNames = testLanguageOneGrammarKeywordNames | testLanguageTwoGrammarKeywordNames;
+
+                export type testTokenNames = testTerminalNames | testKeywordNames;
+            `, expandToString`
+                export type testFileOneAstType = {
+                    Entry1: Entry1
+                }
+
+                export type testFileTwoAstType = {
+                    Entry2: Entry2
+                }
+
+                export type testFileThreeAstType = {
+                }
+
+                export type testLanguageOneGrammarAstType = testFileOneAstType & testFileThreeAstType
+
+                export type testLanguageTwoGrammarAstType = testFileThreeAstType & testFileTwoAstType
+
+                export type testAstType = testLanguageOneGrammarAstType & testLanguageTwoGrammarAstType
+            `]
+        );
+    });
+
+    test('Multi-language project: 2 languages, both import a different grammar file which import each other', async () => {
+        await testMultiProject(
+            [{
+                path: 'one.langium',
+                languageID: 'one',
+                grammarContent: `
+                    grammar OneGrammar
+                    import "oneCommon";
+                    entry Entry1: 'a' a1=ID a2=C1;
+                `,
+                expectedAstContentParts: [
+                    expandToString`
+                        export type testFileOneAstType = {
+                            C1: C1
+                            C2: C2
+                            Entry1: Entry1
+                        }
+                    `, expandToString`
+                        export const testLanguageOneGrammarTerminals = {
+                            ...testFileOneTerminals,
+                            ...testFileOnecommonTerminals,
+                            ...testFileTwocommonTerminals,
+                        };
+
+                        export type testLanguageOneGrammarTerminalNames = keyof typeof testLanguageOneGrammarTerminals;
+
+                        export type testLanguageOneGrammarKeywordNames = testFileOneKeywordNames | testFileOnecommonKeywordNames | testFileTwocommonKeywordNames;
+
+                        export type testLanguageOneGrammarTokenNames = testLanguageOneGrammarTerminalNames | testLanguageOneGrammarKeywordNames;
+                    `
+                ],
+            }, {
+                path: 'two.langium',
+                languageID: 'two',
+                grammarContent: `
+                    grammar TwoGrammar
+                    import "twoCommon";
+                    entry Entry2: 'b' b1=INT b2=C2;
+                `,
+                expectedAstContentParts: [
+                    expandToString`
+                        export type testFileTwoAstType = {
+                            C1: C1
+                            C2: C2
+                            Entry2: Entry2
+                        }
+                    `, expandToString`
+                        export const testLanguageTwoGrammarTerminals = {
+                            ...testFileOnecommonTerminals,
+                            ...testFileTwoTerminals,
+                            ...testFileTwocommonTerminals,
+                        };
+
+                        export type testLanguageTwoGrammarTerminalNames = keyof typeof testLanguageTwoGrammarTerminals;
+
+                        export type testLanguageTwoGrammarKeywordNames = testFileOnecommonKeywordNames | testFileTwoKeywordNames | testFileTwocommonKeywordNames;
+
+                        export type testLanguageTwoGrammarTokenNames = testLanguageTwoGrammarTerminalNames | testLanguageTwoGrammarKeywordNames;
+                    `
+                ],
+            }, {
+                path: 'oneCommon.langium',
+                languageID: undefined,
+                grammarContent: `
+                    import "twoCommon"
+                    terminal ID: /[a-zA-Z]+/;
+                    hidden terminal WS: /\s+/;
+                    C1: 'c1' (c1=C2)?;
+                `,
+                expectedAstContentParts: [
+                    expandToString`
+                        export const testFileOnecommonTerminals = {
+                            ID: /[a-zA-Z]+/,
+                            WS: /s+/,
+                        };
+                    `, expandToString`
+                        export interface C1 extends langium.AstNode {
+                            readonly $container: C2 | Entry1;
+                            readonly $type: 'C1';
+                            c1?: C2;
+                        }
+
+                        export const C1 = {
+                            $type: 'C1',
+                            c1: 'c1'
+                        } as const;
+
+                        export function isC1(item: unknown): item is C1 {
+                            return reflection.isInstance(item, C1.$type);
+                        }
+                    `, expandToString`
+                        export type testFileOnecommonAstType = {
+                            C1: C1
+                            C2: C2
+                        }
+                    `
+                ],
+            }, {
+                path: 'twoCommon.langium',
+                languageID: undefined,
+                grammarContent: `
+                    import "oneCommon"
+                    terminal INT: /[0-9]+/;
+                    C2: 'c2' (c2=C1)?;
+                `,
+                expectedAstContentParts: [
+                    expandToString`
+                        export const testFileTwocommonTerminals = {
+                            INT: /[0-9]+/,
+                        };
+                    `, expandToString`
+                        export interface C2 extends langium.AstNode {
+                            readonly $container: C1 | Entry2;
+                            readonly $type: 'C2';
+                            c2?: C1;
+                        }
+
+                        export const C2 = {
+                            $type: 'C2',
+                            c2: 'c2'
+                        } as const;
+
+                        export function isC2(item: unknown): item is C2 {
+                            return reflection.isInstance(item, C2.$type);
+                        }
+                    `, expandToString`
+                        export type testFileTwocommonAstType = {
+                            C1: C1
+                            C2: C2
+                        }
+                    `
+                ],
+            }],
+            [expandToString`
+                export const testTerminals = {
+                    ...testLanguageOneGrammarTerminals,
+                    ...testLanguageTwoGrammarTerminals,
+                };
+
+                export type testTerminalNames = keyof typeof testTerminals;
+
+                export type testKeywordNames = testLanguageOneGrammarKeywordNames | testLanguageTwoGrammarKeywordNames;
+
+                export type testTokenNames = testTerminalNames | testKeywordNames;
+            `, expandToString`
+                export type testLanguageOneGrammarAstType = testFileOneAstType & testFileOnecommonAstType & testFileTwocommonAstType
+
+                export type testLanguageTwoGrammarAstType = testFileOnecommonAstType & testFileTwoAstType & testFileTwocommonAstType
+
+                export type testAstType = testLanguageOneGrammarAstType & testLanguageTwoGrammarAstType
+            `, expandToString`
+                export type testLanguageOneGrammarAstType = testFileOneAstType & testFileOnecommonAstType & testFileTwocommonAstType
+
+                export type testLanguageTwoGrammarAstType = testFileOnecommonAstType & testFileTwoAstType & testFileTwocommonAstType
+
+                export type testAstType = testLanguageOneGrammarAstType & testLanguageTwoGrammarAstType
+            `]
+        );
+    });
+
     test.skip('Use this test case for debugging the generation of the Arithmetics example (single-file project)', async () => {
         await generate({ file: 'examples/arithmetics/langium-config.json' });
     });
@@ -1169,15 +1447,7 @@ interface GrammarFile {
     grammarContent: string;
     expectedAstContentParts: string[];
 }
-/**
- *
- * @param grammarFiles at least two grammar files
- * @param moreExpectedParts the main 'ast.ts' content
- */
-async function testMultiFilesProject(grammarFiles: GrammarFile[], moreExpectedParts: string[]): Promise<void> {
-    if (grammarFiles.length <= 1) {
-        throw new Error('At least two grammar files are expected here');
-    }
+async function testMultiProject(grammarFiles: GrammarFile[], moreExpectedParts: string[]): Promise<void> {
     // collect all information
     const config: LangiumConfig = {
         [RelativePath]: './',
@@ -1186,6 +1456,7 @@ async function testMultiFilesProject(grammarFiles: GrammarFile[], moreExpectedPa
     };
     const documents: LangiumDocument[] = [];
     const expectedParts: string[] = [];
+    const configMap: Map<LangiumDocument, LangiumLanguageConfig> = new Map();
     for (const file of grammarFiles) {
         const grammarFile = `file:///${file.path}`;
         const uri = URI.parse(grammarFile);
@@ -1194,10 +1465,12 @@ async function testMultiFilesProject(grammarFiles: GrammarFile[], moreExpectedPa
         documents.push(document);
         expectedParts.push(...file.expectedAstContentParts);
         if (file.languageID) { // use this grammar file as entry point for a language
-            config.languages.push({
+            const languageConfig = {
                 id: file.languageID,
                 grammar: grammarFile,
-            });
+            };
+            config.languages.push(languageConfig);
+            configMap.set(document, languageConfig);
         }
     }
     expectedParts.push(...moreExpectedParts);
@@ -1223,7 +1496,9 @@ async function testMultiFilesProject(grammarFiles: GrammarFile[], moreExpectedPa
     }
 
     // generate the ast.ts
-    const generated = generateAstMultiFileProject(services.grammar, config, allGrammars);
+    const generated = configMap.size === 1
+        ? generateAstMultiFileProject(services.grammar, config, allGrammars)
+        : generateAstMultiLanguageProject(services.grammar, stream(configMap.entries()).reduce((prev, cur) => { prev.set(cur[0].parseResult.value as Grammar, cur[1]); return prev; }, new Map<Grammar, LangiumLanguageConfig>()), config, allGrammars);
 
     // check the generated content
     expectedParts.forEach(part => expect(generated).toContain(part));

--- a/packages/langium-cli/test/generator/ast-generator.test.ts
+++ b/packages/langium-cli/test/generator/ast-generator.test.ts
@@ -4,19 +4,21 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import { EmptyFileSystem, type Grammar } from 'langium';
-import { expandToString, normalizeEOL } from 'langium/generate';
+import { AstUtils, EmptyFileSystem, MultiMap, URI, type Grammar, type LangiumDocument } from 'langium';
+import { CompositeGeneratorNode, expandToNode, expandToString, IndentNode, normalizeEOL, toString, type Generated } from 'langium/generate';
 import { createLangiumGrammarServices } from 'langium/grammar';
-import { parseHelper } from 'langium/test';
-import { describe, expect, test } from 'vitest';
-import { generateAst } from '../../src/generator/ast-generator.js';
+import { clearDocuments, expectNoIssues, parseHelper } from 'langium/test';
+import { beforeEach, describe, expect, test } from 'vitest';
+import { generate } from '../../src/generate.js';
+import { generateAstMultiFileProject, generateAstSingleFileProject } from '../../src/generator/ast-generator.js';
+import { getAstIdentifierForGrammarFile } from '../../src/generator/langium-util.js';
 import type { LangiumConfig } from '../../src/package-types.js';
 import { RelativePath } from '../../src/package-types.js';
 
 const services = createLangiumGrammarServices(EmptyFileSystem);
 const parse = parseHelper<Grammar>(services.grammar);
 
-describe('Ast generator', () => {
+describe('Ast generator (with a single *.langium file in the project only)', () => {
 
     test('should generate checker functions for datatype rules comprised of a single string', () => testGeneratedAst(`
         grammar TestGrammar
@@ -663,7 +665,7 @@ async function testTerminalConstants(grammar: string, expected: string) {
         languages: []
     };
     const expectedPart = normalizeEOL(expected).trim();
-    const typesFileContent = generateAst(services.grammar, [result.value], config);
+    const typesFileContent = generateAstSingleFileProject(services.grammar, [result.value], config);
 
     const start = typesFileContent.indexOf(`export const ${config.projectName}Terminals`);
     const end = typesFileContent.indexOf('};', start) + 2;
@@ -695,11 +697,467 @@ async function testGenerated(grammar: string, expected: string, start: string, e
         languages: []
     };
     const expectedPart = normalizeEOL(expected).trim();
-    const typesFileContent = generateAst(services.grammar, [result.value], config);
+    const typesFileContent = generateAstSingleFileProject(services.grammar, [result.value], config);
     let startIndex = typesFileContent.indexOf(start);
     for (let i = 0; i < startCount; i++) {
         startIndex = typesFileContent.indexOf(start, startIndex + start.length);
     }
     const relevantPart = typesFileContent.substring(startIndex, typesFileContent.indexOf(end)).trim();
     expect(relevantPart).toEqual(expectedPart);
+}
+
+describe('Ast generator (with multiple *.langium files)', () => {
+
+    beforeEach(async () => {
+        await clearDocuments(services.shared); // ensure that *.langium files from previous test cases are not existing anymore
+    });
+
+    // TODO (un)used terminals, no ID conflict with unrelated grammars!
+    // TODO multi-language projects
+
+    test('Multi-file project: Grammar "one" uses a type which is inferred in file "two"', async () => {
+        await testMultiFilesProject(
+            [{
+                path: 'one.langium',
+                languageID: 'one',
+                grammarContent: `
+                    grammar OneGrammar
+                    import "two";
+                    entry Entry: A | B;
+                    A: 'a' a=ID;
+                    terminal ID: /[a-zA-Z0-9]+/;
+                    hidden terminal WS: /\s+/;
+                `,
+                expectedAstContentParts: [
+                    expandToString`
+                        export const testFileOneTerminals = {
+                            ID: /[a-zA-Z0-9]+/,
+                            WS: /s+/,
+                        };
+
+                        export type testFileOneTerminalNames = keyof typeof testFileOneTerminals;
+
+                        export type testFileOneKeywordNames =
+                            | "a";
+
+                        export type testFileOneTokenNames = testFileOneTerminalNames | testFileOneKeywordNames;
+
+                    `, expandToString`
+                        export type Entry = A | B;
+                    `, expandToString`
+                        export type testFileOneAstType = {
+                            A: A
+                            B: B
+                            Entry: Entry
+                        }
+                    `, expandToStringIndented(2, expandToNode`
+                        A: {
+                            name: A.$type,
+                            properties: {
+                                a: {
+                                    name: A.a
+                                }
+                            },
+                            superTypes: [Entry.$type]
+                        }
+                    `)
+                ],
+            }, {
+                path: 'two.langium',
+                languageID: undefined,
+                grammarContent: `
+                    B: 'b' b=ID2;
+                    terminal ID2: /[a-zA-Z0-9]+/;
+                    hidden terminal WS2: /\s+/;
+                `,
+                expectedAstContentParts: [
+                    expandToString`
+                        export const testFileTwoTerminals = {
+                            ID2: /[a-zA-Z0-9]+/,
+                            WS2: /s+/,
+                        };
+
+                        export type testFileTwoTerminalNames = keyof typeof testFileTwoTerminals;
+
+                        export type testFileTwoKeywordNames =
+                            | "b";
+
+                        export type testFileTwoTokenNames = testFileTwoTerminalNames | testFileTwoKeywordNames;
+                    `, expandToString`
+                        export interface B extends langium.AstNode {
+                            readonly $type: 'B';
+                            b: string;
+                        }
+
+                        export const B = {
+                            $type: 'B',
+                            b: 'b'
+                        } as const;
+
+                        export function isB(item: unknown): item is B {
+                            return reflection.isInstance(item, B.$type);
+                        }
+                    `, expandToString`
+                        export type testFileTwoAstType = {
+                            B: B
+                        }
+                    `, expandToStringIndented(2, expandToNode`
+                        B: {
+                            name: B.$type,
+                            properties: {
+                                b: {
+                                    name: B.b
+                                }
+                            },
+                            superTypes: [Entry.$type]
+                        }
+                    `)
+                ],
+            }],
+            [expandToString`
+                export const testTerminals = {
+                    ...testFileOneTerminals,
+                    ...testFileTwoTerminals,
+                };
+
+                export type testTerminalNames = keyof typeof testTerminals;
+
+                export type testKeywordNames = testFileOneKeywordNames | testFileTwoKeywordNames;
+
+                export type testTokenNames = testTerminalNames | testKeywordNames;
+            `, expandToString`
+                export type testAstType = testFileOneAstType & testFileTwoAstType
+            `, expandToString`
+                export const reflection = new testAstReflection();
+            `]
+        );
+    });
+
+    // TODO alle aufgelisteten Typen korrekt?
+    test('Multi-file project: Types use types which are declared in (transitively) imported files', async () => {
+        await testMultiFilesProject(
+            [{
+                path: 'one.langium',
+                languageID: 'one',
+                grammarContent: `
+                    grammar OneGrammar
+                    import "two";
+                    entry Entry: 'a' a=ID;
+                    type A = B | C;
+                    terminal ID: /[a-zA-Z0-9]+/;
+                    hidden terminal WS: /\s+/;
+                `,
+                expectedAstContentParts: [
+                    expandToString`
+                        export const testFileOneTerminals = {
+                            ID: /[a-zA-Z0-9]+/,
+                            WS: /s+/,
+                        };
+
+                        export type testFileOneTerminalNames = keyof typeof testFileOneTerminals;
+
+                        export type testFileOneKeywordNames =
+                            | "a";
+
+                        export type testFileOneTokenNames = testFileOneTerminalNames | testFileOneKeywordNames;
+
+                    `, expandToString`
+                        export type A = B | C;
+                    `, expandToString`
+                        export type testFileOneAstType = {
+                            A: A
+                            B: B
+                            B1: B1
+                            C: C
+                            Entry: Entry
+                        }
+                    `
+                ],
+            }, {
+                path: 'two.langium',
+                languageID: undefined,
+                grammarContent: `
+                    import "three";
+                    type B = C | B1;
+                    interface B1 {
+                        b1: string
+                    }
+                `,
+                expectedAstContentParts: [
+                    expandToString`
+                        export type B = B1 | C;
+
+                        export const B = {
+                            $type: 'B'
+                        } as const;
+
+                        export function isB(item: unknown): item is B {
+                            return reflection.isInstance(item, B.$type);
+                        }
+                    `, expandToString`
+                        export interface B1 extends langium.AstNode {
+                            readonly $type: 'B1';
+                            b1: string;
+                        }
+
+                        export const B1 = {
+                            $type: 'B1',
+                            b1: 'b1'
+                        } as const;
+
+                        export function isB1(item: unknown): item is B1 {
+                            return reflection.isInstance(item, B1.$type);
+                        }
+                    `, expandToString`
+                        export type testFileTwoAstType = {
+                            B: B
+                            B1: B1
+                            C: C
+                        }
+                    `
+                ],
+            }, {
+                path: 'three.langium',
+                languageID: undefined,
+                grammarContent: `
+                    interface C {
+                        c: boolean
+                    }
+                `,
+                expectedAstContentParts: [
+                    expandToString`
+                        export interface C extends langium.AstNode {
+                            readonly $type: 'C';
+                            c: boolean;
+                        }
+
+                        export const C = {
+                            $type: 'C',
+                            c: 'c'
+                        } as const;
+
+                        export function isC(item: unknown): item is C {
+                            return reflection.isInstance(item, C.$type);
+                        }
+                    `, expandToString`
+                        export type testFileThreeAstType = {
+                            C: C
+                        }
+                    `
+                ]
+            }],
+            [expandToString`
+                export type testAstType = testFileOneAstType & testFileThreeAstType & testFileTwoAstType
+
+                export class testAstReflection extends langium.AbstractAstReflection {
+                    override readonly types = {
+                        B1: {
+                            name: B1.$type,
+                            properties: {
+                                b1: {
+                                    name: B1.b1
+                                }
+                            },
+                            superTypes: [B.$type]
+                        },
+                        C: {
+                            name: C.$type,
+                            properties: {
+                                c: {
+                                    name: C.c,
+                                    defaultValue: false
+                                }
+                            },
+                            superTypes: [A.$type, B.$type]
+                        },
+                        Entry: {
+                            name: Entry.$type,
+                            properties: {
+                                a: {
+                                    name: Entry.a
+                                }
+                            },
+                            superTypes: []
+                        }
+                    } as const satisfies langium.AstMetaData
+                }
+            `]
+        );
+    });
+
+    test('Multi-file project: Same name "test" for project, file name and language id', async () => {
+        await testMultiFilesProject(
+            [{
+                path: 'test.langium',
+                languageID: 'test',
+                grammarContent: `
+                        grammar Test
+                        import "two";
+                        entry Test returns Test: 'a' a=ID;
+                        terminal ID: /[a-zA-Z0-9]+/;
+                        hidden terminal WS: /\s+/;
+                    `,
+                expectedAstContentParts: [
+                    expandToString`
+                            export type testFileTestAstType = {
+                                Test: Test
+                            }
+                        `
+                ],
+            }, {
+                path: 'two.langium',
+                languageID: undefined,
+                grammarContent: `
+                        interface Test {
+                            a: string
+                        }
+                    `,
+                expectedAstContentParts: [
+                    expandToString`
+                            export interface Test extends langium.AstNode {
+                                readonly $type: 'Test';
+                                a: string;
+                            }
+
+                            export const Test = {
+                                $type: 'Test',
+                                a: 'a'
+                            } as const;
+
+                            export function isTest(item: unknown): item is Test {
+                                return reflection.isInstance(item, Test.$type);
+                            }
+                        `, expandToString`
+                            export type testFileTwoAstType = {
+                                Test: Test
+                            }
+                        `
+                ],
+            }],
+            [expandToString`
+                export type testAstType = testFileTestAstType & testFileTwoAstType
+
+                export class testAstReflection extends langium.AbstractAstReflection {
+                    override readonly types = {
+                        Test: {
+                            name: Test.$type,
+                            properties: {
+                                a: {
+                                    name: Test.a
+                                }
+                            },
+                            superTypes: []
+                        }
+                    } as const satisfies langium.AstMetaData
+                }
+            `]
+        );
+    });
+
+    test('Multi-file project: Same name "test" for project, file name and language id (fails with grammar file names which produce non-unique identifiers)', async () => {
+        expect(async () => await testMultiFilesProject(
+            [{
+                path: 'test.langium',
+                languageID: 'test',
+                grammarContent: `
+                        grammar Test
+                        import "myFolder/Test";
+                        entry Test returns Test: 'a' a=ID;
+                        terminal ID: /[a-zA-Z0-9]+/;
+                        hidden terminal WS: /\s+/;
+                    `,
+                expectedAstContentParts: [],
+            },{
+                path: 'myFolder/Test.langium',
+                languageID: undefined,
+                grammarContent: `
+                        interface Test {
+                            a: string
+                        }
+                    `,
+                expectedAstContentParts: [],
+            }],
+            []
+        )).rejects.toThrowError("The grammars file:///test.langium, file:///myFolder/Test.langium result in the same identifier 'Test': Rename the file name(s) to make the grammar identifiers unique.");
+    });
+
+    test.skip('Use this test case for debugging the generation of the Arithmetics example (single-file project)', async () => {
+        await generate({ file: 'examples/arithmetics/langium-config.json' });
+    });
+    test.skip('Use this test case for debugging the generation of Langium itself (multi-file project)', async () => {
+        await generate({ file: 'packages/langium/langium-config.json' });
+    });
+    test.skip('Use this test case for debugging the generation of the Requirements example (multi-language project)', async () => {
+        await generate({ file: 'examples/requirements/langium-config.json' });
+    });
+});
+
+interface GrammarFile {
+    path: string;
+    languageID: string | undefined; // If not undefined, this grammar file is used as entry point for a language with the given value as 'id'
+    grammarContent: string;
+    expectedAstContentParts: string[];
+}
+/**
+ *
+ * @param grammarFiles at least two grammar files
+ * @param moreExpectedParts the main 'ast.ts' content
+ */
+async function testMultiFilesProject(grammarFiles: GrammarFile[], moreExpectedParts: string[]): Promise<void> {
+    if (grammarFiles.length <= 1) {
+        throw new Error('At least two grammar files are expected here');
+    }
+    // collect all information
+    const config: LangiumConfig = {
+        [RelativePath]: './',
+        projectName: 'test',
+        languages: [], // will be filled later
+    };
+    const documents: LangiumDocument[] = [];
+    const expectedParts: string[] = [];
+    for (const file of grammarFiles) {
+        const grammarFile = `file:///${file.path}`;
+        const uri = URI.parse(grammarFile);
+        const document = services.shared.workspace.LangiumDocumentFactory.fromString(file.grammarContent, uri);
+        services.shared.workspace.LangiumDocuments.addDocument(document);
+        documents.push(document);
+        expectedParts.push(...file.expectedAstContentParts);
+        if (file.languageID) { // use this grammar file as entry point for a language
+            config.languages.push({
+                id: file.languageID,
+                grammar: grammarFile,
+            });
+        }
+    }
+    expectedParts.push(...moreExpectedParts);
+
+    // parse and build grammars
+    const documentBuilder = services.shared.workspace.DocumentBuilder;
+    await documentBuilder.build(documents, { validation: true });
+    const allGrammars = documents.map(d => d.parseResult.value as Grammar);
+
+    // check for validation issues
+    documents.forEach(document => expectNoIssues({
+        document,
+        diagnostics: document.diagnostics ?? [],
+        dispose: async () => {},
+    }));
+    // check that the identifiers of the grammars are unique
+    const mapCheckUnique: MultiMap<string, Grammar> = new MultiMap();
+    allGrammars.forEach(grammar => mapCheckUnique.add(getAstIdentifierForGrammarFile(grammar), grammar));
+    for (const [identifier, grammars] of mapCheckUnique.entriesGroupedByKey()) {
+        if (grammars.length >= 2) {
+            throw new Error(`The grammars ${grammars.map(g => AstUtils.getDocument(g).uri.toString()).join(', ')} result in the same identifier '${identifier}': Rename the file name(s) to make the grammar identifiers unique.`);
+        }
+    }
+
+    // generate the ast.ts
+    const generated = generateAstMultiFileProject(services.grammar, config, allGrammars);
+
+    // check the generated content
+    expectedParts.forEach(part => expect(generated).toContain(part));
+}
+
+function expandToStringIndented(columns: number, content: Generated): string {
+    return toString(new CompositeGeneratorNode().append(new IndentNode(columns * 4 /*spaces*/).append(content)));
 }

--- a/packages/langium-cli/test/generator/ast-generator.test.ts
+++ b/packages/langium-cli/test/generator/ast-generator.test.ts
@@ -14,6 +14,7 @@ import { generateAstMultiFileProject, generateAstSingleFileProject } from '../..
 import { getAstIdentifierForGrammarFile } from '../../src/generator/langium-util.js';
 import type { LangiumConfig } from '../../src/package-types.js';
 import { RelativePath } from '../../src/package-types.js';
+import { DiagnosticSeverity } from 'vscode-languageserver-types';
 
 const services = createLangiumGrammarServices(EmptyFileSystem);
 const parse = parseHelper<Grammar>(services.grammar);
@@ -397,6 +398,7 @@ describe('Ast generator (with a single *.langium file in the project only)', () 
     `, expandToString`
         export const TestTerminals = {
             NUMBER: /(?:[0-9])/,
+            DIGIT: /[0-9]/,
         };
     `));
 
@@ -410,6 +412,7 @@ describe('Ast generator (with a single *.langium file in the project only)', () 
     `, expandToString`
         export const TestTerminals = {
             NUMBER: /([0-9])/,
+            DIGIT: /[0-9]/,
         };
     `));
 
@@ -423,6 +426,7 @@ describe('Ast generator (with a single *.langium file in the project only)', () 
     `, expandToString`
         export const TestTerminals = {
             NUMBER: /(?:([0-9]))+/,
+            DIGIT: /([0-9])/,
         };
     `));
 
@@ -436,6 +440,7 @@ describe('Ast generator (with a single *.langium file in the project only)', () 
     `, expandToString`
         export const TestTerminals = {
             NUMBER: /(?:([0-9])_?)+/,
+            DIGIT: /([0-9])_?/,
         };
     `));
 
@@ -712,7 +717,7 @@ describe('Ast generator (with multiple *.langium files)', () => {
         await clearDocuments(services.shared); // ensure that *.langium files from previous test cases are not existing anymore
     });
 
-    // TODO (un)used terminals, no ID conflict with unrelated grammars!
+    // TODO no ID conflict with unrelated grammars!
     // TODO multi-language projects
 
     test('Multi-file project: Grammar "one" uses a type which is inferred in file "two"', async () => {
@@ -1081,6 +1086,72 @@ describe('Ast generator (with multiple *.langium files)', () => {
         )).rejects.toThrowError("The grammars file:///test.langium, file:///myFolder/Test.langium result in the same identifier 'Test': Rename the file name(s) to make the grammar identifiers unique.");
     });
 
+    test('Multi-file project: All unused terminals are listed, since they might be used by other grammars', async () => {
+        await testMultiFilesProject(
+            [{
+                path: 'one.langium',
+                languageID: 'one',
+                grammarContent: `
+                    grammar OneGrammar
+                    import "two";
+                    entry Entry1: 'a' a1=ID1 a2=ID2 a3=ID3 a4=INT2;
+                    terminal ID1: /[a-zA-Z]+/;
+                    terminal INT1: /[0-9]+/;
+                    hidden terminal WS: /\s+/;
+                `,
+                expectedAstContentParts: [
+                    expandToString`
+                        export const testFileOneTerminals = {
+                            ID1: /[a-zA-Z]+/,
+                            INT1: /[0-9]+/,
+                            WS: /s+/,
+                        };
+                    `
+                ],
+            }, {
+                path: 'two.langium',
+                languageID: undefined,
+                grammarContent: `
+                    grammar TwoGrammar
+                    import "three";
+                    terminal ID2: /[a-zA-Z]+/;
+                    terminal INT2: /[0-9]+/;
+                    entry Entry2: 'b' b1=ID2 b2=ID3;
+                `,
+                expectedAstContentParts: [
+                    expandToString`
+                        export const testFileTwoTerminals = {
+                            ID2: /[a-zA-Z]+/,
+                            INT2: /[0-9]+/,
+                        };
+                    `
+                ],
+            }, {
+                path: 'three.langium',
+                languageID: undefined,
+                grammarContent: `
+                    terminal ID3: /[a-zA-Z]+/;
+                    terminal INT3: /[0-9]+/;
+                `,
+                expectedAstContentParts: [
+                    expandToString`
+                        export const testFileThreeTerminals = {
+                            ID3: /[a-zA-Z]+/,
+                            INT3: /[0-9]+/,
+                        };
+                    `
+                ],
+            }],
+            [expandToString`
+                export const testTerminals = {
+                    ...testFileOneTerminals,
+                    ...testFileThreeTerminals,
+                    ...testFileTwoTerminals,
+                };
+            `]
+        );
+    });
+
     test.skip('Use this test case for debugging the generation of the Arithmetics example (single-file project)', async () => {
         await generate({ file: 'examples/arithmetics/langium-config.json' });
     });
@@ -1136,12 +1207,12 @@ async function testMultiFilesProject(grammarFiles: GrammarFile[], moreExpectedPa
     await documentBuilder.build(documents, { validation: true });
     const allGrammars = documents.map(d => d.parseResult.value as Grammar);
 
-    // check for validation issues
+    // check for validation issues (only errors)
     documents.forEach(document => expectNoIssues({
         document,
         diagnostics: document.diagnostics ?? [],
         dispose: async () => {},
-    }));
+    }, { severity: DiagnosticSeverity.Error }));
     // check that the identifiers of the grammars are unique
     const mapCheckUnique: MultiMap<string, Grammar> = new MultiMap();
     allGrammars.forEach(grammar => mapCheckUnique.add(getAstIdentifierForGrammarFile(grammar), grammar));

--- a/packages/langium/src/grammar/ast-reflection-interpreter.ts
+++ b/packages/langium/src/grammar/ast-reflection-interpreter.ts
@@ -19,7 +19,7 @@ export function interpretAstReflection(grammar: Grammar, services?: LangiumCoreS
 export function interpretAstReflection(grammarOrTypes: Grammar | AstTypes, services?: LangiumCoreServices): AstReflection {
     let collectedTypes: AstTypes;
     if (isGrammar(grammarOrTypes)) {
-        collectedTypes = collectAst(grammarOrTypes, services);
+        collectedTypes = collectAst(grammarOrTypes, { services });
     } else {
         collectedTypes = grammarOrTypes;
     }

--- a/packages/langium/src/grammar/type-system/ast-collector.ts
+++ b/packages/langium/src/grammar/type-system/ast-collector.ts
@@ -4,8 +4,8 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import { type LangiumCoreServices } from '../../index.js';
 import { type Grammar } from '../../languages/generated/ast.js';
+import { type LangiumCoreServices } from '../../services.js';
 import type { ValidationAstTypes } from './type-collector/all-types.js';
 import { collectTypeResources } from './type-collector/all-types.js';
 import type { PlainAstTypes, PlainInterface, PlainUnion } from './type-collector/plain-types.js';

--- a/packages/langium/src/grammar/type-system/ast-collector.ts
+++ b/packages/langium/src/grammar/type-system/ast-collector.ts
@@ -4,25 +4,33 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import type { Grammar } from '../../languages/generated/ast.js';
-import type { LangiumCoreServices } from '../../index.js';
-import type { AstTypes, InterfaceType, PropertyType, TypeOption, UnionType } from './type-collector/types.js';
+import { type LangiumCoreServices } from '../../index.js';
+import { type Grammar } from '../../languages/generated/ast.js';
 import type { ValidationAstTypes } from './type-collector/all-types.js';
-import type { PlainAstTypes, PlainInterface, PlainUnion } from './type-collector/plain-types.js';
-import { findAstTypes } from './types-util.js';
-import { isInterfaceType, isPrimitiveType, isPropertyUnion, isStringType, isUnionType, isValueType } from './type-collector/types.js';
 import { collectTypeResources } from './type-collector/all-types.js';
+import type { PlainAstTypes, PlainInterface, PlainUnion } from './type-collector/plain-types.js';
 import { plainToTypes } from './type-collector/plain-types.js';
+import type { AstTypes, InterfaceType, PropertyType, TypeOption, UnionType } from './type-collector/types.js';
+import { isInterfaceType, isPrimitiveType, isPropertyUnion, isStringType, isUnionType, isValueType } from './type-collector/types.js';
+import { findAstTypes, isAstType } from './types-util.js';
 
 /**
  * Collects all types for the generated AST. The types collector entry point.
  *
  * @param grammars All grammars involved in the type generation process
- * @param services Langium core services to resolve imports as needed, and to pass along JSDoc comments to the generated AST
+ * @param config some optional configurations
  */
-export function collectAst(grammars: Grammar | Grammar[], services?: LangiumCoreServices): AstTypes {
-    const { inferred, declared } = collectTypeResources(grammars, services);
-    return createAstTypes(inferred, declared);
+export function collectAst(grammars: Grammar | Grammar[], config?: {
+    /** Langium core services to resolve imports as needed, and to pass along JSDoc comments to the generated AST */
+    services?: LangiumCoreServices,
+    filterNonAstTypeUnions?: boolean,
+}): AstTypes {
+    const { inferred, declared } = collectTypeResources(grammars, config?.services);
+    const result = createAstTypes(inferred, declared);
+    if (config?.filterNonAstTypeUnions) {
+        result.unions = result.unions.filter(e => isAstType(e.type));
+    }
+    return result;
 }
 
 /**

--- a/packages/langium/src/languages/generated/ast.ts
+++ b/packages/langium/src/languages/generated/ast.ts
@@ -6,7 +6,7 @@
 /* eslint-disable */
 import * as langium from '../../syntax-tree.js';
 
-export const LangiumGrammarTerminals = {
+export const LangiumGrammarFileLangiumGrammarTerminals = {
     ID: /\^?[_a-zA-Z][\w_]*/,
     STRING: /"(\\.|[^"\\])*"|'(\\.|[^'\\])*'/,
     NUMBER: /NaN|-?((\d*\.\d+|\d+)([Ee][+-]?\d+)?|Infinity)/,
@@ -16,9 +16,9 @@ export const LangiumGrammarTerminals = {
     SL_COMMENT: /\/\/[^\n\r]*/,
 };
 
-export type LangiumGrammarTerminalNames = keyof typeof LangiumGrammarTerminals;
+export type LangiumGrammarFileLangiumGrammarTerminalNames = keyof typeof LangiumGrammarFileLangiumGrammarTerminals;
 
-export type LangiumGrammarKeywordNames =
+export type LangiumGrammarFileLangiumGrammarKeywordNames =
     | "!"
     | "&"
     | "("
@@ -74,6 +74,26 @@ export type LangiumGrammarKeywordNames =
     | "{"
     | "|"
     | "}";
+
+export type LangiumGrammarFileLangiumGrammarTokenNames = LangiumGrammarFileLangiumGrammarTerminalNames | LangiumGrammarFileLangiumGrammarKeywordNames;
+
+export const LangiumGrammarFileLangiumTypesTerminals = {
+};
+
+export type LangiumGrammarFileLangiumTypesTerminalNames = keyof typeof LangiumGrammarFileLangiumTypesTerminals;
+
+export type LangiumGrammarFileLangiumTypesKeywordNames = never;
+
+export type LangiumGrammarFileLangiumTypesTokenNames = LangiumGrammarFileLangiumTypesTerminalNames | LangiumGrammarFileLangiumTypesKeywordNames;
+
+export const LangiumGrammarTerminals = {
+    ...LangiumGrammarFileLangiumGrammarTerminals,
+    ...LangiumGrammarFileLangiumTypesTerminals,
+};
+
+export type LangiumGrammarTerminalNames = keyof typeof LangiumGrammarTerminals;
+
+export type LangiumGrammarKeywordNames = LangiumGrammarFileLangiumGrammarKeywordNames | LangiumGrammarFileLangiumTypesKeywordNames;
 
 export type LangiumGrammarTokenNames = LangiumGrammarTerminalNames | LangiumGrammarKeywordNames;
 
@@ -918,7 +938,7 @@ export function isWildcard(item: unknown): item is Wildcard {
     return reflection.isInstance(item, Wildcard.$type);
 }
 
-export type LangiumGrammarAstType = {
+export type LangiumGrammarFileLangiumGrammarAstType = {
     AbstractElement: AbstractElement
     AbstractRule: AbstractRule
     AbstractType: AbstractType
@@ -970,6 +990,61 @@ export type LangiumGrammarAstType = {
     ValueLiteral: ValueLiteral
     Wildcard: Wildcard
 }
+
+export type LangiumGrammarFileLangiumTypesAstType = {
+    AbstractElement: AbstractElement
+    AbstractRule: AbstractRule
+    AbstractType: AbstractType
+    Action: Action
+    Alternatives: Alternatives
+    ArrayLiteral: ArrayLiteral
+    ArrayType: ArrayType
+    Assignment: Assignment
+    BooleanLiteral: BooleanLiteral
+    CharacterRange: CharacterRange
+    Condition: Condition
+    Conjunction: Conjunction
+    CrossReference: CrossReference
+    Disjunction: Disjunction
+    EndOfFile: EndOfFile
+    Grammar: Grammar
+    GrammarImport: GrammarImport
+    Group: Group
+    InferredType: InferredType
+    InfixRule: InfixRule
+    InfixRuleOperatorList: InfixRuleOperatorList
+    InfixRuleOperators: InfixRuleOperators
+    Interface: Interface
+    Keyword: Keyword
+    NamedArgument: NamedArgument
+    NegatedToken: NegatedToken
+    Negation: Negation
+    NumberLiteral: NumberLiteral
+    Parameter: Parameter
+    ParameterReference: ParameterReference
+    ParserRule: ParserRule
+    ReferenceType: ReferenceType
+    RegexToken: RegexToken
+    ReturnType: ReturnType
+    RuleCall: RuleCall
+    SimpleType: SimpleType
+    StringLiteral: StringLiteral
+    TerminalAlternatives: TerminalAlternatives
+    TerminalElement: TerminalElement
+    TerminalGroup: TerminalGroup
+    TerminalRule: TerminalRule
+    TerminalRuleCall: TerminalRuleCall
+    Type: Type
+    TypeAttribute: TypeAttribute
+    TypeDefinition: TypeDefinition
+    UnionType: UnionType
+    UnorderedGroup: UnorderedGroup
+    UntilToken: UntilToken
+    ValueLiteral: ValueLiteral
+    Wildcard: Wildcard
+}
+
+export type LangiumGrammarAstType = LangiumGrammarFileLangiumGrammarAstType & LangiumGrammarFileLangiumTypesAstType
 
 export class LangiumGrammarAstReflection extends langium.AbstractAstReflection {
     override readonly types = {

--- a/packages/langium/src/test/langium-test.ts
+++ b/packages/langium/src/test/langium-test.ts
@@ -682,12 +682,12 @@ export function filterByOptions<T extends AstNode = AstNode, N extends AstNode =
 
 export function expectNoIssues<T extends AstNode = AstNode, N extends AstNode = AstNode>(validationResult: ValidationResult<T>, filterOptions?: ExpectDiagnosticOptions<N>): void {
     const filtered = filterOptions ? filterByOptions<T, N>(validationResult, filterOptions) : validationResult.diagnostics;
-    expectedFunction(filtered.length, 0, `Expected no issues, but found ${filtered.length}:\n${printDiagnostics(filtered)}`);
+    expectedFunction(filtered.length, 0, `Expected no issues in '${validationResult.document.uri.toString()}', but found ${filtered.length}:\n${printDiagnostics(filtered)}`);
 }
 
 export function expectIssue<T extends AstNode = AstNode, N extends AstNode = AstNode>(validationResult: ValidationResult<T>, filterOptions?: ExpectDiagnosticOptions<N>): void {
     const filtered = filterOptions ? filterByOptions<T, N>(validationResult, filterOptions) : validationResult.diagnostics;
-    expectedFunction(filtered.length > 0, true, 'Found no issues');
+    expectedFunction(filtered.length > 0, true, `Found no issues in '${validationResult.document.uri.toString()}'`);
 }
 
 export function expectError<T extends AstNode = AstNode, N extends AstNode = AstNode>(validationResult: ValidationResult<T>, message: string | RegExp, filterOptions: ExpectDiagnosticOptionsWithoutContent<N>): void {

--- a/packages/langium/src/utils/grammar-utils.ts
+++ b/packages/langium/src/utils/grammar-utils.ts
@@ -564,7 +564,7 @@ function abstractElementToRegex(element: ast.AbstractElement, flags?: Flags): st
             parenthesized: element.parenthesized
         });
     } else {
-        throw new Error(`Invalid terminal element: ${element?.$type}`);
+        throw new Error(`Invalid terminal element: ${element?.$type}, ${element?.$cstNode?.text}`);
     }
 }
 

--- a/packages/langium/src/validation/validation-registry.ts
+++ b/packages/langium/src/validation/validation-registry.ts
@@ -5,11 +5,11 @@
  ******************************************************************************/
 
 import type { CodeDescription, DiagnosticRelatedInformation, DiagnosticTag, integer, Range } from 'vscode-languageserver-types';
-import { assertUnreachable } from '../index.js';
 import type { LangiumCoreServices } from '../services.js';
 import type { AstNode, AstReflection, Properties } from '../syntax-tree.js';
 import type { CancellationToken } from '../utils/cancellation.js';
 import { MultiMap } from '../utils/collections.js';
+import { assertUnreachable } from '../utils/errors.js';
 import type { MaybePromise } from '../utils/promise-utils.js';
 import { isOperationCancelled } from '../utils/promise-utils.js';
 import type { Stream } from '../utils/stream.js';


### PR DESCRIPTION
**Summary**

This PR reworks the content of the generated `ast.ts` in case of multiple `*.langium` files OR multiple languages inside the project (as defined in the `langium-config.json`).

**Motivation**

In a recent multi-language project, we wanted to write a formatter for a single language (not for all languages). In order to statically ensure by the TypeScript compiler, that we wrote definitions for all AST types in the language, we used the generated `XXXAstType = { Type1: Type1, Type2: Type2, ... }`. But this forced us to define formatting rules for all types of the project including types from other languages. Therefore this PR contributes (among others) a XXXAstType for each language.

**Contributions in more detail**

The `ast.ts` consists of:
1. terminals
2. keywords
3. type definitions (`export interface YYY extends langium.AstNode { ... }`)
4. `XXXAstType` (as described in the motivation)
5. reflection

While the whole content is merged for all files and languages, this PR splits the generated code for terminals (1), keywords (2) and XXXAstType (4), while type definitions (3) and reflection (5) remain unchanged.
In particular for the type definitions (3) it is important to have only one version of them:
- Otherwise imports in TS files during coding become non-unique
- Type definitions might be "incomplete", since it is possible to infer the same type (identified by its name) with different properties (which are merged together into the final type definition) by different parser rules, which might be part of different Langium files!

One instance of terminals, keywords and XXXAstType is created not only for each language, but also for each `*.langium` file in order to enable more fine-grained implementations.
Additionally, one instance of terminals, keywords and XXXAstType is created for the whole project.

**Discussion of (non) breaking changes**

- The `ast.ts` for a single-file project remains unchanged (try `npm run langium:generate` on the whole Langium repo on your own)!
- The terminals, keywords and XXXAstType created for the whole project have the same names as before this PR, therefore they can be used as before.
- Since the initial `grammar MyName` statement in Langium files is optional, it cannot be used as identifier for the instances for each file. Instead the file name is used with the following limitations (which are validated and reported by the CLI) and therefore can be seen as breaking changes:
    - Only the file name, but not the folder name is considered. Therefore `folder1/my.langium` and `folder2/my.langium` together are not supported.
    - The file name is converted to camel case, e.g. `my.langium` and `mY.langium` together are not supported.

**Additional contributions**

- Added test cases for the CLI generator for multi-file and multi-language projects (so far, only single-file projects are tested)
- Fixed bug in Langium in general: Even terminals of grammars with entry rules which are not used by these grammars are now part of the `ast.ts`, since they might be used by other grammars, since it is possible to import grammars with entry rules (considers also terminal fragments now). This can be seen as breaking changes.