### PR TITLE
Remove long-time deprecated properties

### DIFF
--- a/packages/langium/src/lsp/semantic-token-provider.ts
+++ b/packages/langium/src/lsp/semantic-token-provider.ts
@@ -58,7 +58,7 @@ export const AllSemanticTokenModifiers: Record<string, number> = {
 };
 
 /**
- * @deprecated `SemanticTokenProvider` now supplies its own options.
+ * @deprecated Since 3.2.0. `SemanticTokenProvider` now supplies its own options.
  */
 export const DefaultSemanticTokenOptions: SemanticTokensOptions = {
     legend: {

--- a/packages/langium/src/parser/cst-node-builder.ts
+++ b/packages/langium/src/parser/cst-node-builder.ts
@@ -115,16 +115,6 @@ export abstract class AbstractCstNode implements CstNode {
     root: RootCstNode;
     private _astNode?: AstNode;
 
-    /** @deprecated use `container` instead. */
-    get parent(): CompositeCstNode | undefined {
-        return this.container;
-    }
-
-    /** @deprecated use `grammarSource` instead. */
-    get feature(): AbstractElement | undefined {
-        return this.grammarSource;
-    }
-
     get hidden(): boolean {
         return false;
     }
@@ -139,11 +129,6 @@ export abstract class AbstractCstNode implements CstNode {
 
     set astNode(value: AstNode | undefined) {
         this._astNode = value;
-    }
-
-    /** @deprecated use `astNode` instead. */
-    get element(): AstNode {
-        return this.astNode;
     }
 
     get text(): string {
@@ -195,11 +180,6 @@ export class LeafCstNodeImpl extends AbstractCstNode implements LeafCstNode {
 export class CompositeCstNodeImpl extends AbstractCstNode implements CompositeCstNode {
     readonly content: CstNode[] = new CstNodeContainer(this);
     private _rangeCache?: Range;
-
-    /** @deprecated use `content` instead. */
-    get children(): CstNode[] {
-        return this.content;
-    }
 
     get offset(): number {
         return this.firstNonHiddenNode?.offset ?? 0;

--- a/packages/langium/src/service-registry.ts
+++ b/packages/langium/src/service-registry.ts
@@ -46,7 +46,7 @@ export class DefaultServiceRegistry implements ServiceRegistry {
     protected readonly fileNameMap = new Map<string, LangiumCoreServices>();
 
     /**
-     * @deprecated Use the new `fileExtensionMap` (or `languageIdMap`) property instead.
+     * @deprecated Since 3.1.0. Use the new `fileExtensionMap` (or `languageIdMap`) property instead.
      */
     protected get map(): Map<string, LangiumCoreServices> | undefined {
         return this.fileExtensionMap;

--- a/packages/langium/src/syntax-tree.ts
+++ b/packages/langium/src/syntax-tree.ts
@@ -303,20 +303,14 @@ export type PropertyType = number | string | boolean | PropertyType[];
 export interface CstNode extends DocumentSegment {
     /** The container node in the CST */
     readonly container?: CompositeCstNode;
-    /** @deprecated use `container` instead. */
-    readonly parent?: CompositeCstNode;
     /** The actual text */
     readonly text: string;
     /** The root CST node */
     readonly root: RootCstNode;
     /** The grammar element from which this node was parsed */
     readonly grammarSource?: AbstractElement;
-    /** @deprecated use `grammarSource` instead. */
-    readonly feature?: AbstractElement;
     /** The AST node created from this CST node */
     readonly astNode: AstNode;
-    /** @deprecated use `astNode` instead. */
-    readonly element: AstNode;
     /** Whether the token is hidden, i.e. not explicitly part of the containing grammar rule */
     readonly hidden: boolean;
 }
@@ -326,8 +320,6 @@ export interface CstNode extends DocumentSegment {
  */
 export interface CompositeCstNode extends CstNode {
     readonly content: CstNode[];
-    /** @deprecated use `content` instead. */
-    readonly children: CstNode[];
 }
 
 export function isCompositeCstNode(node: unknown): node is CompositeCstNode {

--- a/packages/langium/src/test/langium-test.ts
+++ b/packages/langium/src/test/langium-test.ts
@@ -49,18 +49,9 @@ export function parseHelper<T extends AstNode = AstNode>(services: LangiumCoreSe
 
 export type ExpectFunction = (actual: unknown, expected: unknown, message?: string) => void;
 
-let expectedFunction: ExpectFunction = (actual, expected, message) => {
+const expectedFunction: ExpectFunction = (actual, expected, message) => {
     assert.deepStrictEqual(actual, expected, message);
 };
-
-/**
- * Overrides the assertion function used by tests. Uses `assert.deepStrictEqual` by default
- *
- * @deprecated Since 1.2.0. Do not override the assertion functionality.
- */
-export function expectFunction(functions: ExpectFunction): void {
-    expectedFunction = functions;
-}
 
 export interface ExpectedBase {
     /**


### PR DESCRIPTION
Removes all fields/methods that were deprecated before the release of Langium v3. Adopters have had more than enough time to use the recommended alternatives.