### PR TITLE
langium ast-utils: follow-up/bugfix on #1990 (pass 'trace' to the recursive calls of 'copyAstNode(...)')

### DIFF
--- a/packages/langium/src/utils/ast-utils.ts
+++ b/packages/langium/src/utils/ast-utils.ts
@@ -278,7 +278,7 @@ export function copyAstNode<T extends AstNode = AstNode>(node: T, buildReference
     for (const [name, value] of Object.entries(node)) {
         if (!name.startsWith('$')) {
             if (isAstNode(value)) {
-                copy[name] = copyAstNode(value, buildReference);
+                copy[name] = copyAstNode(value, buildReference, trace);
             } else if (isReference(value)) {
                 copy[name] = buildReference(
                     copy,
@@ -291,7 +291,7 @@ export function copyAstNode<T extends AstNode = AstNode>(node: T, buildReference
                 const copiedArray: unknown[] = [];
                 for (const element of value) {
                     if (isAstNode(element)) {
-                        copiedArray.push(copyAstNode(element, buildReference));
+                        copiedArray.push(copyAstNode(element, buildReference, trace));
                     } else if (isReference(element)) {
                         copiedArray.push(
                             buildReference(


### PR DESCRIPTION
Yesterday it came all of a sudden to mind that I fucked up the contribution of #1990. 🙈

(I tested it in an application project but the recursive case wasn't touched there and I overlooked it).

So here's the fix accompanied by a proper unit test, which I omitted in the previous PR. Shame on me.