### PR TITLE
langium: removed short cut guards in document builder's 'resetToState' method

### DIFF
--- a/packages/langium/src/workspace/document-builder.ts
+++ b/packages/langium/src/workspace/document-builder.ts
@@ -353,35 +353,20 @@ export class DefaultDocumentBuilder implements DocumentBuilder {
                 // Else fall through
             }
             case DocumentState.Parsed:
-                if (document.state <= DocumentState.Parsed) {
-                    break;
-                }
                 this.indexManager.removeContent(document.uri);
                 // Fall through
             case DocumentState.IndexedContent:
-                if (document.state <= DocumentState.IndexedContent) {
-                    break;
-                }
                 document.localSymbols = undefined;
                 // Fall through
             case DocumentState.ComputedScopes: {
-                if (document.state <= DocumentState.ComputedScopes) {
-                    break;
-                }
                 const linker = this.serviceRegistry.getServices(document.uri).references.Linker;
                 linker.unlink(document);
                 // Fall through
             }
             case DocumentState.Linked:
-                if (document.state <= DocumentState.Linked) {
-                    break;
-                }
                 this.indexManager.removeReferences(document.uri);
                 // Fall through
             case DocumentState.IndexedReferences:
-                if (document.state <= DocumentState.IndexedReferences) {
-                    break;
-                }
                 document.diagnostics = undefined;
         }
         if (document.state > state) {

--- a/packages/langium/test/workspace/document-builder.test.ts
+++ b/packages/langium/test/workspace/document-builder.test.ts
@@ -711,7 +711,7 @@ describe('DefaultDocumentBuilder', () => {
         expect(document.localSymbols).toBeUndefined();
         expect(document.references).toHaveLength(0);
 
-        // Again, resolve the reference "on-the-fly", this is supposed to work as
+        // Again, resolve the reference "on-the-fly", this is supposed to work as 'A' is accessible via the index
         first = document.parseResult.value.foos[0].bar.ref;
         expect(first).toBeDefined();
         expect(first!.$type).toBe('Bar');


### PR DESCRIPTION
in language implementations with transitively resolved cross-refs documents may contain resolved cross-refs although their state is still 'ComputedScopes' or even 'IndexContent' -> reset those docs properly, too;

follow-up on PR #1977