### PR TITLE
Use readonly fields for type meta data

### DIFF
--- a/packages/langium/CHANGELOG.md
+++ b/packages/langium/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log of `langium`
 
+## v4.0.2 (Sep. 2025)
+
+* Fixes an issue in the typing of the `TypeMetaData` ([#2032](https://github.com/eclipse-langium/langium/pull/2032)).
+
 ## v4.0.1 (Sep. 2025)
 
 * Fixes multiple issues related to the stability of infix rules ([#2011](https://github.com/eclipse-langium/langium/pull/2011), [#2023](https://github.com/eclipse-langium/langium/pull/2023)).

--- a/packages/langium/src/syntax-tree.ts
+++ b/packages/langium/src/syntax-tree.ts
@@ -257,7 +257,7 @@ export abstract class AbstractAstReflection implements AstReflection {
  * A map of all AST node types and their meta data.
  */
 export interface AstMetaData {
-    [type: string]: TypeMetaData
+    readonly [type: string]: TypeMetaData
 }
 
 /**
@@ -265,13 +265,13 @@ export interface AstMetaData {
  */
 export interface TypeMetaData {
     /** The name of this AST node type. Corresponds to the `AstNode.$type` value. */
-    name: string
+    readonly name: string
     /** A list of properties with their relevant meta data. */
-    properties: {
-        [name: string]: PropertyMetaData
+    readonly properties: {
+        readonly [name: string]: PropertyMetaData
     }
     /** The super types of this AST node type. */
-    superTypes: string[]
+    readonly superTypes: readonly string[]
 }
 
 /**
@@ -279,17 +279,17 @@ export interface TypeMetaData {
  */
 export interface PropertyMetaData {
     /** The name of this property. */
-    name: string
+    readonly name: string
     /**
      * Indicates that the property is mandatory in the AST node.
      * For example, if an AST node contains an array, but no elements of this array have been parsed,
      * we still expect an empty array instead of `undefined`.
      */
-    defaultValue?: PropertyType
+    readonly defaultValue?: PropertyType
     /**
      * If the property is a reference, this is the type of the reference target.
      */
-    referenceType?: string
+    readonly referenceType?: string
 }
 
 /**


### PR DESCRIPTION
Fixes an issue we noticed in https://github.com/eclipse-langium/langium/discussions/1997#discussioncomment-14006947:

Using `const` automatically makes all fields and arrays `readonly` in TypeScript. We use this in the `types` field of the generated AST reflection. We need to reflect this in the types expected by the `AstMetaData`, otherwise, we might run into compilation issues.