### PR TITLE
DocumentValidator: configure the validation of single nodes

### DIFF
--- a/packages/langium/test/workspace/document-builder.test.ts
+++ b/packages/langium/test/workspace/document-builder.test.ts
@@ -315,8 +315,8 @@ describe('DefaultDocumentBuilder', () => {
         await builder.build([document1], { validation: true });
         expect(document1.state).toBe(DocumentState.Validated);
         expect(document1.diagnostics?.map(d => d.message)).toEqual([
+            'Bar is too long: AnotherStrangeBar',
             'Value is too large: 11',
-            'Bar is too long: AnotherStrangeBar'
         ]);
     });
 


### PR DESCRIPTION
This PR extends the `DocumentValidator` to configure the validation of the current AstNode:
- whether the current node itself should be validated or not
- whether its children should be validated or not: Skipping sub-trees improves performance