### PR TITLE
Don't crash the language server by providing invalid URIs

### DIFF
--- a/packages/langium/src/workspace/documents.ts
+++ b/packages/langium/src/workspace/documents.ts
@@ -155,6 +155,9 @@ export interface LangiumDocumentFactory {
 
     /**
      * Create an Langium document from a specified `URI`. The factory will use the `FileSystemAccess` service to read the file.
+     *
+     * If reading the file failed for some reasons (e.g. the URI is invalid or the file does not exist),
+     * a `LangiumDocument` is returned with a corresponding error message as content.
      */
     fromUri<T extends AstNode = AstNode>(uri: URI, cancellationToken?: CancellationToken): Promise<LangiumDocument<T>>;
 
@@ -181,7 +184,22 @@ export class DefaultLangiumDocumentFactory implements LangiumDocumentFactory {
     }
 
     async fromUri<T extends AstNode = AstNode>(uri: URI, cancellationToken = CancellationToken.None): Promise<LangiumDocument<T>> {
-        const content = await this.fileSystemProvider.readFile(uri);
+        const exists = await this.fileSystemProvider.exists(uri);
+        let content: string;
+        if (exists) {
+            const stats = await this.fileSystemProvider.stat(uri);
+            if (stats.isFile) {
+                try {
+                    content = await this.fileSystemProvider.readFile(uri);
+                } catch (err) {
+                    content = `// reading '${uri.toString()}' from file system failed: ${String(err)}`;
+                }
+            } else {
+                content = `// '${uri.toString()}' exists in the file system, but is no file`;
+            }
+        } else {
+            content = `// '${uri.toString()}' does not exist in the file system`;
+        }
         return this.createAsync<T>(uri, content, cancellationToken);
     }
 

--- a/packages/langium/src/workspace/documents.ts
+++ b/packages/langium/src/workspace/documents.ts
@@ -184,21 +184,21 @@ export class DefaultLangiumDocumentFactory implements LangiumDocumentFactory {
     }
 
     async fromUri<T extends AstNode = AstNode>(uri: URI, cancellationToken = CancellationToken.None): Promise<LangiumDocument<T>> {
-        const exists = await this.fileSystemProvider.exists(uri);
         let content: string;
-        if (exists) {
-            const stats = await this.fileSystemProvider.stat(uri);
-            if (stats.isFile) {
-                try {
-                    content = await this.fileSystemProvider.readFile(uri);
-                } catch (err) {
+        try {
+            content = await this.fileSystemProvider.readFile(uri);
+        } catch (err) {
+            // do the fine-grained checks of the given `uri` only in the error case in order to save performance in the usual case
+            if (await this.fileSystemProvider.exists(uri)) {
+                const stats = await this.fileSystemProvider.stat(uri);
+                if (stats.isFile) {
                     content = `// reading '${uri.toString()}' from file system failed: ${String(err)}`;
+                } else {
+                    content = `// '${uri.toString()}' exists in the file system, but is no file`;
                 }
             } else {
-                content = `// '${uri.toString()}' exists in the file system, but is no file`;
+                content = `// '${uri.toString()}' does not exist in the file system`;
             }
-        } else {
-            content = `// '${uri.toString()}' does not exist in the file system`;
         }
         return this.createAsync<T>(uri, content, cancellationToken);
     }

--- a/packages/langium/test/workspace/document-factory.test.ts
+++ b/packages/langium/test/workspace/document-factory.test.ts
@@ -7,9 +7,10 @@
 import type { Grammar } from 'langium';
 import type { LangiumServices } from 'langium/lsp';
 import { describe, expect, test } from 'vitest';
-import { DocumentState, EmptyFileSystem, TextDocument } from 'langium';
+import { DefaultWorkspaceManager, DocumentState, EmptyFileSystem, TextDocument, URI } from 'langium';
 import { createLangiumGrammarServices } from 'langium/grammar';
 import { CancellationToken } from 'vscode-languageserver';
+import { NodeFileSystem } from '../../src/node/node-file-system-provider.js';
 
 describe('DefaultLangiumDocumentFactory', () => {
 
@@ -45,6 +46,40 @@ describe('DefaultLangiumDocumentFactory', () => {
         // Confirm that the parse result wasn't updated.
         expect(updated.parseResult.value.name).toBe('HELLO');
     });
+
+    test('Handle invalid URIs in the EmptyFileSystem', async () => {
+        // const services = createLangiumGrammarServices(NodeFileSystem).grammar;
+        const services = createLangiumGrammarServices(EmptyFileSystem).grammar;
+        const documentFactory = services.shared.workspace.LangiumDocumentFactory;
+        const uri = URI.parse('file:///file/does/not/exist.langium');
+        const document = await documentFactory.fromUri(uri);
+        expect(document).not.toBe(undefined);
+        expect(document.textDocument.getText().trim()).toBe("// 'file:///file/does/not/exist.langium' does not exist in the file system");
+    });
+
+    test('Handle invalid URIs in the NodeFileSystem', async () => {
+        const services = createLangiumGrammarServices(NodeFileSystem).grammar;
+        const documentFactory = services.shared.workspace.LangiumDocumentFactory;
+        const uri = URI.parse('file:///file/does/not/exist.langium');
+        const document = await documentFactory.fromUri(uri);
+        expect(document).not.toBe(undefined);
+        expect(document.textDocument.getText().trim()).toBe("// 'file:///file/does/not/exist.langium' does not exist in the file system");
+    });
+
+    test('Dont crash the LS initialization with invalid URIs', async () => {
+        class TestWorkspaceManager extends DefaultWorkspaceManager {
+            protected override traverseFolder(folderPath: URI, uris: URI[]): Promise<void> {
+                uris.push(URI.parse('file:///file/does/not/exist.langium'));
+                return super.traverseFolder(folderPath, uris);
+            }
+        }
+        const services = createLangiumGrammarServices(NodeFileSystem, { workspace: { WorkspaceManager: services => new TestWorkspaceManager(services) }}).grammar;
+        await services.shared.workspace.WorkspaceManager.initializeWorkspace([{ name: 'init', uri: 'start-somewhere' }]);
+        const documents = services.shared.workspace.LangiumDocuments.all.toArray();
+        expect(documents).toHaveLength(1);
+        expect(documents[0].textDocument.getText().trim()).toBe("// 'file:///file/does/not/exist.langium' does not exist in the file system");
+    });
+
 });
 
 function createTextDocument(uri: string, text: string, services: LangiumServices): TextDocument {

--- a/packages/langium/test/workspace/document-factory.test.ts
+++ b/packages/langium/test/workspace/document-factory.test.ts
@@ -47,37 +47,35 @@ describe('DefaultLangiumDocumentFactory', () => {
         expect(updated.parseResult.value.name).toBe('HELLO');
     });
 
+    const invalidUri = URI.parse('file:///file/does/not/e*xis:t.langium'); // * is illegal on Windows, : is critical on MacOS
+    const invalidUriPrinted = 'file:///file/does/not/e%2Axis%3At.langium';
+
     test('Handle invalid URIs in the EmptyFileSystem', async () => {
-        // const services = createLangiumGrammarServices(NodeFileSystem).grammar;
         const services = createLangiumGrammarServices(EmptyFileSystem).grammar;
         const documentFactory = services.shared.workspace.LangiumDocumentFactory;
-        const uri = URI.parse('file:///file/does/not/exist.langium');
-        const document = await documentFactory.fromUri(uri);
-        expect(document).not.toBe(undefined);
-        expect(document.textDocument.getText().trim()).toBe("// 'file:///file/does/not/exist.langium' does not exist in the file system");
+        const document = await documentFactory.fromUri(invalidUri);
+        expect(document?.textDocument.getText().trim()).toBe(`// '${invalidUriPrinted}' does not exist in the file system`);
     });
 
     test('Handle invalid URIs in the NodeFileSystem', async () => {
         const services = createLangiumGrammarServices(NodeFileSystem).grammar;
         const documentFactory = services.shared.workspace.LangiumDocumentFactory;
-        const uri = URI.parse('file:///file/does/not/exist.langium');
-        const document = await documentFactory.fromUri(uri);
-        expect(document).not.toBe(undefined);
-        expect(document.textDocument.getText().trim()).toBe("// 'file:///file/does/not/exist.langium' does not exist in the file system");
+        const document = await documentFactory.fromUri(invalidUri);
+        expect(document?.textDocument.getText().trim()).toBe(`// '${invalidUriPrinted}' does not exist in the file system`);
     });
 
     test('Dont crash the LS initialization with invalid URIs', async () => {
         class TestWorkspaceManager extends DefaultWorkspaceManager {
             protected override traverseFolder(folderPath: URI, uris: URI[]): Promise<void> {
-                uris.push(URI.parse('file:///file/does/not/exist.langium'));
+                uris.push(invalidUri);
                 return super.traverseFolder(folderPath, uris);
             }
         }
         const services = createLangiumGrammarServices(NodeFileSystem, { workspace: { WorkspaceManager: services => new TestWorkspaceManager(services) }}).grammar;
         await services.shared.workspace.WorkspaceManager.initializeWorkspace([{ name: 'init', uri: 'start-somewhere' }]);
         const documents = services.shared.workspace.LangiumDocuments.all.toArray();
+        expect(documents[0]?.textDocument.getText().trim()).toBe(`// '${invalidUriPrinted}' does not exist in the file system`);
         expect(documents).toHaveLength(1);
-        expect(documents[0].textDocument.getText().trim()).toBe("// 'file:///file/does/not/exist.langium' does not exist in the file system");
     });
 
 });


### PR DESCRIPTION
This PRs adds error handling in the LS for reading files `fromUri`:
- The existing implementation crashed the LS when providing an invalid URI or an URI for a non-existing file to read.
- Since the API always returns a `LangiumDocument`, a new document is created and the resulting error is put into it. Feel free to suggest a better strategy for error handling!