### PR TITLE
Try to fix partial completion - again

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2709,9 +2709,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2729,9 +2726,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2749,9 +2743,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2769,9 +2760,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2789,9 +2777,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2809,9 +2794,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5428,9 +5410,9 @@
       }
     },
     "node_modules/chevrotain-allstar": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/chevrotain-allstar/-/chevrotain-allstar-0.4.2.tgz",
-      "integrity": "sha512-J3WoNdejJDlmUR0XXgmJK2GnCYKp2eWHnaG1fGkvnBVQw9Y6piP4Q30ETz47bfvPTeaN/DV0V5jqLDgX4PCygg==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/chevrotain-allstar/-/chevrotain-allstar-0.4.3.tgz",
+      "integrity": "sha512-2X4mkroolSMKqW+H22pyPMUVDqYZzPhephTmg/NODKb1IGYPHfxfhcW0EjS7wcPJNbze2i4vBWT7zT5FKF2lrQ==",
       "license": "MIT",
       "dependencies": {
         "lodash-es": "^4.18.1"
@@ -9189,9 +9171,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -9213,9 +9192,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -9237,9 +9213,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -9261,9 +9234,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -15409,7 +15379,7 @@
       "dependencies": {
         "@chevrotain/regexp-to-ast": "~12.0.0",
         "chevrotain": "~12.0.0",
-        "chevrotain-allstar": "~0.4.2",
+        "chevrotain-allstar": "~0.4.3",
         "vscode-languageserver": "~9.0.1",
         "vscode-languageserver-textdocument": "~1.0.12",
         "vscode-uri": "~3.1.0"

--- a/packages/langium/package.json
+++ b/packages/langium/package.json
@@ -67,7 +67,7 @@
   "dependencies": {
     "@chevrotain/regexp-to-ast": "~12.0.0",
     "chevrotain": "~12.0.0",
-    "chevrotain-allstar": "~0.4.2",
+    "chevrotain-allstar": "~0.4.3",
     "vscode-languageserver": "~9.0.1",
     "vscode-languageserver-textdocument": "~1.0.12",
     "vscode-uri": "~3.1.0"

--- a/packages/langium/src/parser/langium-parser.ts
+++ b/packages/langium/src/parser/langium-parser.ts
@@ -138,7 +138,7 @@ export abstract class AbstractLangiumParser implements BaseParser {
     protected allRules = new Map<string, RuleResult>();
     protected mainRule!: RuleResult;
 
-    constructor(services: LangiumCoreServices) {
+    constructor(services: LangiumCoreServices, incomplete: boolean) {
         this.lexer = services.parser.Lexer;
         const tokens = this.lexer.definition;
         const production = services.LanguageMetaData.mode === 'production';
@@ -147,13 +147,13 @@ export abstract class AbstractLangiumParser implements BaseParser {
                 ...services.parser.ParserConfig,
                 skipValidations: production,
                 errorMessageProvider: services.parser.ParserErrorMessageProvider
-            }, services.shared.profilers.LangiumProfiler.createTask('parsing', services.LanguageMetaData.languageId));
+            }, incomplete, services.shared.profilers.LangiumProfiler.createTask('parsing', services.LanguageMetaData.languageId));
         } else {
             this.wrapper = new ChevrotainWrapper(tokens, {
                 ...services.parser.ParserConfig,
                 skipValidations: production,
                 errorMessageProvider: services.parser.ParserErrorMessageProvider
-            });
+            }, incomplete);
         }
     }
 
@@ -223,7 +223,7 @@ export class LangiumParser extends AbstractLangiumParser {
     }
 
     constructor(services: LangiumCoreServices) {
-        super(services);
+        super(services, false);
         this.linker = services.references.Linker;
         this.converter = services.parser.ValueConverter;
         this.astReflection = services.shared.AstReflection;
@@ -694,6 +694,10 @@ export class LangiumCompletionParser extends AbstractLangiumParser {
     private nextTokenIndex = 0;
     private stackSize = 0;
 
+    constructor(services: LangiumCoreServices) {
+        super(services, true);
+    }
+
     action(): void {
         // NOOP
     }
@@ -809,7 +813,7 @@ class ChevrotainWrapper extends EmbeddedActionsParser {
     // This array is set in the base implementation of Chevrotain.
     definitionErrors: IParserDefinitionError[];
 
-    constructor(tokens: TokenVocabulary, config: IParserConfig) {
+    constructor(tokens: TokenVocabulary, config: IParserConfig, incomplete: boolean) {
         const useDefaultLookahead = config && 'maxLookahead' in config;
         super(tokens, {
             ...defaultConfig,
@@ -817,7 +821,8 @@ class ChevrotainWrapper extends EmbeddedActionsParser {
                 ? new LLkLookaheadStrategy({ maxLookahead: config.maxLookahead })
                 : new LLStarLookaheadStrategy({
                     // If validations are skipped, don't log the lookahead warnings
-                    logging: config.skipValidations ? () => { } : undefined
+                    logging: config.skipValidations ? () => { } : undefined,
+                    incomplete,
                 }),
             ...config,
         });
@@ -867,8 +872,8 @@ class ChevrotainWrapper extends EmbeddedActionsParser {
 
 class ProfilerWrapper extends ChevrotainWrapper {
     private readonly task: ProfilingTask;
-    constructor(tokens: TokenVocabulary, config: IParserConfig, task: ProfilingTask) {
-        super(tokens, config);
+    constructor(tokens: TokenVocabulary, config: IParserConfig, incomplete: boolean, task: ProfilingTask) {
+        super(tokens, config, incomplete);
         this.task = task;
     }
 

--- a/packages/langium/test/parser/langium-parser-builder.test.ts
+++ b/packages/langium/test/parser/langium-parser-builder.test.ts
@@ -924,6 +924,45 @@ describe('ALL(*) parser', () => {
         expect(result.parserErrors).toHaveLength(0);
         expect(result.value.$type).toBe('B');
     });
+
+    test('Can perform partial outer context resolution', async () => {
+        const outerContextGrammar = `
+        entry Model: items+=Stmt*;
+        Stmt: 'ensure' expr=Additive;
+
+        Additive infers Expression:                                                                                                                                                                                                     
+            Multiplicative
+            (({infer Add.left=current} '+' | {infer Sub.left=current} '-') right=Multiplicative)*;                                                                                                                                      
+                                                                    
+        Multiplicative infers Expression:
+            Primary
+            (({infer Mul.left=current} '*' | {infer Div.left=current} '/') right=Primary)*;
+                                                                                                                                                                                                                                        
+        Primary infers Expression:
+            RefExpression | NumberLiteral;                                                                                                                                                                                              
+                                                                    
+        RefExpression:
+            target=PathOrMetadataAccess;
+                                                                                                                                                                                                                                        
+        NumberLiteral:
+            value=NUMBER;                                                                                                                                                                                                               
+                                                                    
+        PathOrMetadataAccess returns string:
+            PATH | MetadataAccess;
+
+        // '/' inside PATH collides with '/' as division operator                                                                                                                                                                       
+        PATH returns string:
+            ID | (ID ('/' ID)* ':' ID);                                                                                                                                                                                                 
+                                                                    
+        terminal MetadataAccess: /@[_a-zA-Z][\\w_-]*/;                                                                                                                                                                                   
+        terminal NUMBER: /[0-9]+(\\.[0-9]+)?/;
+        terminal ID: /[_a-zA-Z][\\w_-]*/;                                                                                                                                                                                                
+        hidden terminal WS: /\\s+/;`;
+        const parser = await parserFromGrammar(outerContextGrammar);
+        const result = parser.parse('ensure someOtherNumber / 10');
+        expect(result.lexerErrors).toHaveLength(0);
+        expect(result.parserErrors).toHaveLength(0);
+    });
 });
 
 describe('Parsing actions', () => {


### PR DESCRIPTION
Uses the new `incomplete` mode of the allstar-lookahead package to only take the partial completion at the end of the input into account - the previous version broke a few things.