### PR TITLE
Add changelog for langium 4.2.3

### DIFF
--- a/packages/langium/CHANGELOG.md
+++ b/packages/langium/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log of `langium`
 
+## v4.2.3 (May. 2026)
+
+* Fix a long-standing completion issue for parser rules with common prefixes ([#2146](https://github.com/eclipse-langium/langium/pull/2146), [#2147](https://github.com/eclipse-langium/langium/pull/2147)).
+
 ## v4.2.2 (Apr. 2026)
 
 * Bump Chevrotain to v12 ([#2134](https://github.com/eclipse-langium/langium/pull/2134)).


### PR DESCRIPTION
The release of the fix was already a few days ago - just updates our changelog.