### PR TITLE
Add missing langium package dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7044,9 +7044,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {
@@ -15397,8 +15397,11 @@
         "@chevrotain/regexp-to-ast": "~12.0.0",
         "chevrotain": "~12.0.0",
         "chevrotain-allstar": "~0.4.3",
+        "vscode-jsonrpc": "~8.2.0",
         "vscode-languageserver": "~9.0.1",
+        "vscode-languageserver-protocol": "~3.17.5",
         "vscode-languageserver-textdocument": "~1.0.12",
+        "vscode-languageserver-types": "~3.17.5",
         "vscode-uri": "~3.1.0"
       },
       "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15461,7 +15461,8 @@
       "license": "MIT",
       "dependencies": {
         "langium": "~4.2.0",
-        "sprotty-protocol": "^1.0.0"
+        "sprotty-protocol": "^1.0.0",
+        "vscode-languageserver": "~9.0.1"
       }
     },
     "packages/langium-vscode": {

--- a/packages/langium-cli/src/generate.ts
+++ b/packages/langium-cli/src/generate.ts
@@ -11,7 +11,7 @@ import { AstUtils, GrammarAST, URI, type AstNode, type Grammar, type LangiumDocu
 import { createGrammarDiagramHtml, createGrammarDiagramSvg } from 'langium-railroad';
 import { createLangiumGrammarServices, resolveImport, resolveImportUri, resolveTransitiveImports, type LangiumGrammarServices } from 'langium/grammar';
 import { NodeFileSystem } from 'langium/node';
-import * as path from 'path';
+import * as path from 'node:path';
 import { generateAstMultiLanguageProject, generateAstSingleLanguageProject, getLanguageIdentifier, type LanguageInfo } from './generator/ast-generator.js';
 import { generateBnf } from './generator/bnf-generator.js';
 import { serializeGrammar } from './generator/grammar-serializer.js';

--- a/packages/langium-cli/src/generator/grammar-serializer.ts
+++ b/packages/langium-cli/src/generator/grammar-serializer.ts
@@ -5,9 +5,8 @@
  ******************************************************************************/
 
 /* eslint-disable @stylistic/indent */
-import type { Grammar, LangiumCoreServices } from 'langium';
+import type { Grammar, LangiumCoreServices, URI } from 'langium';
 import { expandToNode, joinToNode, normalizeEOL, toString } from 'langium/generate';
-import type { URI } from 'vscode-uri';
 import type { LangiumConfig } from '../package-types.js';
 import { generatedHeader } from './node-util.js';
 

--- a/packages/langium-cli/src/package.ts
+++ b/packages/langium-cli/src/package.ts
@@ -8,8 +8,8 @@ import type { GenerateOptions } from './generate.js';
 import { log } from './generator/langium-util.js';
 import chalk from 'chalk';
 import fs from 'fs-extra';
-import { EOL } from 'os';
-import * as path from 'path';
+import { EOL } from 'node:os';
+import * as path from 'node:path';
 import type { LangiumConfig} from './package-types.js';
 import { RelativePath } from './package-types.js';
 

--- a/packages/langium-sprotty/package.json
+++ b/packages/langium-sprotty/package.json
@@ -35,7 +35,8 @@
   },
   "dependencies": {
     "langium": "~4.2.0",
-    "sprotty-protocol": "^1.0.0"
+    "sprotty-protocol": "^1.0.0",
+    "vscode-languageserver": "~9.0.1"
   },
   "repository": {
     "type": "git",

--- a/packages/langium-sprotty/src/default-module.ts
+++ b/packages/langium-sprotty/src/default-module.ts
@@ -4,13 +4,12 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import type { Module } from 'langium';
+import { URI, type Module } from 'langium';
 import type { PartialLangiumServices } from 'langium/lsp';
 import type { DiagramOptions } from 'sprotty-protocol';
 import type { LangiumSprottyServices, LangiumSprottySharedServices, SprottyDefaultServices, SprottySharedServices } from './sprotty-services.js';
 import { DiagramServer } from 'sprotty-protocol';
 import { ServerActionHandlerRegistry } from 'sprotty-protocol/lib/action-handler.js';
-import { URI } from 'vscode-uri';
 import { DefaultDiagramServerManager } from './diagram-server-manager.js';
 import { DiagramActionNotification } from './lsp.js';
 import { DefaultPositionTracker, TrackingDocumentHighlightProvider } from './position-tracker.js';

--- a/packages/langium-sprotty/src/trace-provider.ts
+++ b/packages/langium-sprotty/src/trace-provider.ts
@@ -7,9 +7,8 @@
 import type { AstNode, AstNodeLocator, LangiumDocuments } from 'langium';
 import type { SModelElement, SModelRoot } from 'sprotty-protocol';
 import type { Range } from 'vscode-languageserver';
-import { URI } from 'vscode-uri';
 import type { LangiumSprottyServices } from './sprotty-services.js';
-import { AstUtils, GrammarUtils, stream, } from 'langium';
+import { AstUtils, GrammarUtils, stream, URI, } from 'langium';
 
 export interface TracedModelElement extends SModelElement {
     trace?: string

--- a/packages/langium/package.json
+++ b/packages/langium/package.json
@@ -68,8 +68,11 @@
     "@chevrotain/regexp-to-ast": "~12.0.0",
     "chevrotain": "~12.0.0",
     "chevrotain-allstar": "~0.4.3",
+    "vscode-jsonrpc": "~8.2.0",
     "vscode-languageserver": "~9.0.1",
+    "vscode-languageserver-protocol": "~3.17.5",
     "vscode-languageserver-textdocument": "~1.0.12",
+    "vscode-languageserver-types": "~3.17.5",
     "vscode-uri": "~3.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Closes https://github.com/eclipse-langium/langium/issues/2153

Also ensures that `langium-cli` is using the right import - but since it's a `type` import only, it's getting omitted anyway.