### PR TITLE
Fix: Preserve optionality when merging prop types

### DIFF
--- a/packages/langium/src/grammar/type-system/type-collector/inferred-types.ts
+++ b/packages/langium/src/grammar/type-system/type-collector/inferred-types.ts
@@ -661,6 +661,8 @@ function flattenTypes(alternatives: TypePath[], part: TypePart): TypePath[] {
                 const existingProperty = properties.find(e => e.name === altProperty.name);
                 if (existingProperty) {
                     existingProperty.type = mergePropertyTypes(existingProperty.type, altProperty.type);
+                    // if either occurrence is optional, the merged property must be optional
+                    existingProperty.optional = existingProperty.optional || altProperty.optional;
                     altProperty.astNodes.forEach(e => existingProperty.astNodes.add(e));
                 } else {
                     properties.push({ ...altProperty });

--- a/packages/langium/src/grammar/type-system/type-collector/inferred-types.ts
+++ b/packages/langium/src/grammar/type-system/type-collector/inferred-types.ts
@@ -433,6 +433,20 @@ function newTypePart(element?: AbstractParserRule | Action | string): TypePart {
 }
 
 /**
+ * Walks up the type path to attempt to find the name of the type we're currently building
+ */
+function nearestNamedParent(part: TypePart): string | undefined {
+    let current: TypePart | undefined = part;
+    while (current) {
+        if (current.name !== undefined) {
+            return current.name;
+        }
+        current = current.parents[0];
+    }
+    return undefined;
+}
+
+/**
  * Collects all possible type branches of a given parser rule element.
  *
  * @param state State to walk over element's graph.
@@ -482,6 +496,13 @@ function collectElement(graph: TypeGraph, current: TypePart, element: AbstractEl
 
 function addAction(graph: TypeGraph, parent: TypePart, action: Action, services?: LangiumCoreServices): TypePart {
     const commentProvider = services?.documentation.CommentProvider;
+    if (!action.feature || !action.operator) {
+        const actionName = getTypeNameWithoutError(action);
+        if (actionName !== undefined && actionName === nearestNamedParent(parent)) {
+            // action that re-introduces the same type as is, with no other contribution, disregard
+            return parent;
+        }
+    }
 
     // We create a copy of the current type part
     // This is essentially a leaf node of the current type

--- a/packages/langium/test/grammar/type-system/inferred-types.test.ts
+++ b/packages/langium/test/grammar/type-system/inferred-types.test.ts
@@ -42,6 +42,25 @@ describe('Inferred types', () => {
         `);
     });
 
+    test('Should infer optional property when same property has mixed optionality in alternatives', async () => {
+        // both A and B should produce `name?: string` regardless of alternative order
+        await expectTypes(`
+            A: 'a1' name=ID | 'a2' name=ID?;
+            B: 'b1' name=ID? | 'b2' name=ID;
+
+            terminal ID returns string: /string/;
+        `, expandToString`
+            export interface A extends langium.AstNode {
+                readonly $type: 'A';
+                name?: string;
+            }
+            export interface B extends langium.AstNode {
+                readonly $type: 'B';
+                name?: string;
+            }
+        `);
+    });
+
     test('Should infer types for alternatives', async () => {
         await expectTypes(`
             A: name=ID | name=NUMBER;

--- a/packages/langium/test/grammar/type-system/inferred-types.test.ts
+++ b/packages/langium/test/grammar/type-system/inferred-types.test.ts
@@ -62,7 +62,6 @@ describe('Inferred types', () => {
     });
 
     test('Rule with action inferring same type produces a non optional property', async () => {
-        // note @montymxb: This should produce a non-optional prop down the road
         await expectTypes(`
              Entry: {infer Entry} ref=ID;
              terminal ID returns string: /string/;

--- a/packages/langium/test/grammar/type-system/inferred-types.test.ts
+++ b/packages/langium/test/grammar/type-system/inferred-types.test.ts
@@ -61,6 +61,38 @@ describe('Inferred types', () => {
         `);
     });
 
+    test('Rule with action inferring same type produces a non optional property', async () => {
+        // note @montymxb: This should produce a non-optional prop down the road
+        await expectTypes(`
+             Entry: {infer Entry} ref=ID;
+             terminal ID returns string: /string/;
+        `, expandToString`
+            export interface Entry extends langium.AstNode {
+                readonly $type: 'Entry';
+                ref: string;
+            }
+        `);
+    });
+
+    test('Rule with action inferring same type on alternative has req property', async () => {
+        await expectTypes(`
+             Entry: A | B;
+             A: {infer A} 'a1' ref=ID | 'a2' ref=ID;
+             B: 'b1' ref=ID | {infer B} 'b2' ref=ID;
+             terminal ID returns string: /string/;
+        `, expandToString`
+            export interface A extends langium.AstNode {
+                readonly $type: 'A';
+                ref: string;
+            }
+            export interface B extends langium.AstNode {
+                readonly $type: 'B';
+                ref: string;
+            }
+            export type Entry = A | B;
+        `);
+    });
+
     test('Should infer types for alternatives', async () => {
         await expectTypes(`
             A: name=ID | name=NUMBER;


### PR DESCRIPTION
- [x] Failing test issue resolved

Fixes an small issue where the types we infer from parser rules can sometimes produce properties with incorrect optionality.

Ex. 
```langium
// marks `prop` as required
AB:
    'a' prop=ID | 'b' prop=ID?;

// marks `props` as _optional_
BA:
    'b' prop=ID? | 'a' prop=ID;
```

Effectively the resulting interface type in **ast.ts** would change based on the alternative order above. When we were merging the types of properties together, we were not merging whether that property was optional. So effectively we took the base optionality and that was it.

_See comment below for follow-up, the details below were from a draft state, kept for reference._

With that being said, this was a quick 5 min fix conveniently enough. _But_, there's a catch, with this fix we introduce another bug with a incorrect type for the following case and derivatives of it (i.e. Rules with actions that infer the same type):
```langium
// marks `ref` as _optional_
A: {infer A} ref=ID;
```

It's a side-effect of the fact we produce 2 types internally in the type-collector before they're merged together; one from rule `A` and another from the action inferring `A`. This is totally normal & expected, but the fix here kicks in _before_ we merge these types, creating an optional property where there shouldn't be one.

That one needs more time to dig into, given it's not so easy to change without negatively impacting the stability of the collector at large. I've already dug into it a bit, but I'm still working on it. So I figured I would at least bring the original patch up for the smaller fix first.

My thought here is that the aforementioned issue has likely caused problems due to erroneous types being generated, and should be prioritized. The side-effect of this fix also leads to invalid types, but only ones that will lead to redundant assertions & checks being required. I think, for now at least, this patched version is preferable to the existing one.

I've left an existing test case failing before I get some feedback on this. My initial thought was to patch it upfront w/ the 'unintended' behavior, but I felt like it's better to share the state first & see what everyone thinks.

We can also defer the PR until I patch the additional issue as well (which would be ideal), but I can't provide any guarantees on when I can provide that from a time perspective.