### PR TITLE
added types node to tsconfig in generator template

### DIFF
--- a/packages/generator-langium/templates/tsconfig.json
+++ b/packages/generator-langium/templates/tsconfig.json
@@ -14,7 +14,8 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "declaration": true,
-    "composite": true
+    "composite": true,
+    "types": [ "node" ]
   },
   "include": [
      "**/src/**/*",


### PR DESCRIPTION
As VS Code (and newer typescript versions) do not automatically set node types as globally available types, one need to add this to the tsconfig.json in the yeoman templates as well. Otherwise the generated code contains compile errors.