### PR TITLE
Added environment: publish to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,6 +26,7 @@ jobs:
   publish:
     name: Langium Publish
     runs-on: ubuntu-latest
+    environment: publish
     timeout-minutes: 20
     steps:
       - name: Checkout

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,15 +12,6 @@ on:
       - 'maintenance/**'
     paths:
       - '**/package.json'
-      # Also trigger if the publish workflow itself is changed
-      - '.github/workflows/publish.yml'
-  pull_request:
-    branches:
-      - 'main'
-      - 'maintenance/**'
-    paths:
-      - '**/package.json'
-      - '.github/workflows/publish.yml'
 
 jobs:
   publish:


### PR DESCRIPTION
https://github.com/eclipse-langium/.eclipsefdn/pull/6 has been merged, so we can now use the `publish` environment to improve publishing security.