### PR TITLE
Implement TextDocumentContentProvider

### DIFF
--- a/examples/domainmodel/src/language-server/domain-model-module.ts
+++ b/examples/domainmodel/src/language-server/domain-model-module.ts
@@ -5,14 +5,15 @@
  ******************************************************************************/
 
 import { type Module, inject } from 'langium';
-import type { LangiumServices, LangiumSharedServices, PartialLangiumServices } from 'langium/lsp';
-import { createDefaultModule, createDefaultSharedModule, type DefaultSharedModuleContext } from 'langium/lsp';
+import type { LangiumServices, LangiumSharedServices, PartialLangiumServices, PartialLangiumSharedServices } from 'langium/lsp';
+import { createDefaultModule, createDefaultSharedModule, DefaultTextDocumentContentProvider, type DefaultSharedModuleContext } from 'langium/lsp';
 import { DomainModelFormatter } from './domain-model-formatter.js';
 import { QualifiedNameProvider } from './domain-model-naming.js';
 import { DomainModelRenameProvider } from './domain-model-rename-refactoring.js';
 import { DomainModelScopeComputation } from './domain-model-scope.js';
 import { DomainModelValidator, registerValidationChecks } from './domain-model-validator.js';
 import { DomainModelGeneratedModule, DomainModelGeneratedSharedModule } from './generated/module.js';
+import { DomainModelWorkspaceManager } from './domain-model-workspace-manager.js';
 
 export type DomainModelAddedServices = {
     references: {
@@ -39,13 +40,23 @@ export const DomainModelModule: Module<DomainModelServices, PartialLangiumServic
     }
 };
 
+export const DomainModelSharedModule: Module<LangiumSharedServices, PartialLangiumSharedServices> = {
+    lsp: {
+        TextDocumentContentProvider: (services) => new DefaultTextDocumentContentProvider(services, ['domain-model'])
+    },
+    workspace: {
+        WorkspaceManager: (services) => new DomainModelWorkspaceManager(services)
+    }
+};
+
 export function createDomainModelServices(context: DefaultSharedModuleContext): {
     shared: LangiumSharedServices,
     domainmodel: DomainModelServices
 } {
     const shared = inject(
         createDefaultSharedModule(context),
-        DomainModelGeneratedSharedModule
+        DomainModelGeneratedSharedModule,
+        DomainModelSharedModule
     );
     const domainmodel = inject(
         createDefaultModule({ shared }),

--- a/examples/domainmodel/src/language-server/domain-model-module.ts
+++ b/examples/domainmodel/src/language-server/domain-model-module.ts
@@ -13,7 +13,7 @@ import { DomainModelRenameProvider } from './domain-model-rename-refactoring.js'
 import { DomainModelScopeComputation } from './domain-model-scope.js';
 import { DomainModelValidator, registerValidationChecks } from './domain-model-validator.js';
 import { DomainModelGeneratedModule, DomainModelGeneratedSharedModule } from './generated/module.js';
-import { DomainModelWorkspaceManager } from './domain-model-workspace-manager.js';
+import { builtinScheme, DomainModelWorkspaceManager } from './domain-model-workspace-manager.js';
 
 export type DomainModelAddedServices = {
     references: {
@@ -42,7 +42,7 @@ export const DomainModelModule: Module<DomainModelServices, PartialLangiumServic
 
 export const DomainModelSharedModule: Module<LangiumSharedServices, PartialLangiumSharedServices> = {
     lsp: {
-        TextDocumentContentProvider: (services) => new DefaultTextDocumentContentProvider(services, ['domain-model'])
+        TextDocumentContentProvider: (services) => new DefaultTextDocumentContentProvider(services, builtinScheme)
     },
     workspace: {
         WorkspaceManager: (services) => new DomainModelWorkspaceManager(services)

--- a/examples/domainmodel/src/language-server/domain-model-workspace-manager.ts
+++ b/examples/domainmodel/src/language-server/domain-model-workspace-manager.ts
@@ -1,0 +1,26 @@
+/******************************************************************************
+ * Copyright 2026 TypeFox GmbH
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License, which is available in the project root.
+ ******************************************************************************/
+
+import { DefaultWorkspaceManager, URI, type LangiumDocument, type LangiumDocumentFactory, type WorkspaceFolder } from 'langium';
+import type { LangiumSharedServices } from 'langium/lsp';
+
+export class DomainModelWorkspaceManager extends DefaultWorkspaceManager {
+
+    private readonly documentFactory: LangiumDocumentFactory;
+
+    constructor(services: LangiumSharedServices) {
+        super(services);
+        this.documentFactory = services.workspace.LangiumDocumentFactory;
+    }
+
+    protected override async loadAdditionalDocuments(_folders: WorkspaceFolder[], collector: (document: LangiumDocument) => void): Promise<void> {
+        const document = this.documentFactory.fromString(
+            'datatype Int',
+            URI.parse('domain-model://domainmodel/Int.dmodel')
+        );
+        collector(document);
+    }
+}

--- a/examples/domainmodel/src/language-server/domain-model-workspace-manager.ts
+++ b/examples/domainmodel/src/language-server/domain-model-workspace-manager.ts
@@ -7,6 +7,8 @@
 import { DefaultWorkspaceManager, URI, type LangiumDocument, type LangiumDocumentFactory, type WorkspaceFolder } from 'langium';
 import type { LangiumSharedServices } from 'langium/lsp';
 
+export const builtinScheme = 'domain-model';
+
 export class DomainModelWorkspaceManager extends DefaultWorkspaceManager {
 
     private readonly documentFactory: LangiumDocumentFactory;
@@ -19,7 +21,7 @@ export class DomainModelWorkspaceManager extends DefaultWorkspaceManager {
     protected override async loadAdditionalDocuments(_folders: WorkspaceFolder[], collector: (document: LangiumDocument) => void): Promise<void> {
         const document = this.documentFactory.fromString(
             'datatype Int',
-            URI.parse('domain-model://domainmodel/Int.dmodel')
+            URI.parse(`${builtinScheme}://domainmodel/Int.dmodel`)
         );
         collector(document);
     }

--- a/packages/langium/src/lsp/index.ts
+++ b/packages/langium/src/lsp/index.ts
@@ -34,6 +34,7 @@ export * from './references-provider.js';
 export * from './rename-provider.js';
 export * from './semantic-token-provider.js';
 export * from './signature-help-provider.js';
+export * from './text-document-content-provider.js';
 export * from './type-hierarchy-provider.js';
 export * from './type-provider.js';
 export * from './workspace-symbol-provider.js';

--- a/packages/langium/src/lsp/language-server.ts
+++ b/packages/langium/src/lsp/language-server.ts
@@ -127,6 +127,7 @@ export class DefaultLanguageServer implements LanguageServer {
         const hasDeclarationProvider = this.hasService(e => e.lsp?.DeclarationProvider);
         const hasInlayHintProvider = this.hasService(e => e.lsp?.InlayHintProvider);
         const workspaceSymbolProvider = this.services.lsp?.WorkspaceSymbolProvider;
+        const textDocumentContentSchemes = this.services.lsp?.TextDocumentContentProvider?.schemes;
 
         const result: InitializeResult = {
             capabilities: {
@@ -134,7 +135,10 @@ export class DefaultLanguageServer implements LanguageServer {
                     workspaceFolders: {
                         supported: true
                     },
-                    fileOperations: fileOperationOptions
+                    fileOperations: fileOperationOptions,
+                    textDocumentContent: textDocumentContentSchemes ? {
+                        schemes: textDocumentContentSchemes
+                    } : undefined
                 },
                 executeCommandProvider: commandNames && {
                     commands: commandNames
@@ -292,6 +296,7 @@ export function startLanguageServer(services: LangiumSharedServices, serviceRequ
     addCallHierarchyHandler(connection, services, serviceRequirements.CallHierarchyProvider);
     addTypeHierarchyHandler(connection, services, serviceRequirements.TypeHierarchyProvider);
     addCodeLensHandler(connection, services, serviceRequirements.CodeLensProvider);
+    addTextDocumentContentRequestHandler(connection, services);
     addDocumentLinkHandler(connection, services, serviceRequirements.DocumentLinkProvider);
     addConfigurationChangeHandler(connection, services);
     addGoToDeclarationHandler(connection, services, serviceRequirements.DeclarationProvider);
@@ -592,6 +597,20 @@ export function addCodeLensHandler(connection: Connection, services: LangiumShar
         services,
         requiredState
     ));
+}
+
+export function addTextDocumentContentRequestHandler(connection: Connection, services: LangiumSharedServices): void {
+    connection.workspace.textDocumentContent.on(async (params, token) => {
+        const textContentProvider = services.lsp?.TextDocumentContentProvider;
+        if (textContentProvider) {
+            try {
+                return await textContentProvider.provideTextDocumentContent(params, token);
+            } catch (err) {
+                return responseError(err);
+            }
+        }
+        return null;
+    });
 }
 
 export function addWorkspaceSymbolHandler(connection: Connection, services: LangiumSharedServices, requiredState: ServiceRequirement = WorkspaceState.IndexedContent): void {

--- a/packages/langium/src/lsp/lsp-services.ts
+++ b/packages/langium/src/lsp/lsp-services.ts
@@ -35,6 +35,7 @@ import type { TypeHierarchyProvider } from './type-hierarchy-provider.js';
 import type { TypeDefinitionProvider } from './type-provider.js';
 import type { WorkspaceSymbolProvider } from './workspace-symbol-provider.js';
 import type { NotebookDocuments, TextDocuments } from './normalized-text-documents.js';
+import type { TextDocumentContentProvider } from './text-document-content-provider.js';
 
 /**
  * Combined Core + LSP services of Langium (total services)
@@ -87,6 +88,7 @@ export type LangiumSharedLSPServices = {
         readonly FuzzyMatcher: FuzzyMatcher
         readonly LanguageServer: LanguageServer
         readonly NodeKindProvider: NodeKindProvider
+        readonly TextDocumentContentProvider?: TextDocumentContentProvider
         readonly WorkspaceSymbolProvider?: WorkspaceSymbolProvider
     },
     readonly workspace: {

--- a/packages/langium/src/lsp/text-document-content-provider.ts
+++ b/packages/langium/src/lsp/text-document-content-provider.ts
@@ -6,7 +6,7 @@
 
 import type { CancellationToken, TextDocumentContentParams, TextDocumentContentResult } from 'vscode-languageserver-protocol';
 import { URI } from 'vscode-uri';
-import type { LangiumDocuments } from '../workspace/index.js';
+import type { LangiumDocuments, WorkspaceManager } from '../workspace/index.js';
 import type { LangiumSharedServices } from './lsp-services.js';
 
 /**
@@ -39,15 +39,19 @@ export interface TextDocumentContentProvider {
 export class DefaultTextDocumentContentProvider implements TextDocumentContentProvider {
 
     private readonly langiumDocuments: LangiumDocuments;
+    private readonly workspaceManager: WorkspaceManager;
 
     readonly schemes: string[];
 
     constructor(services: LangiumSharedServices, schemes: string[]) {
         this.langiumDocuments = services.workspace.LangiumDocuments;
+        this.workspaceManager = services.workspace.WorkspaceManager;
         this.schemes = schemes;
     }
 
     async provideTextDocumentContent(params: TextDocumentContentParams, _cancellationToken: CancellationToken): Promise<TextDocumentContentResult | undefined> {
+        // Ensure that documents are loaded before attempting to retrieve the content of a document.
+        await this.workspaceManager.ready;
         const uri = URI.parse(params.uri);
         if (!this.schemes.includes(uri.scheme)) {
             return undefined;

--- a/packages/langium/src/lsp/text-document-content-provider.ts
+++ b/packages/langium/src/lsp/text-document-content-provider.ts
@@ -1,0 +1,61 @@
+/******************************************************************************
+ * Copyright 2026 TypeFox GmbH
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License, which is available in the project root.
+ ******************************************************************************/
+
+import type { CancellationToken, TextDocumentContentParams, TextDocumentContentResult } from 'vscode-languageserver-protocol';
+import { URI } from 'vscode-uri';
+import type { LangiumDocuments } from '../workspace/index.js';
+import type { LangiumSharedServices } from './lsp-services.js';
+
+/**
+ * Shared service for handling the LSP text document content request.
+ * It allows clients to request the content of a text document given its URI.
+ *
+ * This is useful for scenarios where a reference is pointing to a virtual document (such as a builtin library).
+ * The client can request the content of that document using this service, without needing to implement a dedicated
+ * file system provider on the client side or other means of accessing the document content.
+ */
+export interface TextDocumentContentProvider {
+    /**
+     * The URI schemes that this provider supports.
+     */
+    readonly schemes: string[];
+    /**
+     * Returns the text content of a file given its URI.
+     */
+    provideTextDocumentContent(params: TextDocumentContentParams, cancellationToken: CancellationToken): Promise<TextDocumentContentResult | undefined>;
+}
+
+/**
+ * Default implementation of the `TextDocumentContentProvider` interface.
+ * It retrieves the content of a text document from the `LangiumDocuments` service based on the provided URI.
+ * If the document is not found or the URI scheme is not supported, it returns `undefined`.
+ *
+ * This implementation is designed for use cases where the language server already registered virtual documents
+ * in the `LangiumDocuments` service - for example, in `loadAdditionalDocuments` of the `DefaultWorkspaceManager`.
+ */
+export class DefaultTextDocumentContentProvider implements TextDocumentContentProvider {
+
+    private readonly langiumDocuments: LangiumDocuments;
+
+    readonly schemes: string[];
+
+    constructor(services: LangiumSharedServices, schemes: string[]) {
+        this.langiumDocuments = services.workspace.LangiumDocuments;
+        this.schemes = schemes;
+    }
+
+    async provideTextDocumentContent(params: TextDocumentContentParams, _cancellationToken: CancellationToken): Promise<TextDocumentContentResult | undefined> {
+        const uri = URI.parse(params.uri);
+        if (!this.schemes.includes(uri.scheme)) {
+            return undefined;
+        }
+        const document = this.langiumDocuments.getDocument(uri);
+        if (!document) {
+            return undefined;
+        }
+        return { text: document.textDocument.getText() };
+    }
+}

--- a/packages/langium/src/lsp/text-document-content-provider.ts
+++ b/packages/langium/src/lsp/text-document-content-provider.ts
@@ -43,7 +43,7 @@ export class DefaultTextDocumentContentProvider implements TextDocumentContentPr
 
     readonly schemes: string[];
 
-    constructor(services: LangiumSharedServices, schemes: string[]) {
+    constructor(services: LangiumSharedServices, ...schemes: string[]) {
         this.langiumDocuments = services.workspace.LangiumDocuments;
         this.workspaceManager = services.workspace.WorkspaceManager;
         this.schemes = schemes;


### PR DESCRIPTION
Adds support for the recent LSP 3.18 `workspace/textDocumentContent` request. Allows to circumvent the need for a dedicated file system provider for the given URI scheme in favor of implementing this request.

Can be (temporarily) tested by trying it out in the domainmodel example. Use the `Int` datatype somewhere and go to its definition to see how it works.