### PR TITLE
Sort keywords by length first (#2193)

### DIFF
--- a/examples/arithmetics/syntaxes/arithmetics.monarch.ts
+++ b/examples/arithmetics/syntaxes/arithmetics.monarch.ts
@@ -6,7 +6,7 @@ export default {
     operators: [
         '%','*','+',',','-','/',':',';','^'
     ],
-    symbols: /%|\(|\)|\*|\+|,|-|\/|:|;|\^/,
+    symbols: /-|,|;|:|\(|\)|\*|\/|%|\^|\+/,
 
     tokenizer: {
         initial: [

--- a/examples/arithmetics/syntaxes/arithmetics.monarch.ts
+++ b/examples/arithmetics/syntaxes/arithmetics.monarch.ts
@@ -1,10 +1,10 @@
 // Monarch syntax highlighting for the arithmetics language.
 export default {
     keywords: [
-        'def','module'
+        'module','def'
     ],
     operators: [
-        '%','*','+',',','-','/',':',';','^'
+        '-',',',';',':','*','/','%','^','+'
     ],
     symbols: /-|,|;|:|\(|\)|\*|\/|%|\^|\+/,
 

--- a/examples/arithmetics/syntaxes/arithmetics.tmLanguage.json
+++ b/examples/arithmetics/syntaxes/arithmetics.tmLanguage.json
@@ -10,7 +10,7 @@
     },
     {
       "name": "keyword.control.arithmetics",
-      "match": "(?i)\\b(def|module)\\b"
+      "match": "(?i)\\b(module|def)\\b"
     }
   ],
   "repository": {

--- a/examples/domainmodel/syntaxes/domain-model.tmLanguage.json
+++ b/examples/domainmodel/syntaxes/domain-model.tmLanguage.json
@@ -10,7 +10,7 @@
     },
     {
       "name": "keyword.control.domain-model",
-      "match": "\\b(datatype|entity|extends|many|package)\\b"
+      "match": "\\b(datatype|extends|package|entity|many)\\b"
     }
   ],
   "repository": {

--- a/examples/domainmodel/syntaxes/domainmodel.monarch.ts
+++ b/examples/domainmodel/syntaxes/domainmodel.monarch.ts
@@ -1,12 +1,12 @@
 // Monarch syntax highlighting for the domain-model language.
 export default {
     keywords: [
-        'datatype','entity','extends','many','package'
+        'datatype','extends','package','entity','many'
     ],
     operators: [
-        '.',':'
+        ':','.'
     ],
-    symbols: /\.|:|\{|\}/,
+    symbols: /:|\.|\{|\}/,
 
     tokenizer: {
         initial: [

--- a/examples/requirements/syntaxes/requirements.tmLanguage.json
+++ b/examples/requirements/syntaxes/requirements.tmLanguage.json
@@ -10,7 +10,7 @@
     },
     {
       "name": "keyword.control.requirements-lang",
-      "match": "\\b(applicable|contact|environment|for|req)\\b"
+      "match": "\\b(environment|applicable|contact|for|req)\\b"
     },
     {
       "name": "string.quoted.double.requirements-lang",

--- a/examples/requirements/syntaxes/tests.tmLanguage.json
+++ b/examples/requirements/syntaxes/tests.tmLanguage.json
@@ -10,7 +10,7 @@
     },
     {
       "name": "keyword.control.tests-lang",
-      "match": "\\b(applicable|contact|for|testFile|tests|tst)\\b"
+      "match": "\\b(applicable|testFile|contact|tests|for|tst)\\b"
     },
     {
       "name": "string.quoted.double.tests-lang",

--- a/examples/statemachine/syntaxes/statemachine.monarch.ts
+++ b/examples/statemachine/syntaxes/statemachine.monarch.ts
@@ -1,7 +1,7 @@
 // Monarch syntax highlighting for the statemachine language.
 export default {
     keywords: [
-        'actions','commands','end','events','initialState','state','statemachine'
+        'initialState','statemachine','commands','actions','events','state','end'
     ],
     operators: [
         '=>'

--- a/examples/statemachine/syntaxes/statemachine.tmLanguage.json
+++ b/examples/statemachine/syntaxes/statemachine.tmLanguage.json
@@ -10,7 +10,7 @@
     },
     {
       "name": "keyword.control.statemachine",
-      "match": "\\b(actions|commands|end|events|initialState|state|statemachine)\\b"
+      "match": "\\b(initialState|statemachine|commands|actions|events|state|end)\\b"
     }
   ],
   "repository": {

--- a/packages/langium-cli/src/generator/langium-util.ts
+++ b/packages/langium-cli/src/generator/langium-util.ts
@@ -34,7 +34,15 @@ export function collectKeywords(grammar: Grammar): string[] {
         keywords.add(keyword.value);
     }
 
-    return Array.from(keywords).sort();
+    // Sort keywords by length (longer first) and then alphabetically to make sure
+    // highlighting works correctly for keywords that are substrings of other keywords
+    // (e.g. 'if' and 'if-def').
+    return Array.from(keywords).sort((a, b) => {
+        if (a.length === b.length) {
+            return a.localeCompare(b);
+        }
+        return b.length - a.length;
+    });
 }
 
 export function collectTerminalRegexps(grammar: Grammar): Record<string, RegExp> {


### PR DESCRIPTION
To make sure keywords who start with the same character sequence as another (shorter) keyword the keywords are sorted by length (longest first) and then lexical.

fixes #2193 