### PR TITLE
Fix multiple file extensions in Langium generator

### DIFF
--- a/packages/generator-langium/src/index.ts
+++ b/packages/generator-langium/src/index.ts
@@ -204,7 +204,8 @@ export class LangiumGenerator extends Generator {
                     .map(ext => ext.replace(/\./g, '').trim()),
             )
         );
-        this.answers.fileExtensions = `[${fileExtensions.map(ext => `".${ext}"`).join(', ')}]`;
+        const fileExtensionsWithDot = fileExtensions.map(ext => `.${ext}`);
+        this.answers.fileExtensions = `[${fileExtensionsWithDot.map(ext => `"${ext}"`).join(', ')}]`;
 
         const fileExtensionGlob = fileExtensions.length > 1 ? `{${fileExtensions.join(',')}}` : fileExtensions[0];
 
@@ -272,7 +273,7 @@ export class LangiumGenerator extends Generator {
             languages: [{
                 id: languageId,
                 grammar: `src/${languageId}.langium`,
-                fileExtensions: [ fileExtensionGlob ],
+                fileExtensions: fileExtensionsWithDot,
                 textMate: {
                     out: `syntaxes/${languageId}.tmLanguage.json`
                 }

--- a/packages/generator-langium/test/yeoman-generator.test.ts
+++ b/packages/generator-langium/test/yeoman-generator.test.ts
@@ -77,7 +77,7 @@ describe('Check yeoman generator works', () => {
         targetRoot + '/packages/extension/tsconfig.json'
     ];
 
-    test('1 Should produce files for workspace and language (no test)', async () => {
+    test('1 Should produce files for workspace and language with multiple extensions (no test)', async () => {
         const context = createHelpers({}).run(path.join(moduleRoot));
 
         // generate in examples
@@ -97,7 +97,10 @@ describe('Check yeoman generator works', () => {
                 // just for double checking
                 console.log(`Generating into directory: ${workingDir}`);
             })
-            .withAnswers(answersForCore)
+            .withAnswers({
+                ...answersForCore,
+                fileExtensions: '.hello, .world'
+            })
             // speed up tests by skipping install
             .withArguments('skip-install')
             // speed up tests by skipping build
@@ -110,6 +113,16 @@ describe('Check yeoman generator works', () => {
 
                 result.assertJsonFileContent(projectRoot + '/package.json', PACKAGE_JSON_EXPECTATION);
                 result.assertFileContent(projectRoot + '/.vscode/tasks.json', TASKS_JSON_EXPECTATION);
+
+                result.assertJsonFileContent(projectRoot + '/packages/language/langium-config.json', {
+                    languages: [{
+                        fileExtensions: ['.hello', '.world']
+                    }]
+                });
+                result.assertFileContent(
+                    projectRoot + '/packages/language/src/generated/module.ts',
+                    "fileExtensions: ['.hello', '.world'],"
+                );
             }).finally(() => {
                 // clean-up examples/generator-tests/test1/hello-world
                 context.cleanTestDirectory(true);


### PR DESCRIPTION
Fixes #2198

Keep each extension entered in the Yeoman prompt as a separate entry in
`fileExtensions`.

Adds a test for the generated `langium-config.json` and `LanguageMetaData`.