### PR TITLE
fix(cli): add $id to langium-config-schema.json for jsonschema 1.5.0+ compatibility

### DIFF
--- a/packages/langium-cli/langium-config-schema.json
+++ b/packages/langium-cli/langium-config-schema.json
@@ -1,5 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft-07/schema#",
+    "$id": "https://langium.org/schema/langium-config.json",
     "$defs": {
         "chevrotainParserConfig": {
             "description": "An object to describe the Chevrotain parser configuration",


### PR DESCRIPTION
## Summary

Adds a top-level `$id` to `packages/langium-cli/langium-config-schema.json`, which is required by `jsonschema@1.5.0+` for resolving internal `$ref` pointers.

## Motivation

`jsonschema@1.5.0` introduced stricter URL validation for `$ref` resolution. When a schema has no top-level `$id`, the validator constructs an invalid base URI (`/undefined`) and throws `TypeError: Invalid URL` when resolving internal `$ref` pointers like `#/$defs/languageItem`.

This breaks `langium generate` for any project that resolves `jsonschema` to 1.5.0 (the version `langium-cli` itself depends on via `~1.5.0`). Downstream projects are forced to pin `jsonschema` to `1.4.1` via pnpm/yarn overrides as a workaround (e.g. cogna-co/core2#23528).

## Root cause

`langium-config-schema.json` declares `$schema` (the draft) but no `$id` (the schema's own identifier). The JSON Schema spec recommends an absolute-URI `$id` at the root so that relative `$ref`s resolve against a valid base. Without it, `jsonschema`'s `resolveUrl('', '#/$defs/...')` falls back to the anonymous base `/`, which on Node.js <21 (V8 <130, Chrome <130) throws `TypeError [ERR_INVALID_URL]: Invalid URL` inside `new URL('/', 'resolve://')`.

On Node.js >=21 (V8 >=130) the `new URL('/', 'resolve://')` call succeeds, so the bug is environment-dependent and doesn't reproduce everywhere — which is why it slipped through.

## Rationale

Adding `"$id": "https://langium.org/schema/langium-config.json"` provides a valid absolute base URI for `$ref` resolution, unblocking `jsonschema@1.5.0+` without any downstream pins. This is also the JSON Schema best practice for root schemas.

## Verification

- Schema is valid JSON with the new `$id` at the root.
- `validate(config, schema, { nestedErrors: true })` with `jsonschema@1.5.0`:
  - Valid config: passes, no throw.
  - Invalid config (forces `$ref` resolution + error reporting): correctly reports errors, no throw.
  - Bad `chevrotainParserConfig` (forces `$ref: #/$defs/chevrotainParserConfig`): correctly reports error, no throw.
- `langium generate` succeeds with the patched schema + `jsonschema@1.5.0`.

## Checklist

- [x] ECA signed (or will sign before requesting review)
- [x] `Signed-off-by` present on commit