### PR TITLE
Fix VS Code ignore patterns during workspace indexing

### DIFF
--- a/packages/langium-vscode/src/language-server/grammar-workspace-manager.ts
+++ b/packages/langium-vscode/src/language-server/grammar-workspace-manager.ts
@@ -53,7 +53,7 @@ export class LangiumGrammarWorkspaceManager extends DefaultWorkspaceManager {
     }
 
     override shouldIncludeEntry(entry: FileSystemNode): boolean {
-        const workspaceFolder = this.workspaceFolders?.find(folder => UriUtils.contains(folder.uri, entry.uri));
+        const workspaceFolder = this.workspaceFolders?.find(folder => UriUtils.contains(URI.parse(folder.uri), entry.uri));
         if (this.matcher && workspaceFolder) {
             // create path relative to workspace folder root: /user/foo/workspace/entry.txt -> entry.txt
             const relPath = path.relative(URI.parse(workspaceFolder.uri).path, entry.uri.path);

--- a/packages/langium-vscode/src/language-server/grammar-workspace-manager.ts
+++ b/packages/langium-vscode/src/language-server/grammar-workspace-manager.ts
@@ -53,7 +53,7 @@ export class LangiumGrammarWorkspaceManager extends DefaultWorkspaceManager {
     }
 
     override shouldIncludeEntry(entry: FileSystemNode): boolean {
-        const workspaceFolder = this.workspaceFolders?.find(folder => UriUtils.contains(URI.parse(folder.uri), entry.uri));
+        const workspaceFolder = this.workspaceFolders?.find(folder => UriUtils.contains(folder.uri, entry.uri));
         if (this.matcher && workspaceFolder) {
             // create path relative to workspace folder root: /user/foo/workspace/entry.txt -> entry.txt
             const relPath = path.relative(URI.parse(workspaceFolder.uri).path, entry.uri.path);

--- a/packages/langium/src/utils/uri-utils.ts
+++ b/packages/langium/src/utils/uri-utils.ts
@@ -58,8 +58,13 @@ export namespace UriUtils {
     }
 
     export function contains(parent: URI | string, child: URI | string): boolean {
-        let parentPath = typeof parent === 'string' ? parent : parent.path;
-        let childPath = typeof child === 'string' ? child : child.path;
+        const parentUri = typeof parent === 'string' ? URI.parse(parent) : parent;
+        const childUri = typeof child === 'string' ? URI.parse(child) : child;
+        if (parentUri.scheme !== childUri.scheme) {
+            return false;
+        }
+        let parentPath = parentUri.path;
+        let childPath = childUri.path;
         // Trim trailing slashes
         if (childPath.charAt(childPath.length - 1) === '/') {
             childPath = childPath.slice(0, -1);

--- a/packages/langium/test/utils/uri-utils.test.ts
+++ b/packages/langium/test/utils/uri-utils.test.ts
@@ -132,6 +132,8 @@ describe('URIUtils#contains', () => {
         const parent = 'file:///path/to';
         const child = 'file:///path/to/file';
         expect(UriUtils.contains(parent, child)).toBeTruthy();
+        expect(UriUtils.contains(parent, URI.parse(child))).toBeTruthy();
+        expect(UriUtils.contains(URI.parse(parent), child)).toBeTruthy();
     });
 
     test('Should return true for child URIs with trailing slashes', () => {
@@ -150,6 +152,12 @@ describe('URIUtils#contains', () => {
         const parent = 'file:///path/to/directory';
         const unrelated = 'file:///path/to/other';
         expect(UriUtils.contains(parent, unrelated)).toBeFalsy();
+    });
+
+    test('Should return false for URIs with different schemes', () => {
+        const parent = URI.parse('file:///path/to');
+        const child = URI.parse('test:///path/to/file');
+        expect(UriUtils.contains(parent, child)).toBeFalsy();
     });
 
 });


### PR DESCRIPTION
`langium.build.ignorePatterns` was ignored during initial workspace indexing. Workspace folder URIs arrive as strings, while file entries use URI objects, so the containment check never matched them.

This change parses the workspace folder URI before checking it against each entry.

<details>
<summary>Before</summary>

<img width="1152" height="768" alt="langium-ignore-patterns-repro" src="https://github.com/user-attachments/assets/aba24dd7-8118-4275-bf7f-bfbe4a481ab1" />

</details>

<details>
<summary>After</summary>

<img width="1440" height="900" alt="langium-ignore-patterns-fixed" src="https://github.com/user-attachments/assets/07b27dde-69bc-4fd5-b9ae-d1da5cb10b58" />

</details>