### PR TITLE
Extended existing assertions to accept error messages, which are calculated on-demand

### DIFF
--- a/packages/langium/src/utils/errors.ts
+++ b/packages/langium/src/utils/errors.ts
@@ -7,17 +7,18 @@
 import type { CstNode } from '../syntax-tree.js';
 
 export class ErrorWithLocation extends Error {
-    constructor(node: CstNode | undefined, message: string) {
-        super(node ? `${message} at ${node.range.start.line}:${node.range.start.character}` : message);
+    constructor(node: CstNode | undefined, message: string | (() => string)) {
+        const msg = typeof message === 'string' ? message : message();
+        super(node ? `${msg} at ${node.range.start.line}:${node.range.start.character}` : msg);
     }
 }
 
-export function assertUnreachable(_: never, message = 'Error: Got unexpected value.'): never {
-    throw new Error(message);
+export function assertUnreachable(_: never, message: string | (() => string) = 'Error: Got unexpected value.'): never {
+    throw new Error(typeof message === 'string' ? message : message());
 }
 
-export function assertCondition(condition: boolean, message: string = 'Error: Condition is violated.'): asserts condition {
+export function assertCondition(condition: boolean, message: string | (() => string) = 'Error: Condition is violated.'): asserts condition {
     if (!condition) {
-        throw new Error(message);
+        throw new Error(typeof message === 'string' ? message : message());
     }
 }


### PR DESCRIPTION
This enables to define demanding error messages, which are lazily calculated on-demand to save some performance.