### PR TITLE
Fixed edge case in MapScope: Don't use outer scope, if it is disabled

### DIFF
--- a/packages/langium/src/references/scope.ts
+++ b/packages/langium/src/references/scope.ts
@@ -139,7 +139,7 @@ export class MapScope implements Scope {
         const localName = this.caseInsensitive ? name.toLowerCase() : name;
         const local = this.elements.get(localName);
         const arr = local ? [local] : [];
-        if ((this.concatOuterScope || arr.length > 0) && this.outerScope) {
+        if ((this.concatOuterScope || arr.length === 0) && this.outerScope) {
             return stream(arr).concat(this.outerScope.getElements(name));
         } else {
             return stream(arr);

--- a/packages/langium/test/references/scope.test.ts
+++ b/packages/langium/test/references/scope.test.ts
@@ -1,0 +1,49 @@
+/******************************************************************************
+ * Copyright 2026 TypeFox GmbH
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License, which is available in the project root.
+ ******************************************************************************/
+
+import { describe, expect, test } from 'vitest';
+import { MapScope } from '../../src/references/scope.js';
+import type { AstNodeDescription } from '../../src/syntax-tree.js';
+
+describe('Tests the default map scope implementation', () => {
+    const description: AstNodeDescription = {
+        name: 'MyName',
+        type: 'Type1',
+        documentUri: undefined!,
+        path: undefined!,
+    };
+
+    test('Do not use a given outer scope, if using the outer scope is disabled by option', async () => {
+        const outerScope = new MapScope([description]);
+        // the outer scope is given, but deactivated by the option
+        const innerScope = new MapScope([description], outerScope, { concatOuterScope: false });
+        const items = innerScope.getElements('MyName').toArray();
+        // we expect only a single description from the inner scope
+        expect(items).toHaveLength(1);
+    });
+
+    test('Outer scope is used, when requested', async () => {
+        const outerScope = new MapScope([description]);
+        const innerScope = new MapScope([description], outerScope, { concatOuterScope: true });
+        const items = innerScope.getElements('MyName').toArray();
+        expect(items).toHaveLength(2);
+    });
+
+    test('Outer scope is used, when inner scope is empty', async () => {
+        const outerScope = new MapScope([description]);
+        const innerScope = new MapScope([/* empty! */], outerScope, { concatOuterScope: false });
+        const items = innerScope.getElements('MyName').toArray();
+        expect(items).toHaveLength(1);
+    });
+
+    test('Outer scope is used, when requested and inner scope is empty', async () => {
+        const outerScope = new MapScope([description]);
+        const innerScope = new MapScope([/* empty! */], outerScope, { concatOuterScope: true });
+        const items = innerScope.getElements('MyName').toArray();
+        expect(items).toHaveLength(1);
+    });
+
+});


### PR DESCRIPTION
The `MapScope` allows to disable a given outer scope under certain conditions by a dedicated option:
- Fixed an edge case, since the outer scope was applied, even when disabled by option.
- Targets only `getElements` for multi-refs
- Added test case for this scenario