### PR TITLE
Completion provider supports both insert and replace mode now

### DIFF
--- a/packages/langium/src/lsp/completion/completion-provider.ts
+++ b/packages/langium/src/lsp/completion/completion-provider.ts
@@ -4,7 +4,7 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import type { CompletionItem, CompletionParams, TextEdit } from 'vscode-languageserver-protocol';
+import type { CompletionClientCapabilities, CompletionItem, CompletionParams, InitializeParams, InsertReplaceEdit, TextEdit } from 'vscode-languageserver-protocol';
 import type { LangiumCompletionParser } from '../../parser/langium-parser.js';
 import type { NameProvider } from '../../references/name-provider.js';
 import type { ScopeProvider } from '../../references/scope-provider.js';
@@ -135,6 +135,7 @@ export class DefaultCompletionProvider implements CompletionProvider {
     protected readonly fuzzyMatcher: FuzzyMatcher;
     protected readonly grammarConfig: GrammarConfig;
     protected readonly astReflection: AstReflection;
+    protected clientCapabilities?: CompletionClientCapabilities;
     readonly completionOptions?: CompletionProviderOptions;
 
     constructor(services: LangiumServices) {
@@ -148,6 +149,14 @@ export class DefaultCompletionProvider implements CompletionProvider {
         this.grammarConfig = services.parser.GrammarConfig;
         this.astReflection = services.shared.AstReflection;
         this.documentationProvider = services.documentation.DocumentationProvider;
+
+        services.shared.lsp.LanguageServer.onInitialize(params => {
+            this.initialize(params);
+        });
+    }
+
+    protected initialize(params: InitializeParams): void {
+        this.clientCapabilities = params.capabilities.textDocument?.completion;
     }
 
     async getCompletion(document: LangiumDocument, params: CompletionParams, _cancelToken?: CancellationToken): Promise<CompletionList | undefined> {
@@ -595,7 +604,41 @@ export class DefaultCompletionProvider implements CompletionProvider {
         return completionItem;
     }
 
-    protected buildCompletionTextEdit(context: CompletionContext, label: string, newText: string): TextEdit | undefined {
+    protected buildCompletionTextEdit(context: CompletionContext, label: string, newText: string): TextEdit | InsertReplaceEdit | undefined {
+        if (this.clientCapabilities?.completionItem?.insertReplaceSupport) {
+            return this.buildCompletionTextEditWithInsertReplace(context, label, newText);
+        } else {
+            return this.buildCompletionTextEditWithoutInsertReplace(context, label, newText);
+        }
+    }
+
+    /**
+     * Returns an {@link InsertReplaceEdit} to enable clients to pick either the insert {@link TextEdit} or the replace {@link TextEdit},
+     * depending on the editor's insert/replace mode.
+     * Note that the token part to the left of the cursor will be overwritten in both modes.
+     */
+    protected buildCompletionTextEditWithInsertReplace(context: CompletionContext, label: string, newText: string): InsertReplaceEdit | undefined {
+        const start = context.textDocument.positionAt(context.tokenOffset);
+        const cursor = context.position;
+        const identifier = context.textDocument.getText({ start, end: cursor });
+        if (this.fuzzyMatcher.match(identifier, label)) {
+            const tokenEnd = context.textDocument.positionAt(context.tokenEndOffset);
+            return {
+                newText,
+                insert: { start, end: cursor },
+                replace: { start, end: tokenEnd }
+            };
+        } else {
+            return undefined;
+        }
+    }
+
+    /**
+     * A {@link TextEdit} is returned for clients without insert/replace mode configuration.
+     * The range of a {@link TextEdit} ends at the cursor position,
+     * so the suffix of an identifier after the cursor (e.g. `Pos|ition`) is never replaced.
+     */
+    protected buildCompletionTextEditWithoutInsertReplace(context: CompletionContext, label: string, newText: string): TextEdit | undefined {
         const content = context.textDocument.getText();
         const identifier = content.substring(context.tokenOffset, context.offset);
         if (this.fuzzyMatcher.match(identifier, label)) {

--- a/packages/langium/test/lsp/completion-provider.test.ts
+++ b/packages/langium/test/lsp/completion-provider.test.ts
@@ -4,10 +4,10 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import { describe, test, beforeEach } from 'vitest';
+import { describe, test, beforeEach, expect } from 'vitest';
 import type { AstNode, AstNodeDescription, GrammarAST, LangiumDocument, Module, ReferenceInfo } from 'langium';
-import { DefaultAstNodeDescriptionProvider, EmptyFileSystem } from 'langium';
-import { createLangiumGrammarServices, createServicesForGrammar } from 'langium/grammar';
+import { assertCondition, DefaultAstNodeDescriptionProvider, EmptyFileSystem, TextDocument } from 'langium';
+import { createLangiumGrammarServices, createServicesForGrammar, type LangiumGrammarServices } from 'langium/grammar';
 import { DefaultCompletionProvider } from 'langium/lsp';
 import type { CompletionContext, LangiumServices, PartialLangiumServices } from 'langium/lsp';
 import { clearDocuments, expectCompletion, parseHelper } from 'langium/test';
@@ -99,6 +99,93 @@ describe('Langium completion provider', () => {
             text: model,
             index: 1,
             expectedItems: []
+        });
+    });
+});
+
+describe('Insert mode', () => {
+
+    const text = `
+    <|>gramm<|>ar g hid<|>den(hiddenTerminal)
+    X: name="X";
+    terminal hiddenTerminal: /x/;
+    `;
+
+    let grammarServices: LangiumGrammarServices;
+    let completion: ReturnType<typeof expectCompletion>;
+
+    beforeEach(async () => {
+        grammarServices = createLangiumGrammarServices(EmptyFileSystem).grammar;
+        completion = expectCompletion(grammarServices);
+    });
+
+    test('Without insert/replace mode', async () => {
+        // Without language client, client capabilities are not specified
+        // => insert/replace mode is not enabled here by default
+        await completion({
+            text,
+            index: 1,
+            expectedItems: [
+                'grammar'
+            ]
+        });
+        // check the positions, where to apply the proposed completion:
+        await completion({
+            text,
+            index: 1,
+            assert: (completions) => {
+                expect(completions.items).toHaveLength(1);
+                const edit = completions.items[0].textEdit;
+                assertCondition(edit !== undefined);
+                expect(edit.newText).toBe('grammar');
+                assertCondition('range' in edit);
+                const textDocument = grammarServices.shared.workspace.LangiumDocuments.all.toArray()[0].textDocument;
+                // The TextEdit behaves like an "insert":
+                // inserts the completion item at the cursor position and keeps the already existing "ar" right of the cursor
+                expect(edit.range.start.character).toBe(4);
+                expect(edit.range.end.character).toBe(9);
+                const inserted = TextDocument.applyEdits(textDocument, [{ range: edit.range, newText: edit.newText }]);
+                expect(inserted.includes('grammarar g hid'), inserted).toBe(true);
+            }
+        });
+    });
+
+    test('With insert/replace mode', async () => {
+        // explicitly enable the insert/replace mode:
+        grammarServices.shared.lsp.LanguageServer.initialize({
+            processId: null,
+            rootUri: null,
+            capabilities: { textDocument: { completion: { completionItem: { insertReplaceSupport: true } }}}
+        });
+        await completion({
+            text,
+            index: 1,
+            expectedItems: [
+                'grammar'
+            ]
+        });
+        // check the positions, where to apply the proposed completion:
+        await completion({
+            text,
+            index: 1,
+            assert: (completions) => {
+                expect(completions.items).toHaveLength(1);
+                const edit = completions.items[0].textEdit;
+                assertCondition(edit !== undefined);
+                expect(edit.newText).toBe('grammar');
+                assertCondition('insert' in edit);
+                const textDocument = grammarServices.shared.workspace.LangiumDocuments.all.toArray()[0].textDocument;
+                // replace: replaces the current token and removes the already existing "ar" right of the cursor
+                expect(edit.replace.start.character).toBe(4);
+                expect(edit.replace.end.character).toBe(11);
+                const replaced = TextDocument.applyEdits(textDocument, [{ range: edit.replace, newText: edit.newText }]);
+                expect(replaced.includes('grammar g hid'), replaced).toBe(true);
+                // insert: inserts the completion item at the cursor position and keeps the already existing "ar" right of the cursor
+                expect(edit.insert.start.character).toBe(4);
+                expect(edit.insert.end.character).toBe(9);
+                const inserted = TextDocument.applyEdits(textDocument, [{ range: edit.insert, newText: edit.newText }]);
+                expect(inserted.includes('grammarar g hid'), inserted).toBe(true);
+            }
         });
     });
 });


### PR DESCRIPTION
Fixes #1924 

The default completion provider supports the editor's insert/replace suggestion mode now.
In VS Code, this setting is `editor.suggest.insertMode`.