### PR TITLE
Support priority read requests for LSP requests

### DIFF
--- a/packages/langium/src/lsp/language-server.ts
+++ b/packages/langium/src/lsp/language-server.ts
@@ -33,6 +33,7 @@ import { isOperationCancelled, type MaybePromise } from '../utils/promise-utils.
 import { URI } from '../utils/uri-utils.js';
 import type { ConfigurationInitializedParams } from '../workspace/configuration.js';
 import { DocumentState, type LangiumDocument } from '../workspace/documents.js';
+import { ReadPriority } from '../workspace/workspace-lock.js';
 import { mergeCompletionProviderOptions } from './completion/completion-provider.js';
 import type { LangiumSharedServices, PartialLangiumLSPServices } from './lsp-services.js';
 import { mergeSemanticTokenProviderOptions } from './semantic-token-provider.js';
@@ -603,10 +604,12 @@ export function addWorkspaceSymbolHandler(connection: Connection, services: Lang
         }
 
         const documentBuilder = services.workspace.DocumentBuilder;
+        const mutex = services.workspace.WorkspaceLock;
         connection.onWorkspaceSymbol(async (params, token) => {
             try {
+                // The required workspace state has been awaited, so the read can run concurrently to an ongoing write
                 await documentBuilder.waitUntil(requiredState.state, token);
-                return await workspaceSymbolProvider.getSymbols(params, token);
+                return await mutex.read(() => workspaceSymbolProvider.getSymbols(params, token), ReadPriority.Immediate);
             } catch (err) {
                 return responseError(err);
             }
@@ -616,7 +619,7 @@ export function addWorkspaceSymbolHandler(connection: Connection, services: Lang
             connection.onWorkspaceSymbolResolve(async (workspaceSymbol, token) => {
                 try {
                     await documentBuilder.waitUntil(requiredState.state, token);
-                    return await resolveWorkspaceSymbol(workspaceSymbol, token);
+                    return await mutex.read(() => resolveWorkspaceSymbol(workspaceSymbol, token), ReadPriority.Immediate);
                 } catch (err) {
                     return responseError(err);
                 }
@@ -709,6 +712,7 @@ export function createHierarchyRequestHandler<P extends TypeHierarchySupertypesP
     requiredState?: ServiceRequirement
 ): LangiumServerRequestHandler<P, R, E> {
     const serviceRegistry = sharedServices.ServiceRegistry;
+    const mutex = sharedServices.workspace.WorkspaceLock;
     return async (params: P, cancelToken: CancellationToken) => {
         const uri = URI.parse(params.item.uri);
         const cancellationError = await waitUntilPhase<E>(sharedServices, cancelToken, uri, requiredState);
@@ -722,7 +726,7 @@ export function createHierarchyRequestHandler<P extends TypeHierarchySupertypesP
         }
         const language = serviceRegistry.getServices(uri);
         try {
-            return await serviceCall(language, params, cancelToken) ?? null;
+            return await mutex.read(() => serviceCall(language, params, cancelToken), readPriority(requiredState)) ?? null;
         } catch (err) {
             return responseError<E>(err);
         }
@@ -736,6 +740,7 @@ export function createServerRequestHandler<P extends { textDocument: TextDocumen
 ): LangiumServerRequestHandler<P, R, E> {
     const documents = sharedServices.workspace.LangiumDocuments;
     const serviceRegistry = sharedServices.ServiceRegistry;
+    const mutex = sharedServices.workspace.WorkspaceLock;
     return async (params: P, cancelToken: CancellationToken) => {
         const uri = URI.parse(params.textDocument.uri);
         const cancellationError = await waitUntilPhase<E>(sharedServices, cancelToken, uri, requiredState);
@@ -749,8 +754,10 @@ export function createServerRequestHandler<P extends { textDocument: TextDocumen
         }
         const language = serviceRegistry.getServices(uri);
         try {
-            const document = await documents.getOrCreateDocument(uri);
-            return await serviceCall(language, document, params, cancelToken) ?? null;
+            return await mutex.read(async () => {
+                const document = await documents.getOrCreateDocument(uri);
+                return serviceCall(language, document, params, cancelToken);
+            }, readPriority(requiredState)) ?? null;
         } catch (err) {
             return responseError<E>(err);
         }
@@ -764,6 +771,7 @@ export function createRequestHandler<P extends { textDocument: TextDocumentIdent
 ): LangiumRequestHandler<P, R, E> {
     const documents = sharedServices.workspace.LangiumDocuments;
     const serviceRegistry = sharedServices.ServiceRegistry;
+    const mutex = sharedServices.workspace.WorkspaceLock;
     return async (params: P, cancelToken: CancellationToken) => {
         const uri = URI.parse(params.textDocument.uri);
         const cancellationError = await waitUntilPhase<E>(sharedServices, cancelToken, uri, requiredState);
@@ -776,12 +784,23 @@ export function createRequestHandler<P extends { textDocument: TextDocumentIdent
         }
         const language = serviceRegistry.getServices(uri);
         try {
-            const document = await documents.getOrCreateDocument(uri);
-            return await serviceCall(language, document, params, cancelToken) ?? null;
+            return await mutex.read(async () => {
+                const document = await documents.getOrCreateDocument(uri);
+                return serviceCall(language, document, params, cancelToken);
+            }, readPriority(requiredState)) ?? null;
         } catch (err) {
             return responseError<E>(err);
         }
     };
+}
+
+/**
+ * Handlers that have awaited a required document/workspace state via {@link waitUntilPhase} don't need to wait
+ * until a whole write action (such as a workspace build) has finished — their read can run concurrently to it.
+ * Without a required state, the read has to wait for write actions to ensure a consistent workspace.
+ */
+function readPriority(requiredState?: ServiceRequirement): ReadPriority {
+    return requiredState === undefined ? ReadPriority.Normal : ReadPriority.Immediate;
 }
 
 async function waitUntilPhase<E>(services: LangiumSharedServices, cancelToken: CancellationToken, uri?: URI, requiredState?: ServiceRequirement): Promise<ResponseError<E> | undefined> {

--- a/packages/langium/src/workspace/workspace-lock.ts
+++ b/packages/langium/src/workspace/workspace-lock.ts
@@ -22,14 +22,18 @@ export interface WorkspaceLock {
 
     /**
      * Performs a single action, like computing completion results or providing workspace symbols.
-     * Read actions will only be executed after all write actions have finished. They will be executed in parallel if possible.
+     * With {@link ReadPriority.Normal} priority (the default), read actions will only be executed after all write actions have finished.
+     * They will be executed in parallel if possible.
      *
      * If a write action is currently running, the read action will be queued up and executed afterwards.
      * If a new write action is queued up while a read action is waiting, the write action will receive priority and will be handled before the read action.
      *
+     * With {@link ReadPriority.Immediate} priority, the read action is executed right away, concurrently to any running write action.
+     * Use this only if the required workspace/document state has already been awaited by other means.
+     *
      * Note that read actions are not allowed to modify anything in the workspace. Please use {@link write} instead.
      */
-    read<T>(action: () => MaybePromise<T>): Promise<T>;
+    read<T>(action: () => MaybePromise<T>, priority?: ReadPriority): Promise<T>;
 
     /**
      * Cancels the last queued write action. All previous write actions already have been cancelled.
@@ -45,11 +49,23 @@ interface LockEntry {
     cancellationToken: CancellationToken;
 }
 
+export enum ReadPriority {
+    /**
+     * The read action is queued up and executed once all write actions have finished.
+     */
+    Normal,
+    /**
+     * The read action is executed immediately, even while a write action is running.
+     */
+    Immediate
+}
+
 export class DefaultWorkspaceLock implements WorkspaceLock {
 
     private previousTokenSource: AbstractCancellationTokenSource = new CancellationTokenSource();
     private writeQueue: LockEntry[] = [];
     private readQueue: LockEntry[] = [];
+    private immediateReads: Array<Promise<unknown>> = [];
     private done = true;
 
     write(action: (token: CancellationToken) => MaybePromise<void>): Promise<void> {
@@ -59,7 +75,19 @@ export class DefaultWorkspaceLock implements WorkspaceLock {
         return this.enqueue(this.writeQueue, action, tokenSource.token);
     }
 
-    read<T>(action: () => MaybePromise<T>): Promise<T> {
+    read<T>(action: () => MaybePromise<T>, priority: ReadPriority = ReadPriority.Normal): Promise<T> {
+        if (priority === ReadPriority.Immediate) {
+            // Immediate reads bypass the queue and run concurrently to any active write.
+            // The caller is responsible for having awaited the workspace/document state it needs.
+            // They are still tracked so that new write actions don't start while they are in progress.
+            const promise = Promise.resolve().then(() => action());
+            this.immediateReads.push(promise);
+            const remove = () => {
+                this.immediateReads.splice(this.immediateReads.indexOf(promise), 1);
+            };
+            promise.then(remove, remove);
+            return promise;
+        }
         return this.enqueue(this.readQueue, action);
     }
 
@@ -83,13 +111,19 @@ export class DefaultWorkspaceLock implements WorkspaceLock {
         if (this.writeQueue.length > 0) {
             // Just perform the next write action
             entries.push(this.writeQueue.shift()!);
+            // A write action would modify the state that running immediate reads operate on,
+            // so wait until all of them have finished before starting the write
+            this.done = false;
+            while (this.immediateReads.length > 0) {
+                await Promise.allSettled(this.immediateReads.slice());
+            }
         } else if (this.readQueue.length > 0) {
             // Empty the read queue and perform all actions in parallel
             entries.push(...this.readQueue.splice(0, this.readQueue.length));
+            this.done = false;
         } else {
             return;
         }
-        this.done = false;
         await Promise.all(entries.map(async ({ action, deferred, cancellationToken }) => {
             try {
                 // Move the execution of the action to the next event loop tick via `Promise.resolve()`

--- a/packages/langium/src/workspace/workspace-lock.ts
+++ b/packages/langium/src/workspace/workspace-lock.ts
@@ -23,7 +23,7 @@ export interface WorkspaceLock {
     /**
      * Performs a single action, like computing completion results or providing workspace symbols.
      * With {@link ReadPriority.Normal} priority (the default), read actions will only be executed after all write actions have finished.
-     * They will be executed in parallel if possible.
+     * They will be executed concurrently if possible.
      *
      * If a write action is currently running, the read action will be queued up and executed afterwards.
      * If a new write action is queued up while a read action is waiting, the write action will receive priority and will be handled before the read action.
@@ -32,6 +32,7 @@ export interface WorkspaceLock {
      * Use this only if the required workspace/document state has already been awaited by other means.
      *
      * Note that read actions are not allowed to modify anything in the workspace. Please use {@link write} instead.
+     * They also cannot be cancelled, independent of their priority, even if a write action is queued up.
      */
     read<T>(action: () => MaybePromise<T>, priority?: ReadPriority): Promise<T>;
 

--- a/packages/langium/test/workspace/workspace-lock.test.ts
+++ b/packages/langium/test/workspace/workspace-lock.test.ts
@@ -5,7 +5,7 @@
  ******************************************************************************/
 
 import { describe, expect, test } from 'vitest';
-import { Deferred, delayNextTick, DefaultWorkspaceLock } from 'langium';
+import { Deferred, delayNextTick, DefaultWorkspaceLock, ReadPriority } from 'langium';
 
 describe('WorkspaceLock', () => {
 
@@ -111,5 +111,70 @@ describe('WorkspaceLock', () => {
         // Counter is 0, since first action has been cancelled
         // and the second action decreases the value again
         expect(counter).toBe(0);
+    });
+
+    test('Immediate read actions are executed concurrently to running write actions', async () => {
+        let counter = 0;
+        const mutex = new DefaultWorkspaceLock();
+        const blocker = new Deferred();
+        mutex.write(async () => {
+            await blocker.promise;
+            counter++;
+        });
+        await delayNextTick();
+        // The write action is still running, but the immediate read is executed right away
+        const immediateResult = await mutex.read(() => counter, ReadPriority.Immediate);
+        expect(immediateResult).toBe(0);
+        blocker.resolve();
+        await delayNextTick();
+        expect(counter).toBe(1);
+    });
+
+    test('Normal read actions wait for write actions, immediate ones do not', async () => {
+        let counter = 0;
+        const mutex = new DefaultWorkspaceLock();
+        const blocker = new Deferred();
+        mutex.write(async () => {
+            await blocker.promise;
+            counter++;
+        });
+        await delayNextTick();
+        const normalRead = mutex.read(() => counter);
+        const immediateRead = mutex.read(() => counter, ReadPriority.Immediate);
+        // The immediate read resolves while the write action is still blocked
+        expect(await immediateRead).toBe(0);
+        blocker.resolve();
+        // The normal read only resolves after the write action has finished
+        expect(await normalRead).toBe(1);
+    });
+
+    test('Write actions do not start while immediate read actions are running', async () => {
+        const mutex = new DefaultWorkspaceLock();
+        let writeStarted = false;
+        const readBlocker = new Deferred();
+        const readAction = mutex.read(() => readBlocker.promise, ReadPriority.Immediate);
+        mutex.write(async () => {
+            writeStarted = true;
+        });
+        await delayNextTick();
+        // The write action is queued, but must not start while the immediate read is in progress
+        expect(writeStarted).toBe(false);
+        readBlocker.resolve();
+        await readAction;
+        await delayNextTick();
+        expect(writeStarted).toBe(true);
+    });
+
+    test('Immediate read actions return the action result', async () => {
+        const mutex = new DefaultWorkspaceLock();
+        const magicalNumber = await mutex.read(() => new Promise(resolve => setTimeout(() => resolve(42), 10)), ReadPriority.Immediate);
+        expect(magicalNumber).toBe(42);
+    });
+
+    test('Immediate read actions propagate errors', async () => {
+        const mutex = new DefaultWorkspaceLock();
+        await expect(mutex.read(() => {
+            throw new Error('Expected error');
+        }, ReadPriority.Immediate)).rejects.toThrow('Expected error');
     });
 });


### PR DESCRIPTION
This is a new version of https://github.com/eclipse-langium/langium/pull/1640.

This is doing a bit less, but it's doing it a bit better. Should resolve intermittent errors that appear due to outdated data within LSP requests.