### PR TITLE
Add basic MCP support to language servers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
       "name": "langium-workspaces",
       "workspaces": [
         "packages/langium",
+        "packages/langium-mcp",
         "packages/langium-railroad",
         "packages/langium-cli",
         "packages/langium-sprotty",
@@ -1139,6 +1140,18 @@
         "@shikijs/vscode-textmate": "^10.0.2"
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.17",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.17.tgz",
+      "integrity": "sha512-dSneS5qhiauZWGDCeK4o695Xd9nUNjviSZCMQrj10eetr8Uln1ucn6bbphOM6UynAMMtNIzZNSpL9vnASJwrPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1593,6 +1606,52 @@
       "resolved": "https://registry.npmjs.org/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
       "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==",
       "license": "MIT"
+    },
+    "node_modules/@modelcontextprotocol/core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/core/-/core-2.0.0.tgz",
+      "integrity": "sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA==",
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@modelcontextprotocol/node": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/node/-/node-2.0.0.tgz",
+      "integrity": "sha512-Y4hAC2XdGDUdDOCbLDOCA4+aL3NUldjsOWlDL/YwpAxrPhRm1xHd7lZ+mLacvZ9t3PaH28wgNoaLQGrIk1P2pg==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/server": "^2.0.0",
+        "hono": "^4.11.4"
+      },
+      "peerDependenciesMeta": {
+        "hono": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/server": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server/-/server-2.0.0.tgz",
+      "integrity": "sha512-YhHWdHfpFMQfd0prsEnxKeS3Qz3ytIGmsS0sth4KDjnacIT7hxk6hXHkJ9KysxlkvTM+WZAtQbbcUhdoP4Hvtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/core": "2.0.0",
+        "zod": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/@napi-rs/keyring": {
       "version": "1.3.0",
@@ -7175,6 +7234,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hono": {
+      "version": "4.13.5",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.5.tgz",
+      "integrity": "sha512-O6+/eCYRkzzzy0rPWwKLiGBR1nFuUPZynnwjxN1MBA62NNqbT0wQEzQyK2gSO5yDIDB336sXQleAhOHrzlYyKw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/hosted-git-info": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
@@ -7921,6 +7990,10 @@
     },
     "node_modules/langium-domainmodel-dsl": {
       "resolved": "examples/domainmodel",
+      "link": true
+    },
+    "node_modules/langium-mcp": {
+      "resolved": "packages/langium-mcp",
       "link": true
     },
     "node_modules/langium-railroad": {
@@ -13319,6 +13392,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "packages/generator-langium": {
       "version": "4.3.0",
       "license": "MIT",
@@ -13418,6 +13500,16 @@
         "node": ">=22.12.0"
       }
     },
+    "packages/langium-mcp": {
+      "version": "4.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/server": "~2.0.0",
+        "langium": "~4.3.0",
+        "vscode-languageserver-types": "~3.18.0",
+        "zod": "~4.4.3"
+      }
+    },
     "packages/langium-railroad": {
       "version": "4.3.0",
       "license": "MIT",
@@ -13439,8 +13531,11 @@
       "version": "4.3.0",
       "license": "MIT",
       "dependencies": {
+        "@modelcontextprotocol/node": "~2.0.0",
+        "@modelcontextprotocol/server": "~2.0.0",
         "ignore": "~7.0.6",
         "langium": "4.3.0",
+        "langium-mcp": "4.3.0",
         "langium-railroad": "4.3.0",
         "vscode-languageserver": "~10.1.0"
       },

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
   },
   "workspaces": [
     "packages/langium",
+    "packages/langium-mcp",
     "packages/langium-railroad",
     "packages/langium-cli",
     "packages/langium-sprotty",

--- a/packages/langium-mcp/LICENSE
+++ b/packages/langium-mcp/LICENSE
@@ -1,0 +1,16 @@
+Copyright 2026 TypeFox GmbH
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute,
+sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or
+substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/langium-mcp/README.md
+++ b/packages/langium-mcp/README.md
@@ -1,0 +1,3 @@
+# Langium MCP Support
+
+This package provides support for integrating MCP servers into language servers built with Langium.

--- a/packages/langium-mcp/package.json
+++ b/packages/langium-mcp/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "langium-mcp",
+  "version": "4.3.0",
+  "description": "Use Langium to build MCP Servers",
+  "homepage": "https://langium.org",
+  "keywords": [
+    "language",
+    "dsl",
+    "lsp",
+    "mcp"
+  ],
+  "license": "MIT",
+  "files": [
+    "lib",
+    "src"
+  ],
+  "sideEffects": false,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./lib/index.d.ts",
+      "import": "./lib/index.js"
+    }
+  },
+  "scripts": {
+    "clean": "shx rm -rf lib coverage",
+    "build": "tsc",
+    "watch": "tsc --watch",
+    "publish:next": "npm --no-git-tag-version version \"$(semver $npm_package_version -i minor)-next.$(git rev-parse --short HEAD)\" && npm publish --tag next",
+    "publish:latest": "npm publish --tag latest --access public"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/server": "~2.0.0",
+    "langium": "~4.3.0",
+    "vscode-languageserver-types": "~3.18.0",
+    "zod": "~4.4.3"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/eclipse-langium/langium.git",
+    "directory": "packages/langium-mcp"
+  },
+  "bugs": "https://github.com/eclipse-langium/langium/issues",
+  "author": {
+    "name": "TypeFox",
+    "url": "https://www.typefox.io"
+  }
+}

--- a/packages/langium-mcp/src/index.ts
+++ b/packages/langium-mcp/src/index.ts
@@ -1,0 +1,7 @@
+/******************************************************************************
+ * Copyright 2026 TypeFox GmbH
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License, which is available in the project root.
+ ******************************************************************************/
+
+export * from './mcp-service.js';

--- a/packages/langium-mcp/src/mcp-service.ts
+++ b/packages/langium-mcp/src/mcp-service.ts
@@ -1,0 +1,74 @@
+/******************************************************************************
+ * Copyright 2026 TypeFox GmbH
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License, which is available in the project root.
+ ******************************************************************************/
+
+import { McpServer } from '@modelcontextprotocol/server';
+import * as z from 'zod/v4';
+import { URI, type LangiumSharedCoreServices } from 'langium';
+
+export interface McpService {
+    createServer(): McpServer;
+}
+
+export interface McpServiceOptions {
+    name: string;
+    version: string;
+}
+
+export class DefaultMcpService implements McpService {
+
+    protected readonly services: LangiumSharedCoreServices;
+    protected readonly options: McpServiceOptions;
+
+    constructor(services: LangiumSharedCoreServices, options: McpServiceOptions) {
+        this.services = services;
+        this.options = options;
+    }
+
+    createServer(): McpServer {
+        const server = new McpServer({
+            name: this.options.name,
+            version: this.options.version
+        });
+        // Register a tool for retrieving diagnostics from the language server
+        this.registerDiagnosticsTool(server);
+        return server;
+    }
+
+    protected registerDiagnosticsTool(server: McpServer): void {
+        server.registerTool('get-diagnostics', {
+            title: 'Get Diagnostics',
+            description: 'Retrieves diagnostics from the language server for all files in the given directory, ordered by file.',
+            inputSchema: z.object({
+                directory: z.string().optional(),
+            })
+        }, async ({ directory }) => {
+            await this.services.workspace.WorkspaceManager.ready;
+            const severities = ['error', 'warning', 'information', 'hint'];
+            const lines: string[] = [];
+            // Wrap the diagnostics read in a lock, to ensure that the workspace build is already done
+            await this.services.workspace.WorkspaceLock.read(() => {
+                const documentManager = this.services.workspace.LangiumDocuments;
+                const documents = directory ? documentManager.getDocuments(URI.file(directory)) : documentManager.all.toArray();
+                for (const doc of documents) {
+                    if (doc.diagnostics && doc.diagnostics.length > 0) {
+                        lines.push(doc.uri.toString());
+                        for (const diag of doc.diagnostics) {
+                            const severity = diag.severity ? severities[diag.severity - 1] : undefined;
+                            const source = diag.source ? ` (${diag.source})` : '';
+                            lines.push(`[${severity ?? 'unknown'} at ${diag.range.start.line + 1}:${diag.range.start.character + 1}] ${diag.message}${source}`);
+                        }
+                    }
+                }
+            });
+            return {
+                content: [{
+                    type: 'text',
+                    text: lines.join('\n') || 'No diagnostics found.'
+                }]
+            };
+        });
+    }
+}

--- a/packages/langium-mcp/tsconfig.json
+++ b/packages/langium-mcp/tsconfig.json
@@ -2,16 +2,12 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "out"
+    "outDir": "lib"
   },
   "references": [{
     "path": "../langium/tsconfig.src.json"
-  }, {
-    "path": "../langium-mcp/tsconfig.json"
-  }, {
-    "path": "../langium-railroad/tsconfig.json"
   }],
   "include": [
-    "src/**/*"
+    "src/**/*.ts"
   ]
 }

--- a/packages/langium-vscode/package.json
+++ b/packages/langium-vscode/package.json
@@ -108,7 +108,10 @@
     "watch": "node esbuild.mjs --watch"
   },
   "dependencies": {
+    "@modelcontextprotocol/node": "~2.0.0",
+    "@modelcontextprotocol/server": "~2.0.0",
     "langium": "4.3.0",
+    "langium-mcp": "4.3.0",
     "langium-railroad": "4.3.0",
     "vscode-languageserver": "~10.1.0",
     "ignore": "~7.0.6"

--- a/packages/langium-vscode/src/language-server/main.ts
+++ b/packages/langium-vscode/src/language-server/main.ts
@@ -5,6 +5,7 @@
  ******************************************************************************/
 
 import { type Module } from 'langium';
+import { createMcpHandler } from '@modelcontextprotocol/server';
 import { createLangiumGrammarServices } from 'langium/grammar';
 import { startLanguageServer, type LangiumSharedServices, type PartialLangiumSharedServices } from 'langium/lsp';
 import { NodeFileSystem } from 'langium/node';
@@ -12,6 +13,9 @@ import { ProposedFeatures, createConnection } from 'vscode-languageserver/node';
 import { LangiumGrammarWorkspaceManager } from './grammar-workspace-manager.js';
 import { registerRailroadConnectionHandler } from './railroad-handler.js';
 import { registerLangiumConfigHandler } from './config-handler.js';
+import { DefaultMcpService } from 'langium-mcp';
+import { toNodeHandler } from '@modelcontextprotocol/node';
+import { createServer } from 'node:http';
 
 const connection = createConnection(ProposedFeatures.all);
 
@@ -25,3 +29,14 @@ const { shared, grammar } = createLangiumGrammarServices({ connection, ...NodeFi
 registerLangiumConfigHandler(connection, shared, grammar);
 registerRailroadConnectionHandler(connection, grammar);
 startLanguageServer(shared);
+
+const mcpService = new DefaultMcpService(shared, {
+    name: 'Langium Grammar MCP Server',
+    version: '4.3.0'
+});
+
+const handler = createMcpHandler(() => mcpService.createServer());
+const nodeHandler = toNodeHandler(handler);
+createServer((req, res) => {
+    nodeHandler(req, res);
+}).listen(8999, '127.0.0.1');

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -3,6 +3,7 @@
     "references": [
         { "path": "./packages/langium/tsconfig.src.json" },
         { "path": "./packages/langium/tsconfig.test.json" },
+        { "path": "./packages/langium-mcp/tsconfig.json" },
         { "path": "./packages/langium-railroad/tsconfig.json" },
         { "path": "./packages/langium-cli/tsconfig.src.json" },
         { "path": "./packages/langium-cli/tsconfig.test.json" },


### PR DESCRIPTION
Adds experimental MCP server support for language servers. Right now, the default implementation only supports a single tool, which is a `get-diagnostics` call. I've confirmed that most models actually prefer this over any other approach to retrieve diagnostics from a given langium file.

Adopters can override it like this:

```ts
class CustomMcpService extends DefaultMcpService {
  override createServer() {
    const server = super.createServer();
    server.registerTool(...);
    return server;
  }
}
```