### PR TITLE
Fix Monarch case sensitivity and escaping

### DIFF
--- a/examples/arithmetics/syntaxes/arithmetics.monarch.ts
+++ b/examples/arithmetics/syntaxes/arithmetics.monarch.ts
@@ -6,6 +6,7 @@ export default {
     operators: [
         '-',',',';',':','*','/','%','^','+'
     ],
+    ignoreCase: true,
     symbols: /-|,|;|:|\(|\)|\*|\/|%|\^|\+/,
 
     tokenizer: {

--- a/examples/domainmodel/syntaxes/domainmodel.monarch.ts
+++ b/examples/domainmodel/syntaxes/domainmodel.monarch.ts
@@ -6,6 +6,7 @@ export default {
     operators: [
         ':','.'
     ],
+    ignoreCase: false,
     symbols: /:|\.|\{|\}/,
 
     tokenizer: {

--- a/examples/statemachine/syntaxes/statemachine.monarch.ts
+++ b/examples/statemachine/syntaxes/statemachine.monarch.ts
@@ -6,6 +6,7 @@ export default {
     operators: [
         '=>'
     ],
+    ignoreCase: false,
     symbols: /=>|\{|\}/,
 
     tokenizer: {

--- a/packages/langium-cli/src/generator/highlighting/monarch-generator.ts
+++ b/packages/langium-cli/src/generator/highlighting/monarch-generator.ts
@@ -17,6 +17,7 @@ interface LanguageDefinition {
     readonly keywords: string[];
     readonly operators: string[];
     readonly symbols: string[];
+    readonly caseInsensitive: boolean;
     readonly tokenPostfix: string;
 }
 
@@ -119,6 +120,7 @@ export function generateMonarch(grammar: Grammar, config: LangiumLanguageConfig)
             keywords: getKeywords(grammar),
             operators,
             symbols,
+            caseInsensitive: Boolean(config.caseInsensitive),
             tokenPostfix: '.' + config.id, // category appended to all tokens
         },
         tokenizer: {
@@ -210,9 +212,13 @@ function prettyPrint(monarchGrammar: MonarchGrammar): string {
 function genLanguageDefEntry(name: string, values: string[]): Generated {
     return expandToNode`
         ${name}: [
-            ${ values.map(v => `'${v}'`).join(',') }
+            ${ values.map(v => `'${escapeMonarchString(v)}'`).join(',') }
         ],
     `;
+}
+
+function escapeMonarchString(value: string): string {
+    return value.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
 }
 
 /**
@@ -224,6 +230,7 @@ function prettyPrintLangDef(languageDef: LanguageDefinition): Generated {
     return expandToNode`
         ${genLanguageDefEntry('keywords', languageDef.keywords)}
         ${genLanguageDefEntry('operators', languageDef.operators)}
+        ignoreCase: ${languageDef.caseInsensitive},
         ${/* special case, identify symbols via singular regex*/ undefined}
         symbols: ${new RegExp(languageDef.symbols.map(RegExpUtils.escapeRegExp).join('|')).toString()},
     `;

--- a/packages/langium-cli/test/generator/monarch-generator.test.ts
+++ b/packages/langium-cli/test/generator/monarch-generator.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2021 TypeFox GmbH
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License, which is available in the project root.
+ */
+
+import { EmptyFileSystem, URI, type Grammar } from 'langium';
+import { createLangiumGrammarServices } from 'langium/grammar';
+import { clearDocuments } from 'langium/test';
+import { afterEach, describe, expect, test } from 'vitest';
+import { generateMonarch } from '../../src/generator/highlighting/monarch-generator.js';
+
+const services = createLangiumGrammarServices(EmptyFileSystem);
+
+describe('Monarch generator', () => {
+    afterEach(() => clearDocuments(services.shared));
+
+    test('emits case-insensitive matching and escaped language strings', async () => {
+        const document = services.shared.workspace.LangiumDocumentFactory.fromString<Grammar>(
+            `grammar Test
+
+entry Model: '\\\\' | "'";`,
+            URI.file('test.langium')
+        );
+        services.shared.workspace.LangiumDocuments.addDocument(document);
+        await services.shared.workspace.DocumentBuilder.build([document]);
+
+        const output = generateMonarch(document.parseResult.value, {
+            id: 'test',
+            grammar: 'test.langium',
+            caseInsensitive: true
+        });
+
+        expect(output).toContain('ignoreCase: true');
+        expect(output).toContain("'\\\\'");
+        expect(output).toContain("'\\''");
+    });
+});


### PR DESCRIPTION
Fixes #2055

## Summary

- propagate `caseInsensitive` to Monarch's `ignoreCase` setting
- escape backslashes and single quotes in generated language-definition strings
- add regression coverage for both generated behaviors

## Root cause

The Monarch generator collected language configuration and grammar strings but did not emit the case-sensitivity option. It also inserted keywords and operators into single-quoted generated source without escaping those delimiters.

## User impact

Generated Monarch tokenizers now honor case-insensitive Langium configurations, and grammars containing quoted or escaped tokens produce valid generated source.

## Validation

- focused Monarch generator test - passed
- related Monarch, module, and grammar serializer tests - 8 passed
- `npm run build` - passed
- `npm run lint` - passed
- `git diff --check` - passed

## Contribution notes

This contribution may require an Eclipse Contributor Agreement associated with the submitting GitHub account.

## AI disclosure

This change was prepared with OpenAI Codex assistance and reviewed and validated locally by the contributor.
