### PR TITLE
Improve longerAlt support for non-standard regex

### DIFF
--- a/packages/langium/src/parser/token-builder.ts
+++ b/packages/langium/src/parser/token-builder.ts
@@ -42,6 +42,14 @@ export interface LexingDiagnostic extends ILexingError {
     severity?: LexingDiagnosticSeverity;
 }
 
+export interface RegExpTokenType extends TokenType {
+    regex: RegExp;
+}
+
+export function isRegExpTokenType(tokenType: TokenType): tokenType is RegExpTokenType {
+    return 'regex' in tokenType && tokenType.regex instanceof RegExp;
+}
+
 export class DefaultTokenBuilder implements TokenBuilder {
     /**
      * The list of diagnostics stored during the lexing process of a single text.
@@ -81,8 +89,9 @@ export class DefaultTokenBuilder implements TokenBuilder {
     protected buildTerminalToken(terminal: TerminalRule): TokenType {
         const regex = terminalRegex(terminal);
         const pattern = this.requiresCustomPattern(regex) ? this.regexPatternFunction(regex) : regex;
-        const tokenType: TokenType = {
+        const tokenType: RegExpTokenType = {
             name: terminal.name,
+            regex,
             PATTERN: pattern,
         };
         if (typeof pattern === 'function') {
@@ -147,8 +156,21 @@ export class DefaultTokenBuilder implements TokenBuilder {
 
     protected findLongerAlt(keyword: Keyword, terminalTokens: TokenType[]): TokenType[] {
         return terminalTokens.reduce((longerAlts: TokenType[], token) => {
-            const pattern = token?.PATTERN as RegExp;
-            if (pattern?.source && partialMatches('^' + pattern.source + '$', keyword.value)) {
+            let pattern: TokenPattern | undefined;
+            if (token.PATTERN instanceof RegExp) {
+                pattern = token.PATTERN;
+            } else if (isRegExpTokenType(token)) {
+                pattern = token.regex;
+            } else {
+                // No regex found, fall back to the pattern function
+                pattern = token.PATTERN;
+            }
+            if (
+                // It's a regexp and we get a (partial) match
+                (pattern instanceof RegExp && partialMatches('^' + pattern.source + '$', keyword.value))
+                // It's a matching function and we full match
+                || (typeof pattern === 'function' && pattern(keyword.value, 0, [], {}) !== null)
+            ) {
                 longerAlts.push(token);
             }
             return longerAlts;

--- a/packages/langium/test/parser/lexer.test.ts
+++ b/packages/langium/test/parser/lexer.test.ts
@@ -81,6 +81,21 @@ describe('DefaultLexer', () => {
         expect(result.hidden).toHaveLength(0);
     });
 
+    test('should use custom pattern terminals as longer alt for keywords', async () => {
+        // Unicode-flagged regexes are compiled into custom matcher functions.
+        // Keywords still need to register them as LONGER_ALT, otherwise 'abcd' lexes as 'abc' + 'd'.
+        const lexer = await getLexer(`
+        grammar Test
+        entry Y: 'abc' name=ID;
+        terminal ID: /[\\p{L}]+/u;
+        hidden terminal WS: /\\s+/;
+        `);
+        const result = lexer.tokenize('abc abcd');
+        expect(result.errors).toHaveLength(0);
+        expect(result.tokens.map(t => t.image)).toEqual(['abc', 'abcd']);
+        expect(result.tokens[1].tokenType.name).toBe('ID');
+    });
+
 });
 
 async function getLexer(grammar: string): Promise<Lexer> {

--- a/packages/langium/test/parser/token-builder.test.ts
+++ b/packages/langium/test/parser/token-builder.test.ts
@@ -5,9 +5,9 @@
  ******************************************************************************/
 
 import type { TokenPattern, TokenType } from '@chevrotain/types';
-import type { Grammar } from 'langium';
+import type { Grammar, RegExpTokenType } from 'langium';
 import { beforeAll, describe, expect, test } from 'vitest';
-import { EmptyFileSystem } from 'langium';
+import { EmptyFileSystem, isRegExpTokenType } from 'langium';
 import { createLangiumGrammarServices } from 'langium/grammar';
 import { parseHelper } from 'langium/test';
 
@@ -104,6 +104,22 @@ describe('tokenBuilder#longerAlts', () => {
 
     test('should create no longer alts for terminals', () => {
         expect(abTerminalToken.LONGER_ALT).toBeUndefined();
+    });
+
+    test('should create partial-match longer alts for custom pattern terminals', async () => {
+        // The 'u' flag forces a custom matcher function. The original regex is kept on the token,
+        // so the keyword 'AB' still gets 'ABC' as a longer alt via partial matching,
+        // even though the matcher function itself would not match 'AB'.
+        const tokens = await getTokens(`
+        grammar test
+        Main: {infer Main} 'AB' ABC;
+        terminal ABC: /ABC/u;
+        `);
+        const [abKeyword, abcTerminal] = tokens;
+        expect(abcTerminal.PATTERN).toBeTypeOf('function');
+        expect(isRegExpTokenType(abcTerminal)).toBe(true);
+        expect((abcTerminal as RegExpTokenType).regex).toEqual(/ABC/u);
+        expect(abKeyword.LONGER_ALT).toEqual([abcTerminal]);
     });
 
 });


### PR DESCRIPTION
Fixes https://github.com/eclipse-langium/langium/issues/2225.

Attempts to make the longerAlt identification more robust, by carrying the original regex over. Will also attempt to use a function pattern, if provided.